### PR TITLE
Update checkout action runtime

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check out merged main
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install uv and Python
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0


### PR DESCRIPTION
Updates the immutable `actions/checkout` pin from v4 to v7 so the deployment workflow uses the current Node 24-compatible runtime and removes GitHub's Node 20 deprecation annotation.

The workflow's behavior and permissions are otherwise unchanged. YAML syntax validation passed.