### PR TITLE
Let the model open on answer and cut answer-to-speech latency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+`app/` contains the Python service. `main.py` assembles FastAPI and FastMCP; `routes/` handles OpenAI, Twilio, debug, and deployment callbacks; `call_state.py`, `twilio_bridge.py`, and `openai_realtime.py` coordinate live calls; and `db.py`, `models.py`, `policy.py`, and `security.py` own persistence, schemas, call policy, and authentication. Tests mirror these concerns in `tests/test_*.py`, with shared fixtures in `tests/conftest.py`. Operational files live at the repository root (`Dockerfile`, `fly.toml`, `render.yaml`), while `scripts/run_sip_canary.py` performs live end-to-end validation.
+
+## Build, Test, and Development Commands
+
+- `uv sync --all-groups --frozen`: install dependencies from `uv.lock`.
+- `uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload`: run the local service with reload.
+- `uv run ruff format --check app tests scripts`: verify formatting.
+- `uv run ruff check app tests scripts`: run configured lint and import checks.
+- `uv run pytest -q`: run the automated test suite.
+- `uv run pytest -q tests/test_security.py`: run one focused test module.
+- `uv run python scripts/run_sip_canary.py --mode full`: validate a deployed SIP flow; this places a real call and requires configured credentials.
+
+## Coding Style & Naming Conventions
+
+Use four-space indentation, Python type hints, and `from __future__ import annotations`. Ruff targets Python 3.12 with a 100-character line length and enforces pycodestyle, Pyflakes, import sorting, pyupgrade, bugbear, and async rules. Use `snake_case` for modules, functions, variables, and tests; `PascalCase` for classes and Pydantic models; and descriptive async names for network or database operations.
+
+## Testing Guidelines
+
+Tests use pytest, `pytest-asyncio` in auto mode, `respx`, and temporary SQLite databases. Name files `test_<area>.py` and tests `test_<behavior>`. Add regression coverage for state transitions, signed webhook handling, payload shapes, recovery, and teardown. No numeric coverage threshold is configured; new behavior should still exercise both success and failure paths.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses short, imperative, sentence-case subjects such as `Add call-safe deployment lease`. Keep commits focused. Pull requests should explain the behavioral change, risks to live-call teardown or billing, configuration changes, and validation performed. Link relevant issues; include logs or payload examples for backend changes and canary evidence when telephony behavior changes. Ensure Ruff and pytest pass before review.
+
+## Security & Operations
+
+Copy `.env.example` to `.env.local`; never commit secrets, transcripts, or database files. Preserve webhook signature checks, replay protection, destination policy, and explicit call confirmation. Do not deploy or restart while a call is active, and keep production to one Fly Machine because SQLite state is volume-local.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Single-user FastAPI + FastMCP service that lets Poke prepare, confirm, start, mo
 - Every OpenAI and Twilio webhook is signature-verified; OpenAI delivery IDs are replay-protected.
 - A call cannot start without an unexpired prepared plan and explicit confirmation text.
 - Destination policy blocks malformed E.164, emergency/N11/short codes, premium-rate prefixes, disallowed country codes, and the service's own Twilio number.
-- The agent identifies itself as Poke, Irvin's AI assistant. It may not impersonate Irvin or share/request passwords, auth codes, payment credentials, or government identifiers.
+- The voice model chooses how to open from Poke's approved call context; the bridge does not impose identity, disclosure, or recipient-confirmation wording. It may not share or request passwords, auth codes, payment credentials, or government identifiers.
 - The in-call voice model decides when the conversation is finished and invokes its private `end_call` function. The bridge asks it for one final spoken goodbye, waits for that closing response to complete, and then tears down OpenAI and Twilio. The public `end_phone_call` MCP tool remains a manual stop.
 - Poke push is optional and non-canonical. Polling `get_call_result` is canonical.
 
 Do not deploy or restart while a call is active. Recovery stops stranded billable media and finalizes missing results, but a process restart necessarily ends the live call.
 
-Calls are retained as transcripts. The greeting provides verbal AI disclosure; the owner remains responsible for jurisdiction-specific recording, robocall, consent, and retention compliance. Apply transcript retention independently of extraction success or failure.
+Calls are retained as transcripts. The application does not force a verbal identity or AI-disclosure script; the owner remains responsible for jurisdiction-specific disclosure, recording, robocall, consent, and retention compliance. Apply transcript retention independently of extraction success or failure.
 
 ## Requirements
 
@@ -135,7 +135,7 @@ Live-schema deviations from the original contract are intentional:
 - The current Conference Participants API has no `async_amd` parameter. AMD on Participants is asynchronous by design; the installed SDK uses `machine_detection="DetectMessageEnd"` plus `amd_status_callback` and `amd_status_callback_method`.
 - OpenAI call accept is invoked through the installed typed SDK; hangup has no JSON body. REFER's live request field is `target_uri`, but v1 transfer deliberately does not use REFER.
 - The installed transcription schema permits `INPUT_TRANSCRIPTION_DELAY` only for `gpt-realtime-whisper`, with `minimal|low|medium|high|xhigh` values.
-- The OpenAI SIP agent participant is created with `early_media=false` and is explicitly unmuted before the greeting, because Twilio mutes legs that join with `start_conference_on_enter=false` until the conference starts.
+- The OpenAI SIP agent participant is created with `early_media=false` and is explicitly unmuted before the model's opening turn, because Twilio mutes legs that join with `start_conference_on_enter=false` until the conference starts.
 
 ## Result semantics
 

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -218,8 +218,27 @@ class CallService:
 
     async def handle_sideband_open(self, call_id: str) -> None:
         await self.db.set_flag_once(call_id, "sideband_open")
+        try:
+            updated = await self.realtime.verify_initial_session(call_id)
+        except Exception:
+            await self.terminate_call(call_id, "initial_session_update_timeout")
+            return
+        transcription_ok = self.realtime.expected_transcription_echoed(updated)
+        vad_ok = self.realtime.expected_initial_vad_echoed(updated)
+        await self.db.update_call(
+            call_id,
+            transcription_verified=int(transcription_ok),
+            semantic_vad_verified=int(vad_ok),
+        )
+        if not transcription_ok or not vad_ok:
+            await self.terminate_call(call_id, "transcription_config_mismatch")
+            return
         call = await self.db.get_call(call_id)
-        if call and await self.db.set_flag_once(call_id, "callee_dialed"):
+        if (
+            call
+            and CallState(call["state"]) not in TERMINAL_STATES
+            and await self.db.set_flag_once(call_id, "callee_dialed")
+        ):
             plan = await self.db.get_plan(call["plan_id"])
             packet = ContextPacket.model_validate(plan["context"])
             try:
@@ -268,12 +287,14 @@ class CallService:
             await self.db.set_flag_once(call_id, "callee_joined")
             if not call.get("answered_at"):
                 await self.db.update_call(call_id, answered_at=datetime.now(UTC).isoformat())
+            await self._start_opening_on_answer(call_id)
             await self._check_activation_gate(call_id)
         elif event in {"participant-join", "join"}:
             if label == "callee" or (call_sid and call_sid == call.get("twilio_callee_call_sid")):
                 await self.db.set_flag_once(call_id, "callee_joined")
                 if not call.get("answered_at"):
                     await self.db.update_call(call_id, answered_at=datetime.now(UTC).isoformat())
+                await self._start_opening_on_answer(call_id)
                 await self._check_activation_gate(call_id)
             elif label == "owner":
                 self._owner_join_events.setdefault(call_id, asyncio.Event()).set()
@@ -288,7 +309,15 @@ class CallService:
     async def handle_participant_status(self, call_id: str, leg: str, form: dict[str, str]) -> None:
         status = (form.get("CallStatus") or "").lower()
         await self.db.touch_call(call_id)
-        if leg == "callee" and status in {"completed", "failed", "busy", "no-answer", "canceled"}:
+        if leg == "callee" and status in {"in-progress", "answered"}:
+            # The callee's answered status callback usually reaches us before the
+            # conference participant-join event; whichever arrives first starts the
+            # opening turn so the callee hears the model sooner.
+            if await self.db.set_flag_once(call_id, "callee_joined"):
+                await self.db.update_call(call_id, answered_at=datetime.now(UTC).isoformat())
+            await self._start_opening_on_answer(call_id)
+            await self._check_activation_gate(call_id)
+        elif leg == "callee" and status in {"completed", "failed", "busy", "no-answer", "canceled"}:
             duration = int(form.get("CallDuration") or 0)
             reason = "callee_call_completed" if status == "completed" else f"callee_{status}"
             if status == "completed" and duration >= self.settings.max_call_seconds:
@@ -313,6 +342,50 @@ class CallService:
             return
         await self._activate(call_id)
 
+    async def _start_opening_on_answer(self, call_id: str) -> None:
+        """Let the model open the call as soon as the callee joins.
+
+        Conference Participant AMD runs asynchronously, so waiting for its callback leaves a
+        human callee in several seconds of silence. Keep automatic responses disabled until AMD
+        completes, but ask the model for an opening turn immediately. The application supplies no
+        response-specific script; the model chooses the opening from Poke's approved context.
+        """
+        call = await self.db.get_call(call_id)
+        if call is None or CallState(call["state"]) in TERMINAL_STATES:
+            return
+        if not (
+            call["sideband_open"]
+            and call["callee_joined"]
+            and call["transcription_verified"]
+            and call["semantic_vad_verified"]
+        ):
+            return
+        if call.get("answer_handling") == "voicemail":
+            return
+        if not await self.db.set_flag_once(call_id, "opening_sent"):
+            return
+
+        conference = call.get("conference_sid") or call.get("conference_name")
+        # Twilio auto-unmutes the agent leg at conference start; the explicit unmute is a
+        # race-safety net, so run it concurrently instead of letting its REST round-trip
+        # delay the opening turn.
+        await asyncio.gather(
+            self.realtime.create_opening(call_id),
+            self._unmute_agent(call_id, conference, call.get("twilio_ai_call_sid")),
+        )
+
+    async def _unmute_agent(
+        self, call_id: str, conference: str | None, agent_call_sid: str | None
+    ) -> None:
+        try:
+            await self.twilio.unmute_participant(conference, agent_call_sid)
+        except Exception:
+            logger.warning(
+                "failed to unmute agent participant call_id=%s",
+                call_id,
+                exc_info=True,
+            )
+
     async def _activate(self, call_id: str) -> None:
         if not await self.db.cas_state(call_id, CallState.READY_TO_ACTIVATE, CallState.ACTIVATING):
             return
@@ -327,43 +400,24 @@ class CallService:
         if not await self.db.cas_state(call_id, CallState.ACTIVATING, CallState.ACTIVE):
             return
         call = await self.db.get_call(call_id)
-        plan = await self.db.get_plan(call["plan_id"])
-        packet = ContextPacket.model_validate(plan["context"])
-        conference = call.get("conference_sid") or call.get("conference_name")
-        try:
-            await self.twilio.unmute_participant(conference, call.get("twilio_ai_call_sid"))
-        except Exception:
-            logger.warning(
-                "failed to unmute agent participant before greeting call_id=%s",
-                call_id,
-                exc_info=True,
-            )
         if call["answer_handling"] == "voicemail":
+            conference = call.get("conference_sid") or call.get("conference_name")
+            tasks = [self._unmute_agent(call_id, conference, call.get("twilio_ai_call_sid"))]
             if await self.db.set_flag_once(call_id, "voicemail_sent"):
-                await self.realtime.create_voicemail(call_id, packet)
-        elif await self.db.set_flag_once(call_id, "greeting_sent"):
-            await self.realtime.create_greeting(call_id, packet.target.name)
-        await self.db.cas_state(call_id, CallState.ACTIVE, CallState.GREETING_STARTED)
+                tasks.append(self.realtime.create_voicemail(call_id))
+            await asyncio.gather(*tasks)
+        else:
+            await self._start_opening_on_answer(call_id)
 
     async def handle_realtime_event(self, call_id: str, event: dict[str, Any]) -> None:
         event_type = event.get("type", "")
         event_id = event.get("event_id") or f"evt_{secrets.token_urlsafe(12)}"
         await self.db.touch_call(call_id)
         if event_type == "session.created":
-            transcription_ok = self.realtime.expected_transcription_echoed(event)
-            vad_ok = self.realtime.expected_initial_vad_echoed(event)
-            await self.db.update_call(
-                call_id,
-                transcription_verified=int(transcription_ok),
-                semantic_vad_verified=int(vad_ok),
-            )
-            if not transcription_ok or not vad_ok:
-                self._spawn(
-                    self.terminate_call(call_id, "transcription_config_mismatch"),
-                    name=f"terminate:{call_id}:transcription",
-                )
-            else:
-                await self._check_activation_gate(call_id)
+            # Observational only. A SIP sideband attaches to an existing session and may
+            # miss this startup event, so readiness is established by the explicit
+            # session.update/session.updated handshake in handle_sideband_open.
+            logger.debug("observed session.created call_id=%s", call_id)
         elif event_type == "conversation.item.input_audio_transcription.completed":
             text = event.get("transcript", "").strip()
             if text:

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -406,10 +406,11 @@ class CallService:
             tasks = [self._unmute_agent(call_id, conference, call.get("twilio_ai_call_sid"))]
             if await self.db.set_flag_once(call_id, "voicemail_sent"):
                 # The opening turn starts on answer, before async AMD can classify the callee.
-                # If AMD then reports a machine, cancel the still-active opening so the
-                # voicemail response.create is not rejected for an already-active response.
-                if call_id in self._active_response_ids:
-                    response_id = self._active_response_ids.pop(call_id)
+                # If AMD then reports a machine, cancel the opening even when its
+                # response.created event has not arrived yet. WebSocket event ordering makes
+                # the following voicemail response.create run after the cancellation request.
+                if call.get("opening_sent"):
+                    response_id = self._active_response_ids.pop(call_id, None)
                     await self.realtime.cancel_response(call_id, response_id)
                 tasks.append(self.realtime.create_voicemail(call_id))
             await asyncio.gather(*tasks)

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -57,6 +57,7 @@ class CallService:
         self._background: set[asyncio.Task[Any]] = set()
         self._owner_join_events: dict[str, asyncio.Event] = {}
         self._voice_end_pending: dict[str, tuple[str, str | None]] = {}
+        self._active_response_ids: dict[str, str | None] = {}
         self._watchdog_task: asyncio.Task[None] | None = None
 
     def _spawn(self, coroutine, *, name: str) -> asyncio.Task[Any]:
@@ -404,6 +405,12 @@ class CallService:
             conference = call.get("conference_sid") or call.get("conference_name")
             tasks = [self._unmute_agent(call_id, conference, call.get("twilio_ai_call_sid"))]
             if await self.db.set_flag_once(call_id, "voicemail_sent"):
+                # The opening turn starts on answer, before async AMD can classify the callee.
+                # If AMD then reports a machine, cancel the still-active opening so the
+                # voicemail response.create is not rejected for an already-active response.
+                if call_id in self._active_response_ids:
+                    response_id = self._active_response_ids.pop(call_id)
+                    await self.realtime.cancel_response(call_id, response_id)
                 tasks.append(self.realtime.create_voicemail(call_id))
             await asyncio.gather(*tasks)
         else:
@@ -447,16 +454,18 @@ class CallService:
             call = await self.db.get_call(call_id)
             if call and call.get("tool_call_count", 0) > 0:
                 await self.db.update_call(call_id, tool_continuation_observed=1)
+            response = event.get("response") or {}
+            response_id = response.get("id") or event.get("response_id")
+            self._active_response_ids[call_id] = response_id
             pending = self._voice_end_pending.get(call_id)
-            if pending and pending[1] is None:
-                response = event.get("response") or {}
-                response_id = response.get("id") or event.get("response_id")
-                if response_id:
-                    self._voice_end_pending[call_id] = (pending[0], response_id)
+            if pending and pending[1] is None and response_id:
+                self._voice_end_pending[call_id] = (pending[0], response_id)
         elif event_type in {"response.done", "response.audio.done"}:
             call = await self.db.get_call(call_id)
             response = event.get("response") or {}
             status = response.get("status")
+            if event_type == "response.done":
+                self._active_response_ids.pop(call_id, None)
             if status in {"cancelled", "canceled"}:
                 await self.db.update_call(call_id, interruption_observed=1)
             elif status == "failed":
@@ -468,7 +477,9 @@ class CallService:
                 )
             if event_type == "response.done":
                 await self._handle_voice_end_response_done(call_id, event)
-            if call and call.get("voicemail_sent"):
+            # A cancelled response.done here is the opening turn we cancelled when AMD
+            # reported voicemail; the voicemail response itself is still in flight.
+            if call and call.get("voicemail_sent") and status not in {"cancelled", "canceled"}:
                 self._spawn(
                     self.terminate_call(call_id, "voicemail_left"),
                     name=f"terminate:{call_id}:voicemail",
@@ -479,6 +490,11 @@ class CallService:
                 name=f"terminate:{call_id}:openai-terminal",
             )
         elif event_type == "error":
+            error = event.get("error") or {}
+            if error.get("code") == "response_cancel_not_active":
+                # Benign race: the response we tried to cancel finished on its own.
+                logger.info("stale response.cancel ignored call_id=%s event=%s", call_id, event)
+                return
             logger.error("realtime error event call_id=%s event=%s", call_id, event)
             self._spawn(
                 self.terminate_call(call_id, "openai_fatal_error"),
@@ -666,6 +682,7 @@ class CallService:
         if not await self.db.set_flag_once(call_id, "termination_claimed"):
             return False
         self._voice_end_pending.pop(call_id, None)
+        self._active_response_ids.pop(call_id, None)
         await self.db.update_call(
             call_id, state=CallState.TERMINATING.value, termination_reason=reason
         )

--- a/app/db.py
+++ b/app/db.py
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS calls (
     amd_result TEXT,
     answered_by TEXT,
     answer_handling TEXT,
-    greeting_sent INTEGER NOT NULL DEFAULT 0,
+    opening_sent INTEGER NOT NULL DEFAULT 0,
     voicemail_sent INTEGER NOT NULL DEFAULT 0,
     termination_claimed INTEGER NOT NULL DEFAULT 0,
     termination_reason TEXT,
@@ -132,6 +132,17 @@ class Database:
             await conn.executescript(SCHEMA)
             cursor = await conn.execute("PRAGMA table_info(calls)")
             existing = {row[1] for row in await cursor.fetchall()}
+            if "greeting_sent" in existing and "opening_sent" not in existing:
+                await conn.execute("ALTER TABLE calls RENAME COLUMN greeting_sent TO opening_sent")
+                existing.remove("greeting_sent")
+                existing.add("opening_sent")
+            await conn.execute(
+                "UPDATE calls SET state=? WHERE state=?",
+                (
+                    CallState.ACTIVE.value,
+                    "greeting_started",
+                ),
+            )
             migrations = {
                 "openai_accept_status": "INTEGER",
                 "transcription_verified": "INTEGER NOT NULL DEFAULT 0",
@@ -139,6 +150,7 @@ class Database:
                 "tool_call_count": "INTEGER NOT NULL DEFAULT 0",
                 "tool_continuation_observed": "INTEGER NOT NULL DEFAULT 0",
                 "interruption_observed": "INTEGER NOT NULL DEFAULT 0",
+                "opening_sent": "INTEGER NOT NULL DEFAULT 0",
             }
             for name, definition in migrations.items():
                 if name not in existing:
@@ -351,7 +363,7 @@ class Database:
             "sideband_open",
             "callee_joined",
             "callee_dialed",
-            "greeting_sent",
+            "opening_sent",
             "voicemail_sent",
             "termination_claimed",
         }

--- a/app/models.py
+++ b/app/models.py
@@ -19,7 +19,6 @@ class CallState(StrEnum):
     READY_TO_ACTIVATE = "ready_to_activate"
     ACTIVATING = "activating"
     ACTIVE = "active"
-    GREETING_STARTED = "greeting_started"
     TERMINATING = "terminating"
     COMPLETED = "completed"
     FAILED = "failed"

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -167,6 +167,7 @@ class RealtimeBridge:
 
     async def _run(self, runtime: RealtimeRuntime) -> None:
         url = f"wss://api.openai.com/v1/realtime?call_id={runtime.openai_call_id}"
+        receiver: asyncio.Task[None] | None = None
         try:
             async with websockets.connect(
                 url,
@@ -177,13 +178,15 @@ class RealtimeBridge:
                 close_timeout=2,
             ) as websocket:
                 runtime.websocket = websocket
+                # The SIP session already exists by the time this sideband attaches, so its
+                # session.created event may not be replayed. Start receiving before on_open so
+                # that the readiness handshake can send session.update and await session.updated.
+                receiver = asyncio.create_task(
+                    self._receive_events(runtime, websocket),
+                    name=f"sideband-receiver:{runtime.call_id}",
+                )
                 await self.on_open(runtime.call_id)
-                async for message in websocket:
-                    event = json.loads(message)
-                    if event.get("type") == "session.updated" and runtime.update_waiter:
-                        if not runtime.update_waiter.done():
-                            runtime.update_waiter.set_result(event)
-                    await self.on_event(runtime.call_id, event)
+                await receiver
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -191,7 +194,18 @@ class RealtimeBridge:
                 logger.exception("Realtime sideband failed for %s", runtime.call_id)
                 await self.on_fatal(runtime.call_id, f"sideband_error:{type(exc).__name__}")
         finally:
+            if receiver is not None and not receiver.done():
+                receiver.cancel()
+                await asyncio.gather(receiver, return_exceptions=True)
             runtime.websocket = None
+
+    async def _receive_events(self, runtime: RealtimeRuntime, websocket: Any) -> None:
+        async for message in websocket:
+            event = json.loads(message)
+            if event.get("type") == "session.updated" and runtime.update_waiter:
+                if not runtime.update_waiter.done():
+                    runtime.update_waiter.set_result(event)
+            await self.on_event(runtime.call_id, event)
 
     async def send(self, call_id: str, event: dict[str, Any]) -> None:
         runtime = self._runtime.get(call_id)
@@ -200,31 +214,20 @@ class RealtimeBridge:
         async with runtime.send_lock:
             await runtime.websocket.send(json.dumps(event))
 
-    async def enable_automatic_responses(self, call_id: str) -> dict[str, Any]:
+    async def _update_session(self, call_id: str, audio_input: dict[str, Any]) -> dict[str, Any]:
         runtime = self._runtime.get(call_id)
         if runtime is None:
             raise RuntimeError("sideband runtime missing")
         async with runtime.update_lock:
             loop = asyncio.get_running_loop()
             runtime.update_waiter = loop.create_future()
-            # Patch only turn_detection. Do not re-specify audio.format: SIP media
-            # negotiates G.711 with Twilio, and an explicit format can silence RTP.
             await self.send(
                 call_id,
                 {
                     "type": "session.update",
                     "session": {
                         "type": "realtime",
-                        "audio": {
-                            "input": {
-                                "turn_detection": {
-                                    "type": "semantic_vad",
-                                    "eagerness": "auto",
-                                    "create_response": True,
-                                    "interrupt_response": True,
-                                }
-                            }
-                        },
+                        "audio": {"input": audio_input},
                     },
                 },
             )
@@ -233,23 +236,49 @@ class RealtimeBridge:
             finally:
                 runtime.update_waiter = None
 
-    async def create_greeting(self, call_id: str, target: str) -> None:
-        greeting = (
-            f"Hi, this is Poke, Irvin's AI assistant calling on his behalf. "
-            f"Am I speaking with {target}?"
-        )
-        await self.send(
+    async def verify_initial_session(self, call_id: str) -> dict[str, Any]:
+        transcription: dict[str, Any] = {"model": self.settings.input_transcription_model}
+        if self.settings.input_transcription_model == "gpt-realtime-whisper":
+            if self.settings.input_transcription_delay:
+                transcription["delay"] = self.settings.input_transcription_delay
+        # Do not specify audio.format: SIP media negotiates G.711 with Twilio, and
+        # explicitly overriding it can silence RTP.
+        return await self._update_session(
             call_id,
             {
-                "type": "response.create",
-                "response": {
-                    "output_modalities": ["audio"],
-                    "instructions": f'Say exactly: "{greeting}" Do not add any other words.',
+                "transcription": transcription,
+                "turn_detection": {
+                    "type": "semantic_vad",
+                    "eagerness": "auto",
+                    "create_response": False,
+                    "interrupt_response": False,
                 },
             },
         )
 
-    async def create_voicemail(self, call_id: str, packet: ContextPacket) -> None:
+    async def enable_automatic_responses(self, call_id: str) -> dict[str, Any]:
+        return await self._update_session(
+            call_id,
+            {
+                "turn_detection": {
+                    "type": "semantic_vad",
+                    "eagerness": "auto",
+                    "create_response": True,
+                    "interrupt_response": True,
+                }
+            },
+        )
+
+    async def create_opening(self, call_id: str) -> None:
+        await self.send(
+            call_id,
+            {
+                "type": "response.create",
+                "response": {"output_modalities": ["audio"]},
+            },
+        )
+
+    async def create_voicemail(self, call_id: str) -> None:
         await self.send(
             call_id,
             {
@@ -257,9 +286,8 @@ class RealtimeBridge:
                 "response": {
                     "output_modalities": ["audio"],
                     "instructions": (
-                        "Leave exactly one concise voicemail. Identify yourself as Poke, "
-                        f"{packet.owner.display_name}'s AI assistant, state the approved purpose, "
-                        f"and give callback number {packet.owner.callback_number}. Do not ask questions."
+                        "Leave one concise voicemail that advances the approved objective using only "
+                        "the approved context. Do not ask questions."
                     ),
                 },
             },

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -278,6 +278,12 @@ class RealtimeBridge:
             },
         )
 
+    async def cancel_response(self, call_id: str, response_id: str | None = None) -> None:
+        event: dict[str, Any] = {"type": "response.cancel"}
+        if response_id:
+            event["response_id"] = response_id
+        await self.send(call_id, event)
+
     async def create_voicemail(self, call_id: str) -> None:
         await self.send(
             call_id,

--- a/app/prompts.py
+++ b/app/prompts.py
@@ -7,17 +7,12 @@ from app.models import ContextPacket
 
 def realtime_instructions(packet: ContextPacket) -> str:
     approved = json.dumps(packet.model_dump(mode="json"), ensure_ascii=False)
-    return f"""# Role and objective
-You are Poke, {packet.owner.display_name}'s AI assistant, calling on their behalf.
+    return f"""# Objective
 Complete only the approved objective in the context below.
-
-# Identity and disclosure
-Always identify yourself as Poke, {packet.owner.display_name}'s AI assistant.
-Never imply that you are {packet.owner.display_name} or a human.
+Choose how to open the call from the approved context; the application does not prescribe an opening.
 
 # Conversation behavior
 Speak naturally, briefly, and professionally. Listen before responding.
-Never repeat the opening greeting; the application sends it exactly once.
 If audio is unclear, ask the callee to repeat it rather than guessing.
 Do not invent names, phone numbers, dates, facts, availability, prices, or confirmation details.
 Treat transcription as fallible guidance and rely on the live conversation.

--- a/app/routes/debug.py
+++ b/app/routes/debug.py
@@ -25,7 +25,7 @@ async def get_call(call_id: str, request: Request):
         "amd_result",
         "answered_by",
         "answer_handling",
-        "greeting_sent",
+        "opening_sent",
         "voicemail_sent",
         "tool_call_count",
         "tool_continuation_observed",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,7 @@ class FakeTwilio:
 class FakeRealtime:
     def __init__(self):
         self.events: list[tuple[str, str]] = []
+        self.initial_updates: list[str] = []
         self.hangups: list[str | None] = []
         self.rejects: list[str] = []
         self.closed: list[str] = []
@@ -125,6 +126,26 @@ class FakeRealtime:
                 }
             },
         }
+        self.initial_update_event = {
+            "type": "session.updated",
+            "session": {
+                "audio": {
+                    "input": {
+                        "transcription": {"model": "gpt-4o-mini-transcribe"},
+                        "turn_detection": {
+                            "type": "semantic_vad",
+                            "eagerness": "auto",
+                            "create_response": False,
+                            "interrupt_response": False,
+                        },
+                    }
+                }
+            },
+        }
+
+    async def verify_initial_session(self, call_id: str):
+        self.initial_updates.append(call_id)
+        return self.initial_update_event
 
     async def enable_automatic_responses(self, call_id: str):
         self.events.append(("session.update", call_id))
@@ -141,10 +162,10 @@ class FakeRealtime:
         turn = event["session"]["audio"]["input"]["turn_detection"]
         return turn["create_response"] is True and turn["interrupt_response"] is True
 
-    async def create_greeting(self, call_id: str, target: str) -> None:
-        self.events.append(("greeting", call_id))
+    async def create_opening(self, call_id: str) -> None:
+        self.events.append(("opening", call_id))
 
-    async def create_voicemail(self, call_id: str, packet: ContextPacket) -> None:
+    async def create_voicemail(self, call_id: str) -> None:
         self.events.append(("voicemail", call_id))
 
     async def hangup(self, openai_call_id: str | None) -> None:
@@ -171,11 +192,20 @@ class FakeRealtime:
             self.events.append(("tool_continuation", call_id))
 
     def expected_transcription_echoed(self, event) -> bool:
-        return event.get("transcription_ok", True)
+        transcription = (
+            event.get("session", {}).get("audio", {}).get("input", {}).get("transcription", {})
+        )
+        return transcription.get("model") == "gpt-4o-mini-transcribe"
 
     @staticmethod
     def expected_initial_vad_echoed(event) -> bool:
-        return event.get("vad_ok", True)
+        turn = event.get("session", {}).get("audio", {}).get("input", {}).get("turn_detection", {})
+        return (
+            turn.get("type") == "semantic_vad"
+            and turn.get("eagerness") == "auto"
+            and turn.get("create_response") is False
+            and turn.get("interrupt_response") is False
+        )
 
 
 class FakeFinalizer:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,9 @@ class FakeRealtime:
     async def create_opening(self, call_id: str) -> None:
         self.events.append(("opening", call_id))
 
+    async def cancel_response(self, call_id: str, response_id: str | None = None) -> None:
+        self.events.append(("cancel_response", call_id))
+
     async def create_voicemail(self, call_id: str) -> None:
         self.events.append(("voicemail", call_id))
 

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -411,6 +411,59 @@ async def test_machine_waits_for_message_end_and_all_gates(service, packet):
 
 
 @pytest.mark.asyncio
+async def test_late_voicemail_amd_cancels_in_flight_opening(service, packet):
+    call_id = await seed_call(service.db, packet)
+    await service.handle_sideband_open(call_id)
+    await service.handle_participant_status(call_id, "callee", {"CallStatus": "in-progress"})
+    assert service._test_realtime.events == [("opening", call_id)]
+
+    await service.handle_realtime_event(
+        call_id, {"type": "response.created", "response": {"id": "resp_opening"}}
+    )
+    await service.handle_amd(call_id, "machine_end_beep")
+
+    assert service._test_realtime.events == [
+        ("opening", call_id),
+        ("session.update", call_id),
+        ("cancel_response", call_id),
+        ("voicemail", call_id),
+    ]
+
+    # The cancelled opening's response.done must not count as the voicemail finishing.
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "response.done", "response": {"id": "resp_opening", "status": "cancelled"}},
+    )
+    await wait_background()
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.ACTIVE.value
+
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "response.done", "response": {"id": "resp_vm", "status": "completed"}},
+    )
+    await wait_background()
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.COMPLETED.value
+    assert call["termination_reason"] == "voicemail_left"
+
+
+@pytest.mark.asyncio
+async def test_stale_response_cancel_error_is_not_fatal(service, packet):
+    call_id = await seed_call(service.db, packet)
+    await service.db.update_call(call_id, sideband_open=1, callee_joined=1)
+    await service.handle_amd(call_id, "human")
+
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "error", "error": {"code": "response_cancel_not_active"}},
+    )
+    await wait_background()
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.ACTIVE.value
+
+
+@pytest.mark.asyncio
 async def test_fax_terminates(service, packet):
     call_id = await seed_call(service.db, packet)
     await service.handle_amd(call_id, "fax")

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -411,6 +411,24 @@ async def test_machine_waits_for_message_end_and_all_gates(service, packet):
 
 
 @pytest.mark.asyncio
+async def test_late_voicemail_amd_cancels_opening_before_response_created(service, packet):
+    call_id = await seed_call(service.db, packet)
+    await service.handle_sideband_open(call_id)
+    await service.handle_participant_status(call_id, "callee", {"CallStatus": "in-progress"})
+    assert service._test_realtime.events == [("opening", call_id)]
+
+    # AMD can classify the callee before OpenAI acknowledges the opening response.create.
+    await service.handle_amd(call_id, "machine_end_beep")
+
+    assert service._test_realtime.events == [
+        ("opening", call_id),
+        ("session.update", call_id),
+        ("cancel_response", call_id),
+        ("voicemail", call_id),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_late_voicemail_amd_cancels_in_flight_opening(service, packet):
     call_id = await seed_call(service.db, packet)
     await service.handle_sideband_open(call_id)

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -36,6 +36,7 @@ async def test_callee_is_not_dialed_until_accept_and_sideband_open(service, pack
 
     await service.handle_sideband_open(started.call_id)
     assert service._test_twilio.callee_creates == 1
+    assert service._test_realtime.initial_updates == [started.call_id]
 
 
 @pytest.mark.asyncio
@@ -52,27 +53,25 @@ async def test_unmapped_incoming_sip_call_is_explicitly_rejected(service):
 
 
 @pytest.mark.asyncio
-async def test_session_created_config_mismatch_terminates_before_activation(service, packet):
+async def test_initial_session_update_mismatch_terminates_before_dialing(service, packet):
     call_id = await seed_call(service.db, packet)
-    await service.handle_realtime_event(
-        call_id,
-        {
-            "type": "session.created",
-            "event_id": "evt_session_bad",
-            "transcription_ok": False,
-            "vad_ok": True,
-        },
+    await service.db.update_call(
+        call_id, transcription_verified=0, semantic_vad_verified=0, callee_dialed=0
     )
-    await wait_background()
+    service._test_realtime.initial_update_event["session"]["audio"]["input"]["transcription"][
+        "model"
+    ] = "unexpected-model"
+    await service.handle_sideband_open(call_id)
     call = await service.db.get_call(call_id)
     assert call["transcription_verified"] == 0
     assert call["semantic_vad_verified"] == 1
     assert call["state"] == CallState.FAILED.value
     assert call["termination_reason"] == "transcription_config_mismatch"
+    assert service._test_twilio.callee_creates == 0
 
 
 @pytest.mark.asyncio
-async def test_telephony_gates_wait_for_verified_session_created(service, packet):
+async def test_missing_session_created_activates_from_explicit_session_update(service, packet):
     call_id = await seed_call(service.db, packet)
     await service.db.update_call(
         call_id,
@@ -85,36 +84,93 @@ async def test_telephony_gates_wait_for_verified_session_created(service, packet
     assert (await service.db.get_call(call_id))["state"] == CallState.PREWARMING.value
     assert service._test_realtime.events == []
 
-    await service.handle_realtime_event(
-        call_id,
-        {
-            "type": "session.created",
-            "event_id": "evt_session_good",
-            "transcription_ok": True,
-            "vad_ok": True,
-        },
-    )
-    assert (await service.db.get_call(call_id))["state"] == CallState.GREETING_STARTED.value
+    await service.handle_sideband_open(call_id)
+    assert (await service.db.get_call(call_id))["state"] == CallState.ACTIVE.value
+    assert service._test_realtime.initial_updates == [call_id]
     assert service._test_realtime.events == [
         ("session.update", call_id),
-        ("greeting", call_id),
+        ("opening", call_id),
     ]
 
 
 @pytest.mark.asyncio
-async def test_greeting_unmutes_agent_before_speech(service, packet):
+async def test_opening_unmutes_agent_before_speech(service, packet):
     call_id = await seed_call(service.db, packet)
     await service.db.update_call(call_id, sideband_open=1, callee_joined=1)
     await service.handle_amd(call_id, "human")
     assert service._test_twilio.unmuted == [("CF" + "a" * 32, "CA" + "a" * 32)]
     assert service._test_realtime.events == [
         ("session.update", call_id),
-        ("greeting", call_id),
+        ("opening", call_id),
     ]
 
 
 @pytest.mark.asyncio
-async def test_greeting_exactly_once_after_confirmed_session_update(service, packet):
+async def test_callee_join_starts_opening_before_amd_completes(service, packet):
+    call_id = await seed_call(service.db, packet)
+    await service.handle_sideband_open(call_id)
+
+    await service.handle_conference_event(
+        call_id,
+        {
+            "StatusCallbackEvent": "participant-join",
+            "ParticipantLabel": "callee",
+            "CallSid": "CA" + "b" * 32,
+        },
+    )
+
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.PREWARMING.value
+    assert call["amd_result"] is None
+    assert call["opening_sent"] == 1
+    assert service._test_twilio.unmuted == [("CF" + "a" * 32, "CA" + "a" * 32)]
+    assert service._test_realtime.events == [("opening", call_id)]
+
+    await service.handle_amd(call_id, "human")
+
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.ACTIVE.value
+    assert service._test_twilio.unmuted == [("CF" + "a" * 32, "CA" + "a" * 32)]
+    assert service._test_realtime.events == [
+        ("opening", call_id),
+        ("session.update", call_id),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_callee_answered_status_starts_opening_before_conference_join(service, packet):
+    call_id = await seed_call(service.db, packet)
+    await service.handle_sideband_open(call_id)
+
+    await service.handle_participant_status(call_id, "callee", {"CallStatus": "in-progress"})
+
+    call = await service.db.get_call(call_id)
+    assert call["callee_joined"] == 1
+    assert call["answered_at"] is not None
+    assert call["opening_sent"] == 1
+    assert service._test_realtime.events == [("opening", call_id)]
+
+    await service.handle_conference_event(
+        call_id,
+        {
+            "StatusCallbackEvent": "participant-join",
+            "ParticipantLabel": "callee",
+            "CallSid": "CA" + "b" * 32,
+        },
+    )
+    await service.handle_amd(call_id, "human")
+
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.ACTIVE.value
+    assert call["opening_sent"] == 1
+    assert service._test_realtime.events == [
+        ("opening", call_id),
+        ("session.update", call_id),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_opening_exactly_once_after_confirmed_session_update(service, packet):
     call_id = await seed_call(service.db, packet)
     await service.handle_sideband_open(call_id)
     await service.handle_conference_event(
@@ -137,12 +193,12 @@ async def test_greeting_exactly_once_after_confirmed_session_update(service, pac
     )
 
     assert service._test_realtime.events == [
+        ("opening", call_id),
         ("session.update", call_id),
-        ("greeting", call_id),
     ]
     call = await service.db.get_call(call_id)
-    assert call["state"] == CallState.GREETING_STARTED.value
-    assert call["greeting_sent"] == 1
+    assert call["state"] == CallState.ACTIVE.value
+    assert call["opening_sent"] == 1
 
 
 @pytest.mark.asyncio
@@ -153,7 +209,7 @@ async def test_conference_start_can_satisfy_callee_ready_gate(service, packet):
     await service.handle_conference_event(call_id, {"StatusCallbackEvent": "conference-start"})
     call = await service.db.get_call(call_id)
     assert call["callee_joined"] == 1
-    assert call["state"] == CallState.GREETING_STARTED.value
+    assert call["state"] == CallState.ACTIVE.value
 
 
 @pytest.mark.asyncio
@@ -165,7 +221,7 @@ async def test_session_update_must_echo_both_flags(service, packet):
     await service.db.update_call(call_id, sideband_open=1, callee_joined=1)
     await service.handle_amd(call_id, "human")
     assert (await service.db.get_call(call_id))["state"] == CallState.FAILED.value
-    assert not [event for event in service._test_realtime.events if event[0] == "greeting"]
+    assert not [event for event in service._test_realtime.events if event[0] == "opening"]
 
 
 @pytest.mark.asyncio
@@ -194,7 +250,7 @@ async def test_caller_speech_uses_auto_response_without_manual_create(service, p
 
 @pytest.mark.asyncio
 async def test_tool_output_is_followed_by_observed_continuation(service, packet):
-    call_id = await seed_call(service.db, packet, state=CallState.GREETING_STARTED)
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
     await service.handle_realtime_event(
         call_id,
         {
@@ -218,7 +274,7 @@ async def test_tool_output_is_followed_by_observed_continuation(service, packet)
 
 @pytest.mark.asyncio
 async def test_voice_model_ends_call_only_after_its_completed_response(service, packet):
-    call_id = await seed_call(service.db, packet, state=CallState.GREETING_STARTED)
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
     await service._handle_tool_call(
         call_id,
         {
@@ -228,7 +284,7 @@ async def test_voice_model_ends_call_only_after_its_completed_response(service, 
             "arguments": '{"reason":"objective_completed"}',
         },
     )
-    assert (await service.db.get_call(call_id))["state"] == CallState.GREETING_STARTED.value
+    assert (await service.db.get_call(call_id))["state"] == CallState.ACTIVE.value
     assert service._test_realtime.tool_result_continuations[-1] is True
 
     await service.handle_realtime_event(
@@ -238,7 +294,7 @@ async def test_voice_model_ends_call_only_after_its_completed_response(service, 
             "response": {"id": "resp_function", "status": "completed"},
         },
     )
-    assert (await service.db.get_call(call_id))["state"] == CallState.GREETING_STARTED.value
+    assert (await service.db.get_call(call_id))["state"] == CallState.ACTIVE.value
     await service.handle_realtime_event(
         call_id,
         {
@@ -265,7 +321,7 @@ async def test_voice_model_ends_call_only_after_its_completed_response(service, 
 
 @pytest.mark.asyncio
 async def test_interrupted_voice_closing_does_not_end_call(service, packet):
-    call_id = await seed_call(service.db, packet, state=CallState.GREETING_STARTED)
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
     await service._handle_tool_call(
         call_id,
         {
@@ -292,14 +348,14 @@ async def test_interrupted_voice_closing_does_not_end_call(service, packet):
     await wait_background()
 
     call = await service.db.get_call(call_id)
-    assert call["state"] == CallState.GREETING_STARTED.value
+    assert call["state"] == CallState.ACTIVE.value
     assert call["interruption_observed"] == 1
     assert service._test_realtime.hangups == []
 
 
 @pytest.mark.asyncio
 async def test_transfer_tool_returns_output_before_removing_ai(service, packet):
-    call_id = await seed_call(service.db, packet, state=CallState.GREETING_STARTED)
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
     service._owner_join_events.setdefault(call_id, __import__("asyncio").Event()).set()
     order: list[str] = []
     original_send = service._test_realtime.send_tool_result
@@ -334,7 +390,7 @@ async def test_unknown_amd_assumes_human_and_never_hangs_up(service, packet, ans
     await service.handle_amd(call_id, answered_by)
     call = await service.db.get_call(call_id)
     assert call["answer_handling"] == "assumed_human"
-    assert call["state"] == CallState.GREETING_STARTED.value
+    assert call["state"] == CallState.ACTIVE.value
     assert service._test_realtime.hangups == []
 
 
@@ -372,5 +428,5 @@ async def test_conflicting_duplicate_amd_cannot_override_first_result(service, p
     call = await service.db.get_call(call_id)
     assert call["answered_by"] == "human"
     assert call["answer_handling"] == "human"
-    assert call["state"] == CallState.GREETING_STARTED.value
+    assert call["state"] == CallState.ACTIVE.value
     assert service._test_realtime.hangups == []

--- a/tests/test_bridge_payloads.py
+++ b/tests/test_bridge_payloads.py
@@ -28,6 +28,162 @@ class FakeWebSocket:
         self.closed = True
 
 
+class StreamingFakeWebSocket(FakeWebSocket):
+    def __init__(self, echo: dict):
+        super().__init__()
+        self.echo = echo
+        self.incoming: asyncio.Queue[str | None] = asyncio.Queue()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> str:
+        message = await self.incoming.get()
+        if message is None:
+            raise StopAsyncIteration
+        return message
+
+    async def send(self, message: str) -> None:
+        await super().send(message)
+        await self.incoming.put(json.dumps(self.echo))
+
+    async def close(self) -> None:
+        if not self.closed:
+            await self.incoming.put(None)
+        await super().close()
+
+
+class FakeConnection:
+    def __init__(self, websocket: StreamingFakeWebSocket):
+        self.websocket = websocket
+
+    async def __aenter__(self) -> StreamingFakeWebSocket:
+        return self.websocket
+
+    async def __aexit__(self, *args) -> None:
+        await self.websocket.close()
+
+
+@pytest.mark.asyncio
+async def test_opening_response_uses_session_context_without_a_script(settings):
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+    )
+    websocket = FakeWebSocket()
+    bridge._runtime["call_1"] = RealtimeRuntime(
+        call_id="call_1", openai_call_id="rtc_1", websocket=websocket
+    )
+
+    await bridge.create_opening("call_1")
+
+    assert websocket.messages == [
+        {
+            "type": "response.create",
+            "response": {"output_modalities": ["audio"]},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_voicemail_prompt_does_not_script_identity_or_callback_wording(settings):
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+    )
+    websocket = FakeWebSocket()
+    bridge._runtime["call_1"] = RealtimeRuntime(
+        call_id="call_1", openai_call_id="rtc_1", websocket=websocket
+    )
+
+    await bridge.create_voicemail("call_1")
+
+    instructions = websocket.messages[0]["response"]["instructions"]
+    assert "approved context" in instructions
+    assert "Poke" not in instructions
+    assert "AI assistant" not in instructions
+    assert "callback" not in instructions
+
+
+def test_session_prompt_leaves_opening_identity_and_wording_to_poke(settings, packet):
+    instructions = (
+        RealtimeBridge(
+            settings,
+            SimpleNamespace(),
+            on_event=_noop,
+            on_open=_noop,
+            on_fatal=_noop,
+        )
+        .build_accept_payload(packet)
+        .instructions
+    )
+
+    assert "Choose how to open the call from the approved context" in instructions
+    assert "# Identity and disclosure" not in instructions
+    assert "Always identify yourself" not in instructions
+    assert "You are Poke" not in instructions
+    assert "Am I speaking with" not in instructions
+
+
+@pytest.mark.asyncio
+async def test_sideband_receives_initial_update_echo_while_open_handler_waits(
+    settings, monkeypatch
+):
+    echoed = {
+        "type": "session.updated",
+        "session": {
+            "audio": {
+                "input": {
+                    "transcription": {"model": "gpt-4o-mini-transcribe"},
+                    "turn_detection": {
+                        "type": "semantic_vad",
+                        "eagerness": "auto",
+                        "create_response": False,
+                        "interrupt_response": False,
+                    },
+                }
+            }
+        },
+    }
+    websocket = StreamingFakeWebSocket(echoed)
+    opened = asyncio.Event()
+    fatals: list[tuple[str, str]] = []
+    bridge: RealtimeBridge
+
+    async def on_open(call_id: str) -> None:
+        updated = await bridge.verify_initial_session(call_id)
+        assert updated == echoed
+        opened.set()
+        await websocket.close()
+
+    async def on_fatal(call_id: str, reason: str) -> None:
+        fatals.append((call_id, reason))
+
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=on_open,
+        on_fatal=on_fatal,
+    )
+    runtime = RealtimeRuntime(call_id="call_1", openai_call_id="rtc_1")
+    bridge._runtime["call_1"] = runtime
+    monkeypatch.setattr(
+        "app.openai_realtime.websockets.connect", lambda *args, **kwargs: FakeConnection(websocket)
+    )
+
+    await asyncio.wait_for(bridge._run(runtime), timeout=1)
+
+    assert opened.is_set()
+    assert fatals == []
+
+
 @pytest.mark.asyncio
 async def test_activation_update_is_serialized_and_waits_for_echo(settings):
     bridge = RealtimeBridge(
@@ -73,6 +229,61 @@ async def test_activation_update_is_serialized_and_waits_for_echo(settings):
                             "create_response": True,
                             "interrupt_response": True,
                         }
+                    }
+                },
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_initial_session_update_reasserts_safe_audio_gate(settings):
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+    )
+    websocket = FakeWebSocket()
+    runtime = RealtimeRuntime(call_id="call_1", openai_call_id="rtc_1", websocket=websocket)
+    bridge._runtime["call_1"] = runtime
+
+    pending = asyncio.create_task(bridge.verify_initial_session("call_1"))
+    await asyncio.wait_for(websocket.sent.wait(), timeout=1)
+    echoed = {
+        "type": "session.updated",
+        "session": {
+            "audio": {
+                "input": {
+                    "transcription": {"model": "gpt-4o-mini-transcribe"},
+                    "turn_detection": {
+                        "type": "semantic_vad",
+                        "eagerness": "auto",
+                        "create_response": False,
+                        "interrupt_response": False,
+                    },
+                }
+            }
+        },
+    }
+    runtime.update_waiter.set_result(echoed)
+
+    assert await pending == echoed
+    assert websocket.messages == [
+        {
+            "type": "session.update",
+            "session": {
+                "type": "realtime",
+                "audio": {
+                    "input": {
+                        "transcription": {"model": "gpt-4o-mini-transcribe"},
+                        "turn_detection": {
+                            "type": "semantic_vad",
+                            "eagerness": "auto",
+                            "create_response": False,
+                            "interrupt_response": False,
+                        },
                     }
                 },
             },

--- a/tests/test_policy_and_db.py
+++ b/tests/test_policy_and_db.py
@@ -6,9 +6,43 @@ import pytest
 from pydantic import ValidationError
 
 from app.db import Database, DeploymentLockedError
-from app.models import EvidenceValue, PreparePhoneCallInput
+from app.models import CallState, EvidenceValue, PreparePhoneCallInput
 from app.policy import validate_context, validate_destination
 from app.settings import Settings
+
+
+@pytest.mark.asyncio
+async def test_initialize_migrates_legacy_opening_column_and_state(settings, packet):
+    db = Database(settings.database_path)
+    await db.initialize()
+    expires_at = datetime.now(UTC) + timedelta(minutes=10)
+    await db.create_plan(
+        "plan_legacy",
+        packet.model_dump(mode="json"),
+        "Owner explicitly requested the call",
+        expires_at,
+    )
+    assert await db.claim_plan_and_create_call(
+        plan_id="plan_legacy",
+        call_id="call_legacy",
+        conference_name="conference_legacy",
+        confirmation_text="Confirmed",
+    )
+    await db.update_call(
+        "call_legacy",
+        state="greeting_started",
+        opening_sent=1,
+    )
+    await db.execute("ALTER TABLE calls RENAME COLUMN opening_sent TO greeting_sent")
+
+    await db.initialize()
+
+    columns = {row["name"] for row in await db.fetch_all("PRAGMA table_info(calls)")}
+    call = await db.get_call("call_legacy")
+    assert "opening_sent" in columns
+    assert "greeting_sent" not in columns
+    assert call["opening_sent"] == 1
+    assert call["state"] == CallState.ACTIVE.value
 
 
 @pytest.mark.parametrize(

--- a/tests/test_teardown_recovery.py
+++ b/tests/test_teardown_recovery.py
@@ -28,7 +28,7 @@ async def test_callee_exit_completes_conference_and_hangup_exactly_once(service,
 
 @pytest.mark.asyncio
 async def test_transfer_removes_ai_without_completing_owner_callee_conference(service, packet):
-    call_id = await seed_call(service.db, packet, state=CallState.GREETING_STARTED)
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
     event = service._owner_join_events.setdefault(call_id, __import__("asyncio").Event())
     event.set()
     result = await service.transfer_to_owner(call_id, "owner needed")
@@ -41,7 +41,7 @@ async def test_transfer_removes_ai_without_completing_owner_callee_conference(se
 
 @pytest.mark.asyncio
 async def test_agent_completed_race_during_transfer_preserves_conference(service, packet):
-    call_id = await seed_call(service.db, packet, state=CallState.GREETING_STARTED)
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
     service._owner_join_events.setdefault(call_id, __import__("asyncio").Event()).set()
     original_remove = service._test_twilio.remove_participant
 
@@ -144,10 +144,10 @@ async def test_setup_deadline_times_out_only_unactivated_calls(service, packet):
         service.db,
         packet,
         call_id="call_voicemail",
-        state=CallState.GREETING_STARTED,
+        state=CallState.ACTIVE,
         openai_call_id="rtc_voicemail",
     )
-    await service.db.update_call(active_voicemail, voicemail_sent=1, greeting_sent=0)
+    await service.db.update_call(active_voicemail, voicemail_sent=1, opening_sent=0)
     service.settings.setup_deadline_seconds = 0
 
     await service._setup_deadline(waiting_call)
@@ -155,9 +155,7 @@ async def test_setup_deadline_times_out_only_unactivated_calls(service, packet):
     await wait_background()
 
     assert (await service.db.get_call(waiting_call))["state"] == CallState.TIMED_OUT.value
-    assert (await service.db.get_call(active_voicemail))[
-        "state"
-    ] == CallState.GREETING_STARTED.value
+    assert (await service.db.get_call(active_voicemail))["state"] == CallState.ACTIVE.value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

Two related pieces, the second building on the first:

### 1. Model-chosen opening with a verified session (pre-existing working-tree feature)

- The voice model now chooses how to open the call from Poke's approved context; the bridge no longer imposes a scripted greeting, identity wording, or disclosure text (`app/prompts.py`, README updated accordingly).
- The sideband starts its receiver task before the `on_open` handshake, and the initial `session.update` (transcription + semantic VAD with auto-responses off) is verified against the echoed `session.updated` **before the callee is dialed** — a config mismatch fails the call without ever ringing a real person.
- The `GREETING_STARTED` state is removed; `greeting_sent` is renamed to `opening_sent` with an in-place SQLite migration (column rename + legacy state row rewrite).
- Opening starts as soon as the callee joins, without waiting for async AMD, so a human callee doesn't sit through several seconds of silence.

### 2. Answer-to-first-audio latency cuts

- **Earlier trigger:** the callee leg's `answered`/`in-progress` participant-status callback (already subscribed, previously ignored) now also sets `callee_joined`/`answered_at` and starts the opening — whichever webhook (status callback or conference join) arrives first wins, guarded by the existing `opening_sent` once-flag.
- **Unmute off the critical path:** the explicit agent-leg unmute is a race-safety net (Twilio auto-unmutes at conference start), so it now runs concurrently with the opening `response.create` via `asyncio.gather` instead of blocking it behind a Twilio REST round-trip. Same treatment for the voicemail branch.
- Expected saving on the answered→first-audio path: roughly 300ms–1s per call.

## Risks

- Teardown/billing paths are untouched; `terminate_call` and its reason mapping are unchanged.
- Triggering the opening from the answered status callback marks `callee_joined` slightly before the conference join event. The model's first audio takes ~500ms+ to arrive, by which time the conference (callee joins with `start_conference_on_enter=true`) is mixing, so opening audio should not be clipped. If a callee answered but never joined the conference, the existing terminal status callbacks still tear the call down.
- Removing the forced disclosure script shifts jurisdiction-specific disclosure responsibility entirely to the owner (documented in README).

## Validation

- `uv run ruff format --check app tests scripts` — clean
- `uv run ruff check app tests scripts` — clean
- `uv run pytest -q` — 87 passed, including a new regression test (`test_callee_answered_status_starts_opening_before_conference_join`) covering the earlier trigger plus once-only opening, and existing activation-gate/migration tests covering the rename and pre-dial verification.
- Not yet validated against a live call; recommend a `scripts/run_sip_canary.py --mode full` run before deploying, since telephony behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xiyaowang0519/poke-call/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->