### PR TITLE
Fix opening spoken before the callee answers (heard 1-2 words, then silence, then hang-up)

### DIFF
--- a/app/call_state.py
+++ b/app/call_state.py
@@ -285,11 +285,12 @@ class CallService:
         if call is None:
             return
         if event in {"conference-start", "start"}:
-            await self.db.set_flag_once(call_id, "callee_joined")
-            if not call.get("answered_at"):
-                await self.db.update_call(call_id, answered_at=datetime.now(UTC).isoformat())
-            await self._start_opening_on_answer(call_id)
-            await self._check_activation_gate(call_id)
+            # Twilio fires conference-start as soon as the agent SIP leg enters the
+            # REST-created conference, while the callee is still ringing. It is not
+            # evidence the callee answered, so it must not mark the callee joined or
+            # trigger the opening turn; the callee's own participant-join event and
+            # answered status callback do that instead.
+            await self.db.touch_call(call_id)
         elif event in {"participant-join", "join"}:
             if label == "callee" or (call_sid and call_sid == call.get("twilio_callee_call_sid")):
                 await self.db.set_flag_once(call_id, "callee_joined")

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -51,22 +51,10 @@ class RealtimeBridge:
         self._runtime: dict[str, RealtimeRuntime] = {}
 
     def build_accept_payload(self, packet: ContextPacket) -> AcceptPayload:
-        transcription: dict[str, Any] = {"model": self.settings.input_transcription_model}
-        if self.settings.input_transcription_model == "gpt-realtime-whisper":
-            if self.settings.input_transcription_delay:
-                transcription["delay"] = self.settings.input_transcription_delay
         return AcceptPayload(
             instructions=realtime_instructions(packet),
             audio={
-                "input": {
-                    "transcription": transcription,
-                    "turn_detection": {
-                        "type": "semantic_vad",
-                        "eagerness": "auto",
-                        "create_response": False,
-                        "interrupt_response": False,
-                    },
-                },
+                "input": self._input_audio_config(create_response=False, interrupt_response=False),
                 "output": {
                     "voice": "marin",
                     "speed": 1.0,
@@ -236,37 +224,40 @@ class RealtimeBridge:
             finally:
                 runtime.update_waiter = None
 
-    async def verify_initial_session(self, call_id: str) -> dict[str, Any]:
+    def _transcription_config(self) -> dict[str, Any]:
         transcription: dict[str, Any] = {"model": self.settings.input_transcription_model}
         if self.settings.input_transcription_model == "gpt-realtime-whisper":
             if self.settings.input_transcription_delay:
                 transcription["delay"] = self.settings.input_transcription_delay
+        return transcription
+
+    def _input_audio_config(
+        self, *, create_response: bool, interrupt_response: bool
+    ) -> dict[str, Any]:
         # Do not specify audio.format: SIP media negotiates G.711 with Twilio, and
-        # explicitly overriding it can silence RTP.
+        # explicitly overriding it can silence RTP. Always re-assert transcription
+        # alongside turn_detection: session.update replaces the nested audio.input
+        # object, so a turn_detection-only update would drop input transcription.
+        return {
+            "transcription": self._transcription_config(),
+            "turn_detection": {
+                "type": "semantic_vad",
+                "eagerness": "auto",
+                "create_response": create_response,
+                "interrupt_response": interrupt_response,
+            },
+        }
+
+    async def verify_initial_session(self, call_id: str) -> dict[str, Any]:
         return await self._update_session(
             call_id,
-            {
-                "transcription": transcription,
-                "turn_detection": {
-                    "type": "semantic_vad",
-                    "eagerness": "auto",
-                    "create_response": False,
-                    "interrupt_response": False,
-                },
-            },
+            self._input_audio_config(create_response=False, interrupt_response=False),
         )
 
     async def enable_automatic_responses(self, call_id: str) -> dict[str, Any]:
         return await self._update_session(
             call_id,
-            {
-                "turn_detection": {
-                    "type": "semantic_vad",
-                    "eagerness": "auto",
-                    "create_response": True,
-                    "interrupt_response": True,
-                }
-            },
+            self._input_audio_config(create_response=True, interrupt_response=True),
         )
 
     async def create_opening(self, call_id: str) -> None:

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -202,14 +202,40 @@ async def test_opening_exactly_once_after_confirmed_session_update(service, pack
 
 
 @pytest.mark.asyncio
-async def test_conference_start_can_satisfy_callee_ready_gate(service, packet):
+async def test_conference_start_alone_does_not_mark_callee_joined(service, packet):
+    """conference-start fires when the agent SIP leg connects, before the callee answers.
+
+    Regression: treating it as callee join used to send the opening turn into an empty
+    conference while the callee's phone was still ringing, so the callee heard only the
+    tail of the opening followed by silence until the watchdog hung up.
+    """
     call_id = await seed_call(service.db, packet)
-    await service.db.update_call(call_id, sideband_open=1)
-    await service.handle_amd(call_id, "human")
+    await service.handle_sideband_open(call_id)
+
     await service.handle_conference_event(call_id, {"StatusCallbackEvent": "conference-start"})
+
+    call = await service.db.get_call(call_id)
+    assert call["callee_joined"] == 0
+    assert call["answered_at"] is None
+    assert call["opening_sent"] == 0
+    assert call["state"] == CallState.PREWARMING.value
+    assert service._test_realtime.events == []
+
+    # The opening starts only once the callee actually answers.
+    await service.handle_participant_status(call_id, "callee", {"CallStatus": "in-progress"})
     call = await service.db.get_call(call_id)
     assert call["callee_joined"] == 1
+    assert call["answered_at"] is not None
+    assert call["opening_sent"] == 1
+    assert service._test_realtime.events == [("opening", call_id)]
+
+    await service.handle_amd(call_id, "human")
+    call = await service.db.get_call(call_id)
     assert call["state"] == CallState.ACTIVE.value
+    assert service._test_realtime.events == [
+        ("opening", call_id),
+        ("session.update", call_id),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_bridge_payloads.py
+++ b/tests/test_bridge_payloads.py
@@ -223,12 +223,16 @@ async def test_activation_update_is_serialized_and_waits_for_echo(settings):
                 "type": "realtime",
                 "audio": {
                     "input": {
+                        # Transcription must be re-asserted: session.update replaces the
+                        # nested audio.input object, so omitting it would drop callee
+                        # transcription for the rest of the call.
+                        "transcription": {"model": "gpt-4o-mini-transcribe"},
                         "turn_detection": {
                             "type": "semantic_vad",
                             "eagerness": "auto",
                             "create_response": True,
                             "interrupt_response": True,
-                        }
+                        },
                     }
                 },
             },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Symptom

Poke calls the owner to tell a joke; after pickup the callee hears only one or two words, then silence, and the call auto-hangs-up (`termination_reason=watchdog_stale`).

## Root cause (from production Fly DB + Twilio call records)

In all three production calls, `callee_joined`/`answered_at` were set ~1s after the **agent** SIP leg connected, while the callee's phone was still ringing:

| call | agent SIP connected | `answered_at` in DB | callee actually answered |
|---|---|---|---|
| failing joke call | 12:36:17 | 12:36:18.08 | 12:36:23 |
| earlier completed call | 07:18:48 | 07:18:48.91 | 07:18:55 |
| voicemail call | 07:17:22 | 07:17:22.88 | 07:17:26 |

Twilio fires `conference-start` as soon as the agent SIP leg enters the REST-created conference — not when the callee joins — and `handle_conference_event` treated that event as proof the callee had answered. The opening `response.create` was therefore sent while the callee was still ringing: in the failing call the model finished its opening at 12:36:20, three seconds **before** pickup at 12:36:23 (transcript turn confirms it). The callee heard only the trailing words of the RTP playback, the model then waited for an answer to a question nobody heard (automatic responses still disabled until AMD resolved as `unknown`), both sides sat silent, and the 15s `watchdog_stale` check hung up at 12:36:49.

Secondary finding: all three calls have **zero callee transcript turns** even though VAD interruption demonstrably worked. The activation `session.update` sent `audio.input` containing only `turn_detection`, which replaces the nested object and drops the `transcription` config.

## Fix

- `handle_conference_event`: `conference-start` no longer marks the callee joined, sets `answered_at`, or triggers the opening; it only refreshes liveness. The callee's own `participant-join` event and answered status callback (both already handled) drive the opening, so the opening now starts when the callee is actually on the line.
- `RealtimeBridge`: accept, initial verification, and activation updates now share one `audio.input` builder that always re-asserts `transcription` alongside `turn_detection`, restoring callee transcription after activation.

## Risk

No changes to teardown, billing paths, signature checks, or confirmation flow. If both the callee's answered status callback and its participant-join event were lost, the callee would never be marked joined and the call would end at the existing `setup_deadline`; previously the spurious `conference-start` could mask that, but it also mis-timed every call.

## Validation

- ✅ `uv run ruff format --check app tests scripts`
- ✅ `uv run ruff check app tests scripts`
- ✅ `uv run pytest -q` (90 passed)
- New regression test `test_conference_start_alone_does_not_mark_callee_joined` reproduces the production sequence (agent joins → `conference-start` → callee answers → AMD) and fails on the pre-fix code.
- Not run: `scripts/run_sip_canary.py --mode full` — it places a real call to the owner's phone; recommend running it after deploy for live confirmation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f60c1-5323-7490-ac51-24fbf285a66a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f60c1-5323-7490-ac51-24fbf285a66a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

