### PR TITLE
Reduce live-call latency across setup, realtime, and tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,19 @@
 OPENAI_API_KEY=
 OPENAI_WEBHOOK_SECRET=
 OPENAI_PROJECT_ID=
+# Live-call REST control bounds; websocket setup has its own bounded timeout.
+OPENAI_CONNECT_TIMEOUT_SECONDS=3
+OPENAI_HTTP_TIMEOUT_SECONDS=10
+# Post-call extraction gets a longer per-request bound than live-call control requests.
+OPENAI_EXTRACTION_TIMEOUT_SECONDS=30
+# Optional measured experiment; unset keeps the OpenAI SDK's default pool policy.
+# OPENAI_KEEPALIVE_EXPIRY_SECONDS=60
 
 # Twilio
 TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
 TWILIO_CALLER_ID=
+TWILIO_HTTP_TIMEOUT_SECONDS=10
 
 # Single owner and Poke authentication
 OWNER_PHONE_E164=
@@ -23,6 +31,8 @@ ALLOWED_COUNTRY_CODES=+1
 # Fixed/release-gated model configuration
 INPUT_TRANSCRIPTION_MODEL=gpt-4o-mini-transcribe
 # INPUT_TRANSCRIPTION_DELAY=low
+# Set to auto to roll back to OpenAI's medium-eagerness behavior.
+SEMANTIC_VAD_EAGERNESS=high
 EXTRACTOR_MODEL=gpt-5.4-nano-2026-03-17
 MINI_MODELS_ENABLED=false
 

--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@ OPENAI_CONNECT_TIMEOUT_SECONDS=3
 OPENAI_HTTP_TIMEOUT_SECONDS=10
 # Post-call extraction gets a longer per-request bound than live-call control requests.
 OPENAI_EXTRACTION_TIMEOUT_SECONDS=30
-# Optional measured experiment; unset keeps the OpenAI SDK's default pool policy.
-# OPENAI_KEEPALIVE_EXPIRY_SECONDS=60
+# Reuse the OpenAI TLS connection between sporadic calls.
+OPENAI_KEEPALIVE_EXPIRY_SECONDS=60
 
 # Twilio
 TWILIO_ACCOUNT_SID=

--- a/.env.example
+++ b/.env.example
@@ -31,8 +31,8 @@ ALLOWED_COUNTRY_CODES=+1
 # Fixed/release-gated model configuration
 INPUT_TRANSCRIPTION_MODEL=gpt-4o-mini-transcribe
 # INPUT_TRANSCRIPTION_DELAY=low
-# Set to auto to roll back to OpenAI's medium-eagerness behavior.
-SEMANTIC_VAD_EAGERNESS=high
+# Defaults to auto (OpenAI's medium-eagerness behavior). Set to high for quicker turn completion.
+# SEMANTIC_VAD_EAGERNESS=auto
 EXTRACTOR_MODEL=gpt-5.4-nano-2026-03-17
 MINI_MODELS_ENABLED=false
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
 Fill every required value in `.env.local`; the guarded copy command deliberately preserves a key previously saved by the OpenAI Platform picker. Generate `MCP_BEARER_TOKEN` and `DEBUG_API_TOKEN` with a password generator or `openssl rand -hex 32`. Never commit env files; `.gitignore` excludes them.
 
+Live-call control requests use `OPENAI_CONNECT_TIMEOUT_SECONDS` and
+`OPENAI_HTTP_TIMEOUT_SECONDS` (3 and 10 seconds by default) with no SDK retries; post-call
+extraction uses `OPENAI_EXTRACTION_TIMEOUT_SECONDS` and retains its single application-level
+retry. Twilio requests use the pooled, no-retry transport bounded by
+`TWILIO_HTTP_TIMEOUT_SECONDS`. `SEMANTIC_VAD_EAGERNESS=high` favors quicker turn completion; set
+it to `auto` to roll back to OpenAI's medium-eagerness behavior. Leave
+`OPENAI_KEEPALIVE_EXPIRY_SECONDS` unset unless production telemetry justifies an explicit pool
+expiry experiment.
+
 Run validation:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Live-call control requests use `OPENAI_CONNECT_TIMEOUT_SECONDS` and
 `OPENAI_HTTP_TIMEOUT_SECONDS` (3 and 10 seconds by default) with no SDK retries; post-call
 extraction uses `OPENAI_EXTRACTION_TIMEOUT_SECONDS` and retains its single application-level
 retry. Twilio requests use the pooled, no-retry transport bounded by
-`TWILIO_HTTP_TIMEOUT_SECONDS`. `SEMANTIC_VAD_EAGERNESS=high` favors quicker turn completion; set
-it to `auto` to roll back to OpenAI's medium-eagerness behavior.
+`TWILIO_HTTP_TIMEOUT_SECONDS`. `SEMANTIC_VAD_EAGERNESS` defaults to `auto` (OpenAI's
+medium-eagerness behavior); set it to `high` for quicker turn completion.
 `OPENAI_KEEPALIVE_EXPIRY_SECONDS=60` keeps the control-plane TLS connection reusable between
 sporadic calls; set it only to a bounded 5-300 second value.
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Live-call control requests use `OPENAI_CONNECT_TIMEOUT_SECONDS` and
 extraction uses `OPENAI_EXTRACTION_TIMEOUT_SECONDS` and retains its single application-level
 retry. Twilio requests use the pooled, no-retry transport bounded by
 `TWILIO_HTTP_TIMEOUT_SECONDS`. `SEMANTIC_VAD_EAGERNESS=high` favors quicker turn completion; set
-it to `auto` to roll back to OpenAI's medium-eagerness behavior. Leave
-`OPENAI_KEEPALIVE_EXPIRY_SECONDS` unset unless production telemetry justifies an explicit pool
-expiry experiment.
+it to `auto` to roll back to OpenAI's medium-eagerness behavior.
+`OPENAI_KEEPALIVE_EXPIRY_SECONDS=60` keeps the control-plane TLS connection reusable between
+sporadic calls; set it only to a bounded 5-300 second value.
 
 Run validation:
 

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -11,7 +11,13 @@ from typing import Any
 
 from openai import AsyncOpenAI
 
-from app.db import Database, DeploymentLockedError, LatencyMark, LatencyStage
+from app.db import (
+    TRANSFER_ELIGIBLE_STATES,
+    Database,
+    DeploymentLockedError,
+    LatencyMark,
+    LatencyStage,
+)
 from app.finalizer import Finalizer
 from app.models import (
     TERMINAL_STATES,
@@ -801,7 +807,10 @@ class CallService:
                     source_event_type=event_type,
                     source_event_id=event_id,
                 )
-        elif event_type == "response.output_audio_transcript.done":
+        elif event_type in {
+            "response.output_audio_transcript.done",
+            "response.audio_transcript.done",
+        }:
             text = event.get("transcript", "").strip()
             if text:
                 await self.db.add_transcript_turn(
@@ -1145,7 +1154,7 @@ class CallService:
                     current = await self.db.get_call(call_id)
                     exact_joining = bool(
                         current
-                        and current.get("state") == CallState.ACTIVE.value
+                        and current.get("state") in TRANSFER_ELIGIBLE_STATES
                         and not current.get("termination_claimed")
                         and current.get("transfer_outcome") == joining
                     )
@@ -1615,7 +1624,7 @@ class CallService:
                 current = await self.db.get_call(call_id)
                 exact_owner_sid = bool(
                     current
-                    and current.get("state") == CallState.ACTIVE.value
+                    and current.get("state") in TRANSFER_ELIGIBLE_STATES
                     and not current.get("termination_claimed")
                     and current.get("transfer_outcome") == joining
                     and current.get("twilio_owner_call_sid") == owner_call_sid

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -4,7 +4,9 @@ import asyncio
 import json
 import logging
 import secrets
+from collections import OrderedDict
 from datetime import UTC, datetime, timedelta
+from time import monotonic_ns
 from typing import Any
 
 from openai import AsyncOpenAI
@@ -30,6 +32,9 @@ from app.twilio_bridge import TwilioBridge
 
 logger = logging.getLogger(__name__)
 
+CALL_ACTIVITY_TOMBSTONE_TTL_SECONDS = 15 * 60
+CALL_ACTIVITY_TOMBSTONE_MAX = 4096
+
 
 class CallService:
     def __init__(
@@ -45,6 +50,10 @@ class CallService:
         self._owns_openai_client = openai is None
         self.openai = openai if openai is not None else create_openai_client(settings)
         self.twilio = twilio or TwilioBridge(settings)
+        self._latest_call_activity: dict[str, LatencyMark] = {}
+        self._dirty_call_activity: dict[str, LatencyMark] = {}
+        self._watchdog_claims: set[str] = set()
+        self._activity_tombstones: OrderedDict[str, int] = OrderedDict()
         self.realtime = RealtimeBridge(
             settings,
             self.openai,
@@ -52,6 +61,7 @@ class CallService:
             on_open=self.handle_sideband_open,
             on_fatal=self._handle_sideband_fatal,
             on_send=self.handle_realtime_send,
+            on_activity=self._note_call_activity,
         )
         self.finalizer = Finalizer(settings, db, self.openai)
         self._background: set[asyncio.Task[Any]] = set()
@@ -70,6 +80,79 @@ class CallService:
 
     def _opening_transition_lock(self, call_id: str) -> asyncio.Lock:
         return self._opening_transition_locks.setdefault(call_id, asyncio.Lock())
+
+    def _note_call_activity(self, call_id: str, mark: LatencyMark | None = None) -> bool:
+        # A watchdog claim is the liveness linearization point. Activity observed
+        # before the claim updates these maps; activity after it cannot resurrect a
+        # call whose timeout teardown has already won.
+        self._prune_activity_tombstones()
+        if call_id in self._watchdog_claims or call_id in self._activity_tombstones:
+            return False
+        observed = mark or LatencyMark.now()
+        latest = self._latest_call_activity.get(call_id)
+        if latest is not None and latest.monotonic_ns >= observed.monotonic_ns:
+            return True
+        self._latest_call_activity[call_id] = observed
+        dirty = self._dirty_call_activity.get(call_id)
+        if dirty is None or dirty.monotonic_ns < observed.monotonic_ns:
+            self._dirty_call_activity[call_id] = observed
+        return True
+
+    def _clear_call_activity(self, call_id: str) -> None:
+        self._latest_call_activity.pop(call_id, None)
+        self._dirty_call_activity.pop(call_id, None)
+        self._watchdog_claims.discard(call_id)
+
+    def _tombstone_call_activity(self, call_id: str) -> None:
+        now_ns = monotonic_ns()
+        self._prune_activity_tombstones(now_ns)
+        self._activity_tombstones.pop(call_id, None)
+        self._activity_tombstones[call_id] = now_ns + (
+            CALL_ACTIVITY_TOMBSTONE_TTL_SECONDS * 1_000_000_000
+        )
+        while len(self._activity_tombstones) > CALL_ACTIVITY_TOMBSTONE_MAX:
+            self._activity_tombstones.popitem(last=False)
+        self._clear_call_activity(call_id)
+
+    def _prune_activity_tombstones(self, now_ns: int | None = None) -> None:
+        cutoff = monotonic_ns() if now_ns is None else now_ns
+        while self._activity_tombstones:
+            _, expires_at = next(iter(self._activity_tombstones.items()))
+            if expires_at > cutoff:
+                break
+            self._activity_tombstones.popitem(last=False)
+
+    @staticmethod
+    def _call_activity_is_closed(call: dict[str, Any]) -> bool:
+        state = CallState(call["state"])
+        return state == CallState.TERMINATING or state in TERMINAL_STATES
+
+    async def _flush_call_activity(self) -> None:
+        if not self._dirty_call_activity:
+            return
+        pending = self._dirty_call_activity
+        self._dirty_call_activity = {}
+        try:
+            await self.db.touch_calls(
+                (call_id, mark.occurred_at) for call_id, mark in pending.items()
+            )
+        except BaseException as exc:
+            # Keep the newest observation if more activity arrived while the write
+            # was in flight. A terminal cleanup removes the latest map entry and
+            # therefore prevents a failed flush from re-adding a dead call.
+            for call_id, failed_mark in pending.items():
+                latest = self._latest_call_activity.get(call_id)
+                if latest is None:
+                    continue
+                candidate = (
+                    latest if latest.monotonic_ns >= failed_mark.monotonic_ns else failed_mark
+                )
+                current = self._dirty_call_activity.get(call_id)
+                if current is None or current.monotonic_ns < candidate.monotonic_ns:
+                    self._dirty_call_activity[call_id] = candidate
+            if not isinstance(exc, Exception):
+                raise
+            logger.warning("failed to persist batched call activity", exc_info=True)
 
     async def _record_latency(
         self,
@@ -369,6 +452,18 @@ class CallService:
         await self._check_activation_gate(call_id)
 
     async def handle_amd(self, call_id: str, answered_by: str) -> None:
+        received = LatencyMark.now()
+        if not self._note_call_activity(call_id, received):
+            return
+        call = await self.db.get_call(call_id)
+        if call is None:
+            self._clear_call_activity(call_id)
+            return
+        if self._call_activity_is_closed(call):
+            self._tombstone_call_activity(call_id)
+            return
+        if not self._note_call_activity(call_id, received):
+            return
         normalized = (answered_by or "unknown").lower()
         if normalized == "fax":
             handling = "fax"
@@ -388,11 +483,19 @@ class CallService:
 
     async def handle_conference_event(self, call_id: str, form: dict[str, str]) -> None:
         received = LatencyMark.now()
+        if not self._note_call_activity(call_id, received):
+            return
         event = (form.get("StatusCallbackEvent") or form.get("ConferenceStatus") or "").lower()
         label = (form.get("ParticipantLabel") or form.get("Label") or "").lower()
         call_sid = form.get("CallSid") or form.get("ParticipantCallSid")
         call = await self.db.get_call(call_id)
         if call is None:
+            self._clear_call_activity(call_id)
+            return
+        if self._call_activity_is_closed(call):
+            self._tombstone_call_activity(call_id)
+            return
+        if not self._note_call_activity(call_id, received):
             return
         if event in {"conference-start", "start"}:
             # Twilio fires conference-start as soon as the agent SIP leg enters the
@@ -427,6 +530,17 @@ class CallService:
 
     async def handle_participant_status(self, call_id: str, leg: str, form: dict[str, str]) -> None:
         received = LatencyMark.now()
+        if not self._note_call_activity(call_id, received):
+            return
+        call = await self.db.get_call(call_id)
+        if call is None:
+            self._clear_call_activity(call_id)
+            return
+        if self._call_activity_is_closed(call):
+            self._tombstone_call_activity(call_id)
+            return
+        if not self._note_call_activity(call_id, received):
+            return
         status = (form.get("CallStatus") or "").lower()
         await self.db.touch_call(call_id)
         if leg == "callee" and status in {"in-progress", "answered"}:
@@ -560,7 +674,6 @@ class CallService:
         received = LatencyMark.now()
         event_type = event.get("type", "")
         event_id = event.get("event_id") or f"evt_{secrets.token_urlsafe(12)}"
-        await self.db.touch_call(call_id)
         if event_type in {
             "response.output_audio_transcript.delta",
             "response.output_audio_transcript.done",
@@ -843,13 +956,21 @@ class CallService:
         await_finalizer: bool = False,
     ) -> bool:
         call = await self.db.get_call(call_id)
-        if call is None or CallState(call["state"]) in TERMINAL_STATES:
+        if call is None:
+            self._clear_call_activity(call_id)
             return False
+        state = CallState(call["state"])
+        if state in TERMINAL_STATES:
+            self._tombstone_call_activity(call_id)
+            return False
+        if state == CallState.TERMINATING:
+            self._tombstone_call_activity(call_id)
         if (call.get("transfer_outcome") or "").startswith(("in_progress:", "completed:")):
             preserve_conference = True
             reason = "transfer_completed"
         if not await self.db.set_flag_once(call_id, "termination_claimed"):
             return False
+        self._tombstone_call_activity(call_id)
         self._voice_end_pending.pop(call_id, None)
         self._active_response_ids.pop(call_id, None)
         await self.db.update_call(
@@ -894,6 +1015,7 @@ class CallService:
             ended_at=ended_at.isoformat(),
             duration_seconds=duration,
         )
+        self._tombstone_call_activity(call_id)
         await self.db.add_transcript_turn(
             call_id=call_id,
             turn_id=f"telephony_{secrets.token_urlsafe(10)}",
@@ -983,6 +1105,7 @@ class CallService:
         for task in list(self._background):
             task.cancel()
         await asyncio.gather(*self._background, return_exceptions=True)
+        await self._flush_call_activity()
         if self._owns_openai_client:
             await self.openai.close()
 
@@ -992,7 +1115,54 @@ class CallService:
             await self._watchdog_once()
 
     async def _watchdog_once(self) -> None:
-        cutoff = datetime.now(UTC) - timedelta(seconds=self.settings.watchdog_stale_seconds)
-        for call in await self.db.list_nonterminal_calls():
-            if datetime.fromisoformat(call["last_event_at"]) < cutoff:
-                await self.terminate_call(call["call_id"], "watchdog_stale")
+        await self._flush_call_activity()
+        now = LatencyMark.now()
+        cutoff = datetime.fromisoformat(now.occurred_at) - timedelta(
+            seconds=self.settings.watchdog_stale_seconds
+        )
+        stale_ns = self.settings.watchdog_stale_seconds * 1_000_000_000
+        calls = await self.db.list_nonterminal_calls()
+        for call in calls:
+            call_id = call["call_id"]
+            if self._call_activity_is_closed(call):
+                self._tombstone_call_activity(call_id)
+                continue
+            if datetime.fromisoformat(call["last_event_at"]) >= cutoff:
+                continue
+            activity_before = self._latest_call_activity.get(call_id)
+            if (
+                activity_before is not None
+                and now.monotonic_ns - activity_before.monotonic_ns <= stale_ns
+            ):
+                continue
+
+            # The initial list can go stale while another callback updates the call.
+            # Re-read both durable and in-memory liveness before claiming timeout.
+            current = await self.db.get_call(call_id)
+            if current is None:
+                self._clear_call_activity(call_id)
+                continue
+            if self._call_activity_is_closed(current):
+                self._tombstone_call_activity(call_id)
+                continue
+            if datetime.fromisoformat(current["last_event_at"]) >= cutoff:
+                continue
+            activity_after = self._latest_call_activity.get(call_id)
+            if activity_after is not None:
+                changed = (
+                    activity_before is None
+                    or activity_after.monotonic_ns > activity_before.monotonic_ns
+                )
+                fresh = now.monotonic_ns - activity_after.monotonic_ns <= stale_ns
+                if changed or fresh:
+                    continue
+
+            # No await is allowed between the final monotonic check and this claim.
+            # That makes all pre-claim activity win and all post-claim activity lose.
+            self._watchdog_claims.add(call_id)
+            terminated = False
+            try:
+                terminated = await self.terminate_call(call_id, "watchdog_stale")
+            finally:
+                if not terminated:
+                    self._watchdog_claims.discard(call_id)

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from openai import AsyncOpenAI
 
-from app.db import Database, DeploymentLockedError
+from app.db import Database, DeploymentLockedError, LatencyMark, LatencyStage
 from app.finalizer import Finalizer
 from app.models import (
     TERMINAL_STATES,
@@ -52,12 +52,14 @@ class CallService:
             on_event=self.handle_realtime_event,
             on_open=self.handle_sideband_open,
             on_fatal=self._handle_sideband_fatal,
+            on_send=self.handle_realtime_send,
         )
         self.finalizer = Finalizer(settings, db, self.openai)
         self._background: set[asyncio.Task[Any]] = set()
         self._owner_join_events: dict[str, asyncio.Event] = {}
         self._voice_end_pending: dict[str, tuple[str, str | None]] = {}
         self._active_response_ids: dict[str, str | None] = {}
+        self._queued_latency_events: dict[tuple[str, LatencyStage, str], LatencyMark] = {}
         self._watchdog_task: asyncio.Task[None] | None = None
 
     def _spawn(self, coroutine, *, name: str) -> asyncio.Task[Any]:
@@ -65,6 +67,49 @@ class CallService:
         self._background.add(task)
         task.add_done_callback(self._background.discard)
         return task
+
+    async def _record_latency(
+        self,
+        call_id: str,
+        *events: tuple[LatencyStage, LatencyMark, str],
+    ) -> None:
+        try:
+            await self.db.record_latency_events(call_id, events)
+        except Exception:
+            # Losing telemetry is preferable to changing the outcome of a live call.
+            logger.warning(
+                "failed to persist call latency event call_id=%s", call_id, exc_info=True
+            )
+
+    def _queue_latency_batch(
+        self,
+        call_id: str,
+        *events: tuple[LatencyStage, LatencyMark, str],
+    ) -> None:
+        pending: list[tuple[LatencyStage, LatencyMark, str]] = []
+        for stage, mark, event_key in events:
+            key = (call_id, stage, event_key)
+            previous = self._queued_latency_events.get(key)
+            if previous is not None and previous.monotonic_ns <= mark.monotonic_ns:
+                continue
+            self._queued_latency_events[key] = mark
+            pending.append((stage, mark, event_key))
+        if not pending:
+            return
+        self._spawn(
+            self._record_latency(call_id, *pending),
+            name=f"latency:{call_id}:{pending[0][0].value}",
+        )
+
+    def _queue_latency(
+        self,
+        call_id: str,
+        stage: LatencyStage,
+        mark: LatencyMark,
+        *,
+        event_key: str = "",
+    ) -> None:
+        self._queue_latency_batch(call_id, (stage, mark, event_key))
 
     @staticmethod
     def _confirmation_summary(packet: ContextPacket) -> str:
@@ -165,19 +210,35 @@ class CallService:
                     {"code": "plan_unavailable", "message": "Plan is expired or already started"}
                 )
             )
+        agent_request = LatencyMark.now()
         try:
             participant = await self.twilio.create_agent_participant(
                 call_id=call_id,
                 plan_id=plan_id,
                 conference_name=conference_name,
             )
+        except Exception:
+            self._queue_latency_batch(
+                call_id,
+                (LatencyStage.TWILIO_AGENT_REQUEST, agent_request, ""),
+            )
+            logger.exception("failed to originate agent leg")
+            await self.terminate_call(call_id, "agent_leg_setup_failed")
+            raise
+        agent_created = LatencyMark.now()
+        self._queue_latency_batch(
+            call_id,
+            (LatencyStage.TWILIO_AGENT_REQUEST, agent_request, ""),
+            (LatencyStage.TWILIO_AGENT_CREATED, agent_created, ""),
+        )
+        try:
             await self.db.update_call(
                 call_id,
                 twilio_ai_call_sid=participant.call_sid,
                 conference_sid=participant.conference_sid,
             )
         except Exception:
-            logger.exception("failed to originate agent leg")
+            logger.exception("failed to persist originated agent leg")
             await self.terminate_call(call_id, "agent_leg_setup_failed")
             raise
         self._spawn(self._setup_deadline(call_id), name=f"setup-deadline:{call_id}")
@@ -205,25 +266,53 @@ class CallService:
         await self.db.update_call(call_id, openai_call_id=openai_call_id)
         plan = await self.db.get_plan(call["plan_id"])
         packet = ContextPacket.model_validate(plan["context"])
+        accept_request = LatencyMark.now()
         try:
             accept_status = await self.realtime.accept_and_connect(
                 call_id=call_id,
                 openai_call_id=openai_call_id,
                 packet=packet,
             )
+        except Exception:
+            self._queue_latency_batch(
+                call_id,
+                (LatencyStage.OPENAI_ACCEPT_REQUEST, accept_request, ""),
+            )
+            logger.exception("failed to accept OpenAI call")
+            await self.terminate_call(call_id, "openai_accept_failed")
+            raise
+        accept_completed = LatencyMark.now()
+        self._queue_latency_batch(
+            call_id,
+            (LatencyStage.OPENAI_ACCEPT_REQUEST, accept_request, ""),
+            (LatencyStage.OPENAI_ACCEPT_COMPLETED, accept_completed, ""),
+        )
+        try:
             await self.db.update_call(call_id, openai_accept_status=accept_status)
         except Exception:
+            logger.exception("failed to persist OpenAI accept status")
             await self.terminate_call(call_id, "openai_accept_failed")
             raise
         return call_id
 
     async def handle_sideband_open(self, call_id: str) -> None:
+        sideband_open = LatencyMark.now()
         await self.db.set_flag_once(call_id, "sideband_open")
         try:
             updated = await self.realtime.verify_initial_session(call_id)
         except Exception:
+            self._queue_latency_batch(
+                call_id,
+                (LatencyStage.SIDEBAND_OPEN, sideband_open, ""),
+            )
             await self.terminate_call(call_id, "initial_session_update_timeout")
             return
+        initial_session_ack = LatencyMark.now()
+        self._queue_latency_batch(
+            call_id,
+            (LatencyStage.SIDEBAND_OPEN, sideband_open, ""),
+            (LatencyStage.INITIAL_SESSION_ACK, initial_session_ack, ""),
+        )
         transcription_ok = self.realtime.expected_transcription_echoed(updated)
         vad_ok = self.realtime.expected_initial_vad_echoed(updated)
         await self.db.update_call(
@@ -242,6 +331,7 @@ class CallService:
         ):
             plan = await self.db.get_plan(call["plan_id"])
             packet = ContextPacket.model_validate(plan["context"])
+            callee_request = LatencyMark.now()
             try:
                 participant = await self.twilio.create_callee_participant(
                     call_id=call_id,
@@ -249,12 +339,28 @@ class CallService:
                     conference_sid_or_name=call.get("conference_sid") or call["conference_name"],
                     packet=packet,
                 )
+            except Exception:
+                self._queue_latency_batch(
+                    call_id,
+                    (LatencyStage.TWILIO_CALLEE_REQUEST, callee_request, ""),
+                )
+                logger.exception("failed to originate callee leg")
+                await self.terminate_call(call_id, "callee_leg_setup_failed")
+                return
+            callee_created = LatencyMark.now()
+            self._queue_latency_batch(
+                call_id,
+                (LatencyStage.TWILIO_CALLEE_REQUEST, callee_request, ""),
+                (LatencyStage.TWILIO_CALLEE_CREATED, callee_created, ""),
+            )
+            try:
                 await self.db.update_call(
                     call_id,
                     twilio_callee_call_sid=participant.call_sid,
                     conference_sid=participant.conference_sid or call.get("conference_sid"),
                 )
             except Exception:
+                logger.exception("failed to persist originated callee leg")
                 await self.terminate_call(call_id, "callee_leg_setup_failed")
                 return
         await self._check_activation_gate(call_id)
@@ -278,6 +384,7 @@ class CallService:
         await self._check_activation_gate(call_id)
 
     async def handle_conference_event(self, call_id: str, form: dict[str, str]) -> None:
+        received = LatencyMark.now()
         event = (form.get("StatusCallbackEvent") or form.get("ConferenceStatus") or "").lower()
         label = (form.get("ParticipantLabel") or form.get("Label") or "").lower()
         call_sid = form.get("CallSid") or form.get("ParticipantCallSid")
@@ -293,11 +400,18 @@ class CallService:
             await self.db.touch_call(call_id)
         elif event in {"participant-join", "join"}:
             if label == "callee" or (call_sid and call_sid == call.get("twilio_callee_call_sid")):
-                await self.db.set_flag_once(call_id, "callee_joined")
-                if not call.get("answered_at"):
-                    await self.db.update_call(call_id, answered_at=datetime.now(UTC).isoformat())
-                await self._start_opening_on_answer(call_id)
-                await self._check_activation_gate(call_id)
+                answered = received
+                try:
+                    await self.db.set_flag_once(call_id, "callee_joined")
+                    if not call.get("answered_at"):
+                        await self.db.update_call(call_id, answered_at=answered.occurred_at)
+                    await self._start_opening_on_answer(call_id)
+                    await self._check_activation_gate(call_id)
+                finally:
+                    self._queue_latency_batch(
+                        call_id,
+                        (LatencyStage.CALLEE_ANSWERED, answered, ""),
+                    )
             elif label == "owner":
                 self._owner_join_events.setdefault(call_id, asyncio.Event()).set()
         elif event in {"participant-leave", "leave"}:
@@ -309,16 +423,24 @@ class CallService:
             await self.db.touch_call(call_id)
 
     async def handle_participant_status(self, call_id: str, leg: str, form: dict[str, str]) -> None:
+        received = LatencyMark.now()
         status = (form.get("CallStatus") or "").lower()
         await self.db.touch_call(call_id)
         if leg == "callee" and status in {"in-progress", "answered"}:
             # The callee's answered status callback usually reaches us before the
             # conference participant-join event; whichever arrives first starts the
             # opening turn so the callee hears the model sooner.
-            if await self.db.set_flag_once(call_id, "callee_joined"):
-                await self.db.update_call(call_id, answered_at=datetime.now(UTC).isoformat())
-            await self._start_opening_on_answer(call_id)
-            await self._check_activation_gate(call_id)
+            answered = received
+            try:
+                if await self.db.set_flag_once(call_id, "callee_joined"):
+                    await self.db.update_call(call_id, answered_at=answered.occurred_at)
+                await self._start_opening_on_answer(call_id)
+                await self._check_activation_gate(call_id)
+            finally:
+                self._queue_latency_batch(
+                    call_id,
+                    (LatencyStage.CALLEE_ANSWERED, answered, ""),
+                )
         elif leg == "callee" and status in {"completed", "failed", "busy", "no-answer", "canceled"}:
             duration = int(form.get("CallDuration") or 0)
             reason = "callee_call_completed" if status == "completed" else f"callee_{status}"
@@ -419,9 +541,19 @@ class CallService:
             await self._start_opening_on_answer(call_id)
 
     async def handle_realtime_event(self, call_id: str, event: dict[str, Any]) -> None:
+        received = LatencyMark.now()
         event_type = event.get("type", "")
         event_id = event.get("event_id") or f"evt_{secrets.token_urlsafe(12)}"
         await self.db.touch_call(call_id)
+        if event_type in {
+            "response.output_audio_transcript.delta",
+            "response.output_audio_transcript.done",
+            "response.audio_transcript.delta",
+            "response.audio_transcript.done",
+        }:
+            self._queue_latency(call_id, LatencyStage.FIRST_ASSISTANT_TRANSCRIPT, received)
+        elif event_type in {"response.output_audio.delta", "response.audio.delta"}:
+            self._queue_latency(call_id, LatencyStage.FIRST_OPENAI_AUDIO_DELTA, received)
         if event_type == "session.created":
             # Observational only. A SIP sideband attaches to an existing session and may
             # miss this startup event, so readiness is established by the explicit
@@ -450,7 +582,11 @@ class CallService:
                     source_event_id=event_id,
                 )
         elif event_type == "response.function_call_arguments.done":
-            await self.db.increment_tool_calls(call_id)
+            await self.db.increment_tool_calls(
+                call_id,
+                latency_mark=received,
+                event_key=str(event.get("call_id") or event_id),
+            )
             await self._handle_tool_call(call_id, event)
         elif event_type == "response.created":
             call = await self.db.get_call(call_id)
@@ -501,6 +637,21 @@ class CallService:
             self._spawn(
                 self.terminate_call(call_id, "openai_fatal_error"),
                 name=f"terminate:{call_id}:openai-error",
+            )
+
+    async def handle_realtime_send(self, call_id: str, event: dict[str, Any]) -> None:
+        sent = LatencyMark.now()
+        event_type = event.get("type")
+        if event_type == "response.create":
+            self._queue_latency(call_id, LatencyStage.FIRST_RESPONSE_CREATE, sent)
+            return
+        item = event.get("item") or {}
+        if event_type == "conversation.item.create" and item.get("type") == "function_call_output":
+            self._queue_latency(
+                call_id,
+                LatencyStage.TOOL_RESULT_SENT,
+                sent,
+                event_key=str(item.get("call_id") or "unknown"),
             )
 
     async def _handle_tool_call(self, call_id: str, event: dict[str, Any]) -> None:
@@ -739,6 +890,9 @@ class CallService:
             await self.finalizer.finalize(call_id)
         else:
             self._spawn(self.finalizer.finalize(call_id), name=f"finalize:{call_id}")
+        self._queued_latency_events = {
+            key: mark for key, mark in self._queued_latency_events.items() if key[0] != call_id
+        }
         return True
 
     async def get_snapshot(self, call_id: str) -> CallSnapshot:

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -109,6 +109,18 @@ class CallService:
         def finished(completed: asyncio.Task[Any]) -> None:
             self._background.discard(completed)
             self._must_finish_background.discard(completed)
+            if completed.cancelled():
+                return
+            # Some callers (e.g. owner transfer) attach their own logging callback too;
+            # a duplicate log line there is acceptable so every fire-and-forget failure
+            # is guaranteed to surface instead of only appearing as a GC-time warning.
+            error = completed.exception()
+            if error is not None:
+                logger.error(
+                    "background task failed name=%s",
+                    completed.get_name(),
+                    exc_info=(type(error), error, error.__traceback__),
+                )
 
         task.add_done_callback(finished)
         return task
@@ -874,6 +886,35 @@ class CallService:
                 event_key=str(item.get("call_id") or "unknown"),
             )
 
+    async def _guarded_send_tool_result(
+        self,
+        call_id: str,
+        tool_call_id: str,
+        output: dict[str, Any],
+        *,
+        continuation_instructions: str | None = None,
+    ) -> None:
+        """Swallow benign teardown races (e.g. "sideband is not open") so they cannot
+        escalate into a fatal error and redundant termination. CancelledError must still
+        propagate so the dispatcher stays cancellable."""
+
+        try:
+            await self.realtime.send_tool_result(
+                call_id,
+                tool_call_id,
+                output,
+                continuation_instructions=continuation_instructions,
+            )
+        except asyncio.CancelledError:
+            logger.warning("nontransfer tool output was cancelled call_id=%s", call_id)
+            raise
+        except Exception:
+            logger.warning(
+                "nontransfer tool output could not be delivered call_id=%s",
+                call_id,
+                exc_info=True,
+            )
+
     async def _send_nontransfer_tool_result(
         self,
         call_id: str,
@@ -900,8 +941,21 @@ class CallService:
         if advisory_outcome is not None:
             # accepted=true represents business data that must survive a crash. Do not
             # acknowledge a valid advisory until the fused transaction is durable.
-            await persistence
-            await self.realtime.send_tool_result(
+            try:
+                await persistence
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("advisory outcome persistence failed call_id=%s", call_id)
+                # The model must not be left hanging with no tool result at all; best-effort
+                # tell it the outcome was not recorded, then surface the durability failure.
+                await self._guarded_send_tool_result(
+                    call_id,
+                    tool_call_id,
+                    {"accepted": False, "error": "outcome could not be persisted"},
+                )
+                raise
+            await self._guarded_send_tool_result(
                 call_id,
                 tool_call_id,
                 output,
@@ -909,7 +963,7 @@ class CallService:
             )
             return
         try:
-            await self.realtime.send_tool_result(
+            await self._guarded_send_tool_result(
                 call_id,
                 tool_call_id,
                 output,
@@ -1195,6 +1249,14 @@ class CallService:
                             name=f"retry-compensation-conference:{call_id}:{attempt}",
                         )
                         await self._await_network_task(completion, propagate_cancellation=True)
+                        try:
+                            await self.db.set_conference_cleanup_pending(call_id, False)
+                        except Exception:
+                            logger.warning(
+                                "failed to clear conference cleanup pending flag call_id=%s",
+                                call_id,
+                                exc_info=True,
+                            )
                         return
                     terminalization = asyncio.create_task(
                         self._finish_claimed_termination(
@@ -1240,11 +1302,29 @@ class CallService:
         )
         try:
             await self._await_network_task(completion)
-            return True
         except Exception:
             logger.warning("failed to compensate conference call_id=%s", call_id, exc_info=True)
+            try:
+                # The in-process retry must still be scheduled even if this durable marker
+                # write fails; the marker only aids crash recovery, it does not gate the retry.
+                await self.db.set_conference_cleanup_pending(call_id, True)
+            except Exception:
+                logger.warning(
+                    "failed to persist conference cleanup pending flag call_id=%s",
+                    call_id,
+                    exc_info=True,
+                )
             self._schedule_conference_completion_retry(call, reason=None)
             return False
+        try:
+            await self.db.set_conference_cleanup_pending(call_id, False)
+        except Exception:
+            logger.warning(
+                "failed to clear conference cleanup pending flag call_id=%s",
+                call_id,
+                exc_info=True,
+            )
+        return True
 
     async def _owner_transfer_workflow(
         self,
@@ -2107,6 +2187,23 @@ class CallService:
                 logger.error("startup recovery scheduled teardown retry call_id=%s", call_id)
                 continue
             recovered.add(call_id)
+        # A crash between a failed compensation attempt and the in-process retry taking
+        # over would otherwise permanently orphan the Twilio conference: the call row is
+        # typically already terminal, so it is invisible to list_nonterminal_calls above.
+        for call in await self.db.list_conference_cleanup_pending():
+            call_id = call["call_id"]
+            if call_id in recovered:
+                continue
+            try:
+                # Twilio conference completion is idempotent (a 404 is treated as success
+                # in twilio_bridge), so a duplicate completion here is harmless.
+                await self._complete_conference_or_schedule(call)
+            except Exception:
+                logger.warning(
+                    "startup conference cleanup recovery failed call_id=%s",
+                    call_id,
+                    exc_info=True,
+                )
         # A crash can occur after telephony is terminal but before finalization committed.
         for call in await self.db.list_terminal_calls_needing_finalization():
             if call["call_id"] not in recovered:

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -34,6 +34,14 @@ logger = logging.getLogger(__name__)
 
 CALL_ACTIVITY_TOMBSTONE_TTL_SECONDS = 15 * 60
 CALL_ACTIVITY_TOMBSTONE_MAX = 4096
+OWNER_JOIN_TIMEOUT_SECONDS = 30
+TERMINATION_MEDIA_RETRY_DELAY_SECONDS = 0.1
+TERMINATION_MEDIA_BACKGROUND_RETRY_BASE_SECONDS = 0.5
+TERMINATION_MEDIA_BACKGROUND_RETRY_MAX_SECONDS = 15.0
+
+
+class OwnerTransferDeparted(RuntimeError):
+    """The owner leg became terminal before the AI handoff finished."""
 
 
 class CallService:
@@ -65,21 +73,91 @@ class CallService:
         )
         self.finalizer = Finalizer(settings, db, self.openai)
         self._background: set[asyncio.Task[Any]] = set()
+        self._must_finish_background: set[asyncio.Task[Any]] = set()
+        self._conference_retry_tasks: dict[tuple[str, str], asyncio.Task[Any]] = {}
+        self._stopping = False
         self._owner_join_events: dict[str, asyncio.Event] = {}
+        self._owner_departure_events: dict[str, asyncio.Event] = {}
+        self._owner_expected_sids: dict[str, str] = {}
+        self._owner_joined_sids: dict[str, str | None] = {}
+        self._owner_failures: dict[str, tuple[str | None, str]] = {}
+        self._owner_transfer_tasks: dict[str, asyncio.Task[dict[str, Any]]] = {}
+        self._owner_transfer_locks: dict[str, asyncio.Lock] = {}
         self._opening_transition_locks: dict[str, asyncio.Lock] = {}
         self._voice_end_pending: dict[str, tuple[str, str | None]] = {}
         self._active_response_ids: dict[str, str | None] = {}
+        self._tool_seen_calls: set[str] = set()
         self._queued_latency_events: dict[tuple[str, LatencyStage, str], LatencyMark] = {}
         self._watchdog_task: asyncio.Task[None] | None = None
 
-    def _spawn(self, coroutine, *, name: str) -> asyncio.Task[Any]:
+    def _spawn(self, coroutine, *, name: str, must_finish: bool = False) -> asyncio.Task[Any]:
+        if self._stopping and not must_finish:
+            # Reject new ordinary work once shutdown starts, but still register a
+            # no-op task so callers holding the returned Task cannot outlive the
+            # stable background drain.
+            coroutine.close()
+
+            async def skipped_during_shutdown() -> None:
+                return None
+
+            coroutine = skipped_during_shutdown()
         task = asyncio.create_task(coroutine, name=name)
         self._background.add(task)
-        task.add_done_callback(self._background.discard)
+        if must_finish:
+            self._must_finish_background.add(task)
+
+        def finished(completed: asyncio.Task[Any]) -> None:
+            self._background.discard(completed)
+            self._must_finish_background.discard(completed)
+
+        task.add_done_callback(finished)
         return task
 
     def _opening_transition_lock(self, call_id: str) -> asyncio.Lock:
         return self._opening_transition_locks.setdefault(call_id, asyncio.Lock())
+
+    def _owner_transfer_lock(self, call_id: str) -> asyncio.Lock:
+        return self._owner_transfer_locks.setdefault(call_id, asyncio.Lock())
+
+    def _owner_sid_matches(self, call_id: str, call_sid: str | None) -> bool:
+        expected = self._owner_expected_sids.get(call_id)
+        return expected is None or call_sid is None or call_sid == expected
+
+    def _record_owner_join(self, call_id: str, call_sid: str | None) -> None:
+        event = self._owner_join_events.get(call_id)
+        if event is None or not self._owner_sid_matches(call_id, call_sid):
+            return
+        self._owner_joined_sids[call_id] = call_sid
+        event.set()
+
+    def _record_owner_failure(self, call_id: str, call_sid: str | None, reason: str) -> None:
+        event = self._owner_join_events.get(call_id)
+        if event is None or not self._owner_sid_matches(call_id, call_sid):
+            return
+        self._owner_failures[call_id] = (call_sid, reason)
+        self._owner_departure_events.setdefault(call_id, asyncio.Event()).set()
+        event.set()
+
+    def _track_owner_transfer(self, call_id: str, task: asyncio.Task[dict[str, Any]]) -> None:
+        self._owner_transfer_tasks[call_id] = task
+
+        def finished(completed: asyncio.Task[dict[str, Any]]) -> None:
+            if self._owner_transfer_tasks.get(call_id) is completed:
+                self._owner_transfer_tasks.pop(call_id, None)
+            if completed.cancelled():
+                return
+            try:
+                error = completed.exception()
+            except asyncio.CancelledError:
+                return
+            if error is not None:
+                logger.error(
+                    "owner transfer task failed call_id=%s",
+                    call_id,
+                    exc_info=(type(error), error, error.__traceback__),
+                )
+
+        task.add_done_callback(finished)
 
     def _note_call_activity(self, call_id: str, mark: LatencyMark | None = None) -> bool:
         # A watchdog claim is the liveness linearization point. Activity observed
@@ -483,11 +561,16 @@ class CallService:
 
     async def handle_conference_event(self, call_id: str, form: dict[str, str]) -> None:
         received = LatencyMark.now()
-        if not self._note_call_activity(call_id, received):
-            return
         event = (form.get("StatusCallbackEvent") or form.get("ConferenceStatus") or "").lower()
         label = (form.get("ParticipantLabel") or form.get("Label") or "").lower()
         call_sid = form.get("CallSid") or form.get("ParticipantCallSid")
+        if label == "owner":
+            if event in {"participant-join", "join"}:
+                self._record_owner_join(call_id, call_sid)
+            elif event in {"participant-leave", "leave"}:
+                self._record_owner_failure(call_id, call_sid, "owner_left")
+        if not self._note_call_activity(call_id, received):
+            return
         call = await self.db.get_call(call_id)
         if call is None:
             self._clear_call_activity(call_id)
@@ -518,8 +601,6 @@ class CallService:
                         call_id,
                         (LatencyStage.CALLEE_ANSWERED, answered, ""),
                     )
-            elif label == "owner":
-                self._owner_join_events.setdefault(call_id, asyncio.Event()).set()
         elif event in {"participant-leave", "leave"}:
             if label == "callee" or (call_sid and call_sid == call.get("twilio_callee_call_sid")):
                 await self.terminate_call(call_id, "callee_participant_leave")
@@ -530,6 +611,16 @@ class CallService:
 
     async def handle_participant_status(self, call_id: str, leg: str, form: dict[str, str]) -> None:
         received = LatencyMark.now()
+        status = (form.get("CallStatus") or "").lower()
+        participant_sid = form.get("CallSid") or form.get("ParticipantCallSid")
+        if leg == "owner" and status in {
+            "completed",
+            "failed",
+            "busy",
+            "no-answer",
+            "canceled",
+        }:
+            self._record_owner_failure(call_id, participant_sid, f"owner_{status}")
         if not self._note_call_activity(call_id, received):
             return
         call = await self.db.get_call(call_id)
@@ -541,7 +632,6 @@ class CallService:
             return
         if not self._note_call_activity(call_id, received):
             return
-        status = (form.get("CallStatus") or "").lower()
         await self.db.touch_call(call_id)
         if leg == "callee" and status in {"in-progress", "answered"}:
             # The callee's answered status callback usually reaches us before the
@@ -711,16 +801,17 @@ class CallService:
                     source_event_id=event_id,
                 )
         elif event_type == "response.function_call_arguments.done":
-            await self.db.increment_tool_calls(
+            self._tool_seen_calls.add(call_id)
+            await self._handle_tool_call(
                 call_id,
-                latency_mark=received,
+                event,
+                received=received,
                 event_key=str(event.get("call_id") or event_id),
             )
-            await self._handle_tool_call(call_id, event)
         elif event_type == "response.created":
-            call = await self.db.get_call(call_id)
-            if call and call.get("tool_call_count", 0) > 0:
-                await self.db.update_call(call_id, tool_continuation_observed=1)
+            if call_id in self._tool_seen_calls:
+                self._tool_seen_calls.discard(call_id)
+                await self.db.mark_tool_continuation_observed(call_id)
             response = event.get("response") or {}
             response_id = response.get("id") or event.get("response_id")
             self._active_response_ids[call_id] = response_id
@@ -783,67 +874,142 @@ class CallService:
                 event_key=str(item.get("call_id") or "unknown"),
             )
 
-    async def _handle_tool_call(self, call_id: str, event: dict[str, Any]) -> None:
+    async def _send_nontransfer_tool_result(
+        self,
+        call_id: str,
+        tool_call_id: str,
+        output: dict[str, Any],
+        *,
+        received: LatencyMark,
+        event_key: str,
+        advisory_outcome: dict[str, Any] | None = None,
+        continuation_instructions: str | None = None,
+    ) -> None:
+        # Begin the one durable tool write before yielding to the WebSocket, but do not
+        # put SQLite on the response path. Await it before returning so the FIFO dispatcher
+        # cannot process response.created before tool_call_count is committed.
+        persistence = asyncio.create_task(
+            self.db.record_tool_call(
+                call_id,
+                latency_mark=received,
+                event_key=event_key,
+                advisory_outcome=advisory_outcome,
+            ),
+            name=f"persist-tool:{call_id}:{event_key}",
+        )
+        if advisory_outcome is not None:
+            # accepted=true represents business data that must survive a crash. Do not
+            # acknowledge a valid advisory until the fused transaction is durable.
+            await persistence
+            await self.realtime.send_tool_result(
+                call_id,
+                tool_call_id,
+                output,
+                continuation_instructions=continuation_instructions,
+            )
+            return
+        try:
+            await self.realtime.send_tool_result(
+                call_id,
+                tool_call_id,
+                output,
+                continuation_instructions=continuation_instructions,
+            )
+        finally:
+            await persistence
+
+    async def _handle_tool_call(
+        self,
+        call_id: str,
+        event: dict[str, Any],
+        *,
+        received: LatencyMark | None = None,
+        event_key: str | None = None,
+    ) -> None:
         name = event.get("name")
-        tool_call_id = event.get("call_id")
+        tool_call_id = str(event.get("call_id") or "unknown")
+        received = received or LatencyMark.now()
+        event_key = event_key or tool_call_id
         try:
             arguments = json.loads(event.get("arguments") or "{}")
         except json.JSONDecodeError:
             arguments = {}
         if name == "record_call_outcome":
+            advisory_outcome: dict[str, Any] | None = None
             try:
                 advisory = AdvisoryOutcome.model_validate(arguments)
-                await self.db.update_call(
-                    call_id, advisory_outcome_json=advisory.model_dump(mode="json", by_alias=True)
-                )
+                advisory_outcome = advisory.model_dump(mode="json", by_alias=True)
                 output = {"accepted": True}
             except Exception as exc:
                 output = {"accepted": False, "error": str(exc)}
-            await self.realtime.send_tool_result(call_id, tool_call_id, output)
+            await self._send_nontransfer_tool_result(
+                call_id,
+                tool_call_id,
+                output,
+                received=received,
+                event_key=event_key,
+                advisory_outcome=advisory_outcome,
+            )
         elif name == "end_call":
             try:
                 request = VoiceEndCallRequest.model_validate(arguments)
             except Exception as exc:
-                await self.realtime.send_tool_result(
+                await self._send_nontransfer_tool_result(
                     call_id,
                     tool_call_id,
                     {"accepted": False, "error": str(exc)},
+                    received=received,
+                    event_key=event_key,
                 )
                 return
             pending = (tool_call_id, None)
             self._voice_end_pending[call_id] = pending
-            await self.realtime.send_tool_result(
+            # Arm teardown before either the WebSocket send or post-send bookkeeping
+            # can fail. Otherwise a durable-write failure could skip the only fallback.
+            self._spawn(
+                self._voice_end_fallback(call_id, tool_call_id),
+                name=f"voice-end-fallback:{call_id}",
+            )
+            await self._send_nontransfer_tool_result(
                 call_id,
                 tool_call_id,
                 {"accepted": True, "reason": request.reason},
+                received=received,
+                event_key=event_key,
                 continuation_instructions=(
                     "The call is now ending. Briefly confirm the outcome or next step if useful, "
                     "then say one concise, natural goodbye. Do not call any function."
                 ),
             )
-            self._spawn(
-                self._voice_end_fallback(call_id, tool_call_id),
-                name=f"voice-end-fallback:{call_id}",
-            )
         elif name == "transfer_to_owner":
-            reason = arguments.get("reason", "requested")
-            output, owner_call_sid = await self._join_owner(call_id)
-            if not output.get("accepted"):
-                await self.realtime.send_tool_result(call_id, tool_call_id, output)
-                return
+            reason = str(arguments.get("reason") or "requested")
+            persistence = asyncio.create_task(
+                self.db.record_tool_call(
+                    call_id,
+                    latency_mark=received,
+                    event_key=event_key,
+                ),
+                name=f"persist-tool:{call_id}:{event_key}",
+            )
             try:
-                # Return the function output while the AI sideband is still connected.
-                await self.realtime.send_tool_result(call_id, tool_call_id, output)
-            except Exception:
-                logger.warning("transfer tool output could not be delivered", exc_info=True)
-            if await self._finish_owner_transfer(call_id, reason, owner_call_sid):
-                self._spawn(
-                    self.terminate_call(call_id, "transfer_completed", preserve_conference=True),
-                    name=f"terminate:{call_id}:transfer",
+                transfer_task, error = await self._start_owner_transfer(
+                    call_id, reason, tool_call_id=tool_call_id
                 )
+                if transfer_task is None:
+                    await self.realtime.send_tool_result(
+                        call_id,
+                        tool_call_id,
+                        {"accepted": False, "error": error},
+                    )
+            finally:
+                await persistence
         else:
-            await self.realtime.send_tool_result(
-                call_id, tool_call_id, {"accepted": False, "error": "unknown tool"}
+            await self._send_nontransfer_tool_result(
+                call_id,
+                tool_call_id,
+                {"accepted": False, "error": "unknown tool"},
+                received=received,
+                event_key=event_key,
             )
 
     async def _handle_voice_end_response_done(self, call_id: str, event: dict[str, Any]) -> None:
@@ -880,72 +1046,666 @@ class CallService:
     async def transfer_to_owner(
         self, call_id: str, reason: str, *, terminate_after: bool = True
     ) -> dict[str, Any]:
-        output, owner_call_sid = await self._join_owner(call_id)
-        if not output.get("accepted"):
-            return output
-        if not await self._finish_owner_transfer(call_id, reason, owner_call_sid):
-            return {"accepted": False, "error": "AI participant could not be removed"}
-        if terminate_after:
-            self._spawn(
-                self.terminate_call(call_id, "transfer_completed", preserve_conference=True),
-                name=f"terminate:{call_id}:transfer",
-            )
-        return {"accepted": True, "status": "transferred"}
+        # A successful handoff is always terminal. Keep the legacy keyword for callers
+        # but do not allow a claimed transfer to strand the call in TERMINATING.
+        del terminate_after
+        task, error = await self._start_owner_transfer(call_id, reason, tool_call_id=None)
+        if task is None:
+            return {"accepted": False, "error": error}
+        return await asyncio.shield(task)
 
-    async def _join_owner(self, call_id: str) -> tuple[dict[str, Any], str | None]:
+    async def _start_owner_transfer(
+        self,
+        call_id: str,
+        reason: str,
+        *,
+        tool_call_id: str | None,
+    ) -> tuple[asyncio.Task[dict[str, Any]] | None, str | None]:
+        if self._stopping:
+            return None, "service is stopping"
         call = await self.db.get_call(call_id)
         if call is None:
-            return {"accepted": False, "error": "call not found"}, None
+            return None, "call not found"
         plan = await self.db.get_plan(call["plan_id"])
         if plan is None:
-            return {"accepted": False, "error": "call plan not found"}, None
+            return None, "call plan not found"
         packet = ContextPacket.model_validate(plan["context"])
         if packet.escalation.mode != "transfer_to_owner":
-            return {"accepted": False, "error": "owner transfer is not authorized"}, None
-        event = self._owner_join_events.setdefault(call_id, asyncio.Event())
-        owner_call_sid: str | None = None
-        try:
-            participant = await self.twilio.create_owner_participant(
-                call_id=call_id,
-                plan_id=call["plan_id"],
-                conference_sid_or_name=call.get("conference_sid") or call["conference_name"],
-                owner_phone=packet.escalation.owner_phone,
-            )
-            owner_call_sid = participant.call_sid
-            await asyncio.wait_for(event.wait(), timeout=30)
-            return {"accepted": True, "status": "owner_joined"}, owner_call_sid
-        except Exception as exc:
-            if owner_call_sid:
+            return None, "owner transfer is not authorized"
+
+        async def claim_and_spawn() -> tuple[asyncio.Task[dict[str, Any]] | None, str | None]:
+            async with self._owner_transfer_lock(call_id):
+                if call_id in self._owner_transfer_tasks:
+                    return None, "owner transfer already in progress"
+                if self._stopping:
+                    return None, "service is stopping"
+                joining = f"joining:{reason}"
+                claim_error: Exception | None = None
                 try:
-                    await self.twilio.remove_participant(
-                        call.get("conference_sid") or call["conference_name"], owner_call_sid
+                    claimed = await self.db.claim_transfer_joining(call_id, reason)
+                except Exception as exc:
+                    claimed = False
+                    claim_error = exc
+                claimed_call = call
+                if not claimed:
+                    current = await self.db.get_call(call_id)
+                    exact_joining = bool(
+                        current
+                        and current.get("state") == CallState.ACTIVE.value
+                        and not current.get("termination_claimed")
+                        and current.get("transfer_outcome") == joining
+                    )
+                    if not exact_joining:
+                        if claim_error is not None:
+                            raise claim_error
+                        return None, "owner transfer already attempted or call is ending"
+                    claimed_call = current
+                    logger.warning("reconciled ambiguous owner transfer claim call_id=%s", call_id)
+                if self._stopping:
+                    await self.db.fail_joining_transfer(call_id, joining, "failed:service_stopping")
+                    return None, "service is stopping"
+                # Install callback-visible state before dialing can emit owner status.
+                self._owner_join_events.setdefault(call_id, asyncio.Event())
+                self._owner_departure_events.setdefault(call_id, asyncio.Event())
+                task = self._spawn(
+                    self._owner_transfer_workflow(
+                        claimed_call,
+                        packet,
+                        reason,
+                        tool_call_id=tool_call_id,
+                    ),
+                    name=f"owner-transfer:{call_id}",
+                )
+                self._track_owner_transfer(call_id, task)
+                return task, None
+
+        # Cancellation after SQLite commits but before this caller observes the result
+        # must not leave durable joining without a registered cleanup workflow.
+        claim = self._spawn(
+            claim_and_spawn(),
+            name=f"claim-owner-transfer:{call_id}",
+            must_finish=True,
+        )
+        return await self._await_network_task(claim)
+
+    @staticmethod
+    async def _await_network_task(
+        task: asyncio.Task[Any], *, propagate_cancellation: bool = False
+    ) -> Any:
+        """Let a to_thread-backed operation settle despite caller cancellation."""
+
+        interrupted = False
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                # Twilio's synchronous request is still running in its worker thread.
+                # Its configured HTTP timeout bounds this wait; abandoning the result
+                # could lose the participant SID needed for cleanup.
+                interrupted = True
+                continue
+        try:
+            result = task.result()
+        except BaseException:
+            if interrupted and propagate_cancellation:
+                raise asyncio.CancelledError from None
+            raise
+        if interrupted and propagate_cancellation:
+            raise asyncio.CancelledError
+        return result
+
+    def _schedule_conference_completion_retry(
+        self,
+        call: dict[str, Any],
+        *,
+        reason: str | None,
+        expected_transfer_outcome: str | None = None,
+        await_finalizer: bool = False,
+    ) -> None:
+        """Retry required conference teardown without blocking callers or startup."""
+
+        if self._stopping:
+            return
+        call_id = call["call_id"]
+        mode = f"termination:{reason}" if reason is not None else "compensation"
+        key = (call_id, mode)
+        existing = self._conference_retry_tasks.get(key)
+        if existing is not None and not existing.done():
+            return
+
+        async def retry() -> None:
+            attempt = 0
+            while True:
+                delay = min(
+                    TERMINATION_MEDIA_BACKGROUND_RETRY_BASE_SECONDS * (2 ** min(attempt, 10)),
+                    TERMINATION_MEDIA_BACKGROUND_RETRY_MAX_SECONDS,
+                )
+                await asyncio.sleep(delay)
+                attempt += 1
+                try:
+                    if reason is not None:
+                        current = await self.db.get_call(call_id)
+                        if current is None or CallState(current["state"]) in TERMINAL_STATES:
+                            return
+                    if reason is None:
+                        completion = asyncio.create_task(
+                            self.twilio.complete_conference(
+                                call.get("conference_sid") or call.get("conference_name")
+                            ),
+                            name=f"retry-compensation-conference:{call_id}:{attempt}",
+                        )
+                        await self._await_network_task(completion, propagate_cancellation=True)
+                        return
+                    terminalization = asyncio.create_task(
+                        self._finish_claimed_termination(
+                            call,
+                            reason,
+                            preserve_conference=False,
+                            await_finalizer=await_finalizer,
+                            expected_transfer_outcome=expected_transfer_outcome,
+                            schedule_conference_retry=False,
+                        ),
+                        name=f"retry-terminalize:{call_id}:{attempt}",
+                    )
+                    if await self._await_network_task(terminalization, propagate_cancellation=True):
+                        return
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.warning(
+                        "conference completion background retry failed call_id=%s attempt=%s",
+                        call_id,
+                        attempt,
+                        exc_info=True,
+                    )
+
+        task = self._spawn(retry(), name=f"conference-retry:{call_id}:{mode}")
+        self._conference_retry_tasks[key] = task
+
+        def clear(completed: asyncio.Task[Any]) -> None:
+            if self._conference_retry_tasks.get(key) is completed:
+                self._conference_retry_tasks.pop(key, None)
+
+        task.add_done_callback(clear)
+
+    async def _complete_conference_or_schedule(self, call: dict[str, Any]) -> bool:
+        """Fail closed now, retaining bounded in-process ownership on failure."""
+
+        call_id = call["call_id"]
+        completion = asyncio.create_task(
+            self.twilio.complete_conference(
+                call.get("conference_sid") or call.get("conference_name")
+            ),
+            name=f"compensate-conference:{call_id}",
+        )
+        try:
+            await self._await_network_task(completion)
+            return True
+        except Exception:
+            logger.warning("failed to compensate conference call_id=%s", call_id, exc_info=True)
+            self._schedule_conference_completion_retry(call, reason=None)
+            return False
+
+    async def _owner_transfer_workflow(
+        self,
+        call: dict[str, Any],
+        packet: ContextPacket,
+        reason: str,
+        *,
+        tool_call_id: str | None,
+    ) -> dict[str, Any]:
+        call_id = call["call_id"]
+        joining = f"joining:{reason}"
+        in_progress = f"in_progress:{reason}"
+        conference = call.get("conference_sid") or call["conference_name"]
+        event = self._owner_join_events.setdefault(call_id, asyncio.Event())
+        departure_event = self._owner_departure_events.setdefault(call_id, asyncio.Event())
+        owner_call_sid: str | None = None
+        owner_cleanup_started = False
+        create_task: asyncio.Task[Any] | None = None
+        promoted: dict[str, Any] | None = None
+        phase = "joining"
+        completed_outcome: str | None = None
+        workflow_task = asyncio.current_task()
+
+        async def cleanup_owner() -> bool:
+            nonlocal owner_cleanup_started
+            if owner_call_sid is None:
+                return True
+            if owner_cleanup_started:
+                return False
+            owner_cleanup_started = True
+            cleanup = asyncio.create_task(
+                self.twilio.remove_participant(conference, owner_call_sid),
+                name=f"remove-owner:{call_id}",
+            )
+            try:
+                await self._await_network_task(cleanup)
+                return True
+            except Exception:
+                # The primary transfer/termination outcome must survive cleanup failure.
+                # Full conference teardown is the remaining compensation path.
+                logger.warning(
+                    "failed to clean up owner transfer leg call_id=%s", call_id, exc_info=True
+                )
+                return False
+
+        async def complete_conference_compensation() -> bool:
+            return await self._complete_conference_or_schedule(call)
+
+        def owner_failure_reason() -> str | None:
+            failure = self._owner_failures.get(call_id)
+            if failure is None:
+                return None
+            failure_sid, failure_reason = failure
+            if owner_call_sid and failure_sid and failure_sid != owner_call_sid:
+                return None
+            return failure_reason
+
+        async def _fail_joining_and_compensate(failure: str, cleaned: bool) -> None:
+            transitioned: bool | None
+            promoted_transition: bool | None = False
+            try:
+                transitioned = await self.db.fail_joining_transfer(call_id, joining, failure)
+            except Exception:
+                transitioned = None
+                logger.warning(
+                    "joining transfer failure could not be persisted call_id=%s",
+                    call_id,
+                    exc_info=True,
+                )
+            if transitioned is not True:
+                # The promotion UPDATE may have committed even if awaiting it raised.
+                # Probe the exact in-progress value with a guarded CAS; this adopts
+                # teardown ownership without a fresh read or a false transferred result.
+                suffix = failure.removeprefix("failed:") or "owner_transfer"
+                failure_reason = f"transfer_failed:{suffix}"
+                try:
+                    promoted_transition = await self.db.fail_promoted_transfer(
+                        call_id,
+                        in_progress,
+                        failure,
+                        failure_reason,
                     )
                 except Exception:
-                    logger.warning("failed to clean up owner transfer leg", exc_info=True)
-            await self.db.update_call(call_id, transfer_outcome=f"failed:{type(exc).__name__}")
-            return {"accepted": False, "error": "owner did not join"}, None
-
-    async def _finish_owner_transfer(
-        self, call_id: str, reason: str, owner_call_sid: str | None
-    ) -> bool:
-        call = await self.db.get_call(call_id)
-        if call is None:
-            return False
-        conference = call.get("conference_sid") or call["conference_name"]
-        try:
-            # Persist this before AI removal because Twilio/OpenAI terminal callbacks may race it.
-            await self.db.update_call(call_id, transfer_outcome=f"in_progress:{reason}")
-            await self.twilio.remove_participant(conference, call.get("twilio_ai_call_sid"))
-            await self.db.update_call(call_id, transfer_outcome=f"completed:{reason}")
-            return True
-        except Exception as exc:
-            if owner_call_sid:
+                    promoted_transition = None
+                    logger.warning(
+                        "ambiguous transfer promotion could not be adopted call_id=%s",
+                        call_id,
+                        exc_info=True,
+                    )
+                if promoted_transition is True:
+                    try:
+                        finished = await self._finish_claimed_termination(
+                            call,
+                            failure_reason,
+                            preserve_conference=False,
+                            await_finalizer=False,
+                            expected_transfer_outcome=failure,
+                        )
+                    except Exception:
+                        finished = False
+                        logger.warning(
+                            "adopted transfer termination failed call_id=%s",
+                            call_id,
+                            exc_info=True,
+                        )
+                    if finished:
+                        return
+                    await complete_conference_compensation()
+                    return
+                if promoted_transition is None:
+                    await complete_conference_compensation()
+                    return
+            if not cleaned and transitioned is True:
                 try:
-                    await self.twilio.remove_participant(conference, owner_call_sid)
+                    terminated = await self.terminate_call(
+                        call_id,
+                        "transfer_cleanup_failed",
+                        _initiating_task=workflow_task,
+                    )
                 except Exception:
-                    logger.warning("failed to roll back owner transfer leg", exc_info=True)
-            await self.db.update_call(call_id, transfer_outcome=f"failed:{type(exc).__name__}")
-            return False
+                    terminated = False
+                    logger.warning(
+                        "owner cleanup termination failed call_id=%s",
+                        call_id,
+                        exc_info=True,
+                    )
+                if not terminated:
+                    await complete_conference_compensation()
+            elif owner_call_sid is not None and (transitioned is None or not cleaned):
+                # SQLite state is ambiguous. Conference completion is the only
+                # DB-independent guarantee that the owner leg cannot keep billing.
+                await complete_conference_compensation()
+
+        async def fail_joining_and_compensate(failure: str, cleaned: bool) -> None:
+            compensation = self._spawn(
+                _fail_joining_and_compensate(failure, cleaned),
+                name=f"compensate-joining-transfer:{call_id}",
+                must_finish=True,
+            )
+            await self._await_network_task(compensation)
+
+        async def _fail_promoted_and_compensate(
+            expected: str, failure: str, failure_reason: str
+        ) -> None:
+            transitioned: bool | None
+            try:
+                transitioned = await self.db.fail_promoted_transfer(
+                    call_id,
+                    expected,
+                    failure,
+                    failure_reason,
+                )
+            except Exception:
+                transitioned = None
+                logger.warning(
+                    "promoted transfer failure could not be persisted call_id=%s",
+                    call_id,
+                    exc_info=True,
+                )
+            # Completing the promoted transfer can also commit before its await raises.
+            # If in-progress no longer matches, adopt the exact completed value before
+            # resorting to DB-independent conference compensation.
+            if (
+                transitioned is not True
+                and expected == in_progress
+                and completed_outcome is not None
+            ):
+                try:
+                    transitioned = await self.db.fail_promoted_transfer(
+                        call_id,
+                        completed_outcome,
+                        failure,
+                        failure_reason,
+                    )
+                except Exception:
+                    transitioned = None
+                    logger.warning(
+                        "ambiguous transfer completion could not be adopted call_id=%s",
+                        call_id,
+                        exc_info=True,
+                    )
+            if transitioned is True:
+                try:
+                    finished = await self._finish_claimed_termination(
+                        promoted or call,
+                        failure_reason,
+                        preserve_conference=False,
+                        await_finalizer=False,
+                        expected_transfer_outcome=failure,
+                    )
+                except Exception:
+                    finished = False
+                    logger.warning(
+                        "promoted transfer termination failed call_id=%s",
+                        call_id,
+                        exc_info=True,
+                    )
+                if finished:
+                    return
+            # A lost/ambiguous CAS must never be interpreted as a successful handoff.
+            # Complete the conference without relying on another database read.
+            await complete_conference_compensation()
+
+        async def fail_promoted_and_compensate(
+            expected: str, failure: str, failure_reason: str
+        ) -> None:
+            compensation = self._spawn(
+                _fail_promoted_and_compensate(expected, failure, failure_reason),
+                name=f"compensate-promoted-transfer:{call_id}",
+                must_finish=True,
+            )
+            await self._await_network_task(compensation)
+
+        async def send_failure(error: str) -> None:
+            if tool_call_id is None:
+                return
+            try:
+                await self.realtime.send_tool_result(
+                    call_id,
+                    tool_call_id,
+                    {"accepted": False, "error": error},
+                )
+            except asyncio.CancelledError:
+                logger.warning("transfer failure output was cancelled call_id=%s", call_id)
+            except Exception:
+                logger.warning(
+                    "transfer failure output could not be delivered call_id=%s",
+                    call_id,
+                    exc_info=True,
+                )
+
+        def reconcile_owner_callbacks() -> None:
+            """Drop pre-create callbacks that belong to a different owner leg."""
+
+            event_was_set = event.is_set()
+            had_join = call_id in self._owner_joined_sids
+            had_failure = call_id in self._owner_failures
+            joined_sid = self._owner_joined_sids.get(call_id)
+            failure = self._owner_failures.get(call_id)
+            if had_join and joined_sid is not None and joined_sid != owner_call_sid:
+                self._owner_joined_sids.pop(call_id, None)
+                had_join = False
+            if (
+                had_failure
+                and failure is not None
+                and failure[0] is not None
+                and failure[0] != owner_call_sid
+            ):
+                self._owner_failures.pop(call_id, None)
+                had_failure = False
+
+            event.clear()
+            departure_event.clear()
+            # Tests and legacy callback senders may signal a join without a SID.
+            if had_join or had_failure or (event_was_set and not (had_join or had_failure)):
+                event.set()
+            if had_failure:
+                departure_event.set()
+
+        def raise_if_owner_departed() -> None:
+            failure = owner_failure_reason()
+            if failure is not None or departure_event.is_set():
+                raise OwnerTransferDeparted(failure or "owner_departed")
+
+        try:
+            create_task = asyncio.create_task(
+                self.twilio.create_owner_participant(
+                    call_id=call_id,
+                    plan_id=call["plan_id"],
+                    conference_sid_or_name=conference,
+                    owner_phone=packet.escalation.owner_phone,
+                ),
+                name=f"create-owner:{call_id}",
+            )
+            participant = await asyncio.shield(create_task)
+            owner_call_sid = participant.call_sid
+            self._owner_expected_sids[call_id] = owner_call_sid
+            reconcile_owner_callbacks()
+            owner_sid_error: Exception | None = None
+            try:
+                owner_sid_persisted = await self.db.record_transfer_owner_sid(
+                    call_id, joining, owner_call_sid
+                )
+            except Exception as exc:
+                owner_sid_persisted = False
+                owner_sid_error = exc
+            if not owner_sid_persisted:
+                current = await self.db.get_call(call_id)
+                exact_owner_sid = bool(
+                    current
+                    and current.get("state") == CallState.ACTIVE.value
+                    and not current.get("termination_claimed")
+                    and current.get("transfer_outcome") == joining
+                    and current.get("twilio_owner_call_sid") == owner_call_sid
+                )
+                if not exact_owner_sid:
+                    if owner_sid_error is not None:
+                        raise owner_sid_error
+                    raise RuntimeError("owner transfer SID could not be persisted")
+                logger.warning("reconciled ambiguous owner SID persistence call_id=%s", call_id)
+            call["twilio_owner_call_sid"] = owner_call_sid
+            await asyncio.wait_for(event.wait(), timeout=OWNER_JOIN_TIMEOUT_SECONDS)
+            raise_if_owner_departed()
+            promoted = await self.db.promote_transfer(call_id, reason)
+            if promoted is None:
+                cleaned = await cleanup_owner()
+                await fail_joining_and_compensate("failed:termination_won", cleaned)
+                await send_failure("call ended before owner transfer completed")
+                return {"accepted": False, "error": "call ended during owner transfer"}
+            phase = "promoted"
+            raise_if_owner_departed()
+
+            if tool_call_id is not None:
+                try:
+                    # A successful tool output must be observable before the AI leg disappears.
+                    await self.realtime.send_tool_result(
+                        call_id,
+                        tool_call_id,
+                        {"accepted": True, "status": "owner_joined"},
+                    )
+                except asyncio.CancelledError:
+                    logger.warning("transfer tool output was cancelled call_id=%s", call_id)
+                except Exception:
+                    logger.warning(
+                        "transfer tool output could not be delivered call_id=%s",
+                        call_id,
+                        exc_info=True,
+                    )
+            raise_if_owner_departed()
+
+            remove_ai = asyncio.create_task(
+                self.twilio.remove_participant(conference, call.get("twilio_ai_call_sid")),
+                name=f"remove-ai:{call_id}",
+            )
+            departure_wait = asyncio.create_task(
+                departure_event.wait(), name=f"wait-owner-departure:{call_id}"
+            )
+            try:
+                done, _ = await asyncio.wait(
+                    {remove_ai, departure_wait}, return_when=asyncio.FIRST_COMPLETED
+                )
+                if departure_wait in done:
+                    try:
+                        await self._await_network_task(remove_ai)
+                    except Exception:
+                        logger.warning(
+                            "AI removal also failed after owner departure call_id=%s",
+                            call_id,
+                            exc_info=True,
+                        )
+                    raise_if_owner_departed()
+                remove_ai.result()
+            except asyncio.CancelledError:
+                try:
+                    await self._await_network_task(remove_ai)
+                except Exception:
+                    logger.warning(
+                        "AI removal failed while transfer was cancelled call_id=%s",
+                        call_id,
+                        exc_info=True,
+                    )
+                raise
+            finally:
+                departure_wait.cancel()
+                await asyncio.gather(departure_wait, return_exceptions=True)
+            raise_if_owner_departed()
+
+            completed_outcome = f"completed:{reason}"
+            if not await self.db.complete_promoted_transfer(
+                call_id, in_progress, completed_outcome
+            ):
+                raise RuntimeError("owner transfer completion state was lost")
+            phase = "completed"
+            raise_if_owner_departed()
+            # The owner becomes responsible for conference lifetime only after the
+            # handoff outcome is durably completed. If arming this fails, compensate
+            # the transfer rather than leave the callee alone and billing later.
+            arm_owner_exit = asyncio.create_task(
+                self.twilio.enable_end_conference_on_exit(conference, owner_call_sid),
+                name=f"arm-owner-conference-exit:{call_id}",
+            )
+            await self._await_network_task(arm_owner_exit)
+            raise_if_owner_departed()
+            terminalization = self._spawn(
+                self._finish_claimed_termination(
+                    promoted,
+                    "transfer_completed",
+                    preserve_conference=True,
+                    await_finalizer=False,
+                    expected_transfer_outcome=completed_outcome,
+                ),
+                name=f"terminalize-owner-transfer:{call_id}",
+                must_finish=True,
+            )
+            terminalized = await self._await_network_task(terminalization)
+            if not terminalized:
+                cleaned = await cleanup_owner()
+                await fail_promoted_and_compensate(
+                    completed_outcome,
+                    "failed:terminal_cas",
+                    "transfer_failed:terminal_cas",
+                )
+                if not cleaned:
+                    await complete_conference_compensation()
+                return {"accepted": False, "error": "transfer teardown requires retry"}
+            phase = "terminal"
+            return {"accepted": True, "status": "transferred"}
+        except TimeoutError:
+            cleaned = await cleanup_owner()
+            await fail_joining_and_compensate("failed:owner_join_timeout", cleaned)
+            await send_failure("owner did not join")
+            return {"accepted": False, "error": "owner did not join"}
+        except asyncio.CancelledError:
+            # If creation completed in its worker thread after cancellation, recover
+            # its SID before returning so the remote owner leg cannot leak.
+            if owner_call_sid is None and create_task is not None:
+                try:
+                    participant = await self._await_network_task(create_task)
+                    owner_call_sid = participant.call_sid
+                except Exception:
+                    pass
+            cleaned = await cleanup_owner()
+            if phase == "promoted":
+                failure_reason = "transfer_failed:CancelledError"
+                failure = "failed:CancelledError"
+                await fail_promoted_and_compensate(
+                    in_progress,
+                    failure,
+                    failure_reason,
+                )
+            elif phase == "completed" and completed_outcome is not None:
+                await fail_promoted_and_compensate(
+                    completed_outcome,
+                    "failed:CancelledError",
+                    "transfer_failed:CancelledError",
+                )
+            elif phase != "terminal":
+                await fail_joining_and_compensate("failed:CancelledError", cleaned)
+            return {"accepted": False, "error": "owner transfer cancelled"}
+        except Exception as exc:
+            logger.exception("owner transfer failed call_id=%s", call_id)
+            cleaned = await cleanup_owner()
+            error_type = type(exc).__name__
+            failure_reason = f"transfer_failed:{error_type}"
+            failure = f"failed:{error_type}"
+            if phase == "promoted":
+                await fail_promoted_and_compensate(
+                    in_progress,
+                    failure,
+                    failure_reason,
+                )
+            elif phase == "completed" and completed_outcome is not None:
+                await fail_promoted_and_compensate(
+                    completed_outcome,
+                    failure,
+                    failure_reason,
+                )
+            elif phase != "terminal":
+                await fail_joining_and_compensate(failure, cleaned)
+                await send_failure("owner transfer failed")
+            return {"accepted": False, "error": "owner transfer failed"}
 
     async def terminate_call(
         self,
@@ -954,28 +1714,108 @@ class CallService:
         *,
         preserve_conference: bool = False,
         await_finalizer: bool = False,
+        _initiating_task: asyncio.Task[Any] | None = None,
     ) -> bool:
-        call = await self.db.get_call(call_id)
+        if self._stopping and _initiating_task is None:
+            return False
+        initiating_task = _initiating_task or asyncio.current_task()
+        continuation = self._spawn(
+            self._claim_and_finish_termination(
+                call_id,
+                reason,
+                preserve_conference=preserve_conference,
+                await_finalizer=await_finalizer,
+                initiating_task=initiating_task,
+            ),
+            name=f"claimed-termination:{call_id}",
+            must_finish=True,
+        )
+        # Once a termination claim may commit, caller cancellation must not strand
+        # billing/media teardown behind an unreclaimable termination_claimed flag.
+        return await self._await_network_task(continuation)
+
+    async def _claim_and_finish_termination(
+        self,
+        call_id: str,
+        reason: str,
+        *,
+        preserve_conference: bool,
+        await_finalizer: bool,
+        initiating_task: asyncio.Task[Any] | None,
+    ) -> bool:
+        transfer_task: asyncio.Task[dict[str, Any]] | None = None
+        async with self._owner_transfer_lock(call_id):
+            claim_error: Exception | None = None
+            try:
+                call = await self.db.claim_termination(call_id, reason)
+            except Exception as exc:
+                call = None
+                claim_error = exc
+            if call is None and claim_error is not None:
+                current = await self.db.get_call(call_id)
+                exact_claim = bool(
+                    current
+                    and current.get("state") == CallState.TERMINATING.value
+                    and current.get("termination_claimed")
+                    and current.get("termination_reason") == reason
+                )
+                if not exact_claim:
+                    raise claim_error
+                call = current
+                logger.warning("reconciled ambiguous termination claim call_id=%s", call_id)
+            if call is not None:
+                transfer_task = self._owner_transfer_tasks.get(call_id)
         if call is None:
-            self._clear_call_activity(call_id)
+            current = await self.db.get_call(call_id)
+            if current is None:
+                self._clear_call_activity(call_id)
+            elif CallState(current["state"]) in TERMINAL_STATES or current.get(
+                "termination_claimed"
+            ):
+                self._tombstone_call_activity(call_id)
             return False
-        state = CallState(call["state"])
-        if state in TERMINAL_STATES:
-            self._tombstone_call_activity(call_id)
-            return False
-        if state == CallState.TERMINATING:
-            self._tombstone_call_activity(call_id)
-        if (call.get("transfer_outcome") or "").startswith(("in_progress:", "completed:")):
-            preserve_conference = True
-            reason = "transfer_completed"
-        if not await self.db.set_flag_once(call_id, "termination_claimed"):
-            return False
+
+        # An ordinary termination can only claim a pre-promotion transfer. Stop its
+        # worker and wait for late Twilio creation/removal cleanup before completing
+        # the conference. A promoted transfer already owns termination and cannot
+        # reach this branch.
+        if transfer_task is not None and transfer_task is not initiating_task:
+            transfer_task.cancel()
+            try:
+                await self._await_network_task(transfer_task)
+            except asyncio.CancelledError:
+                logger.warning(
+                    "owner transfer task cancelled before cleanup started call_id=%s", call_id
+                )
+            except Exception:
+                logger.warning(
+                    "owner transfer cleanup failed during termination call_id=%s",
+                    call_id,
+                    exc_info=True,
+                )
+
+        return await self._finish_claimed_termination(
+            call,
+            reason,
+            preserve_conference=preserve_conference,
+            await_finalizer=await_finalizer,
+            expected_transfer_outcome=call.get("transfer_outcome"),
+        )
+
+    async def _finish_claimed_termination(
+        self,
+        call: dict[str, Any],
+        reason: str,
+        *,
+        preserve_conference: bool,
+        await_finalizer: bool,
+        expected_transfer_outcome: str | None = None,
+        schedule_conference_retry: bool = True,
+    ) -> bool:
+        call_id = call["call_id"]
         self._tombstone_call_activity(call_id)
         self._voice_end_pending.pop(call_id, None)
         self._active_response_ids.pop(call_id, None)
-        await self.db.update_call(
-            call_id, state=CallState.TERMINATING.value, termination_reason=reason
-        )
         media_tasks = [self.realtime.hangup(call.get("openai_call_id"))]
         if not preserve_conference:
             media_tasks.append(
@@ -987,7 +1827,41 @@ class CallService:
         for result in results:
             if isinstance(result, Exception):
                 logger.warning("media teardown operation failed", exc_info=result)
-        await self.realtime.drain_and_close(call_id)
+        conference_failed = (
+            not preserve_conference and len(results) > 1 and isinstance(results[1], Exception)
+        )
+        if conference_failed:
+            # Retry once in the live process. If Twilio still cannot confirm conference
+            # completion, retain TERMINATING so startup recovery can adopt it again.
+            await asyncio.sleep(TERMINATION_MEDIA_RETRY_DELAY_SECONDS)
+            retry = asyncio.create_task(
+                self.twilio.complete_conference(
+                    call.get("conference_sid") or call.get("conference_name")
+                ),
+                name=f"retry-complete-conference:{call_id}",
+            )
+            try:
+                await self._await_network_task(retry)
+                conference_failed = False
+            except Exception:
+                logger.warning(
+                    "conference completion retry failed call_id=%s", call_id, exc_info=True
+                )
+        try:
+            await self.realtime.drain_and_close(call_id)
+        except Exception:
+            logger.warning("Realtime drain/close failed call_id=%s", call_id, exc_info=True)
+        if conference_failed:
+            # Keep the durable claim nonterminal. Startup recovery will retry the
+            # required media teardown instead of publishing a false terminal result.
+            if schedule_conference_retry:
+                self._schedule_conference_completion_retry(
+                    call,
+                    reason=reason,
+                    expected_transfer_outcome=expected_transfer_outcome,
+                    await_finalizer=await_finalizer,
+                )
+            return False
         ended_at = datetime.now(UTC)
         started_at = (
             datetime.fromisoformat(call["started_at"]) if call.get("started_at") else ended_at
@@ -1009,25 +1883,92 @@ class CallService:
             terminal = CallState.COMPLETED
         else:
             terminal = CallState.FAILED
-        await self.db.update_call(
-            call_id,
-            state=terminal.value,
-            ended_at=ended_at.isoformat(),
-            duration_seconds=duration,
-        )
+        terminal_error: BaseException | None = None
+        try:
+            terminalized = await self.db.finish_claimed_termination(
+                call_id,
+                expected_reason=reason,
+                terminal_state=terminal,
+                ended_at=ended_at.isoformat(),
+                duration_seconds=duration,
+                expected_transfer_outcome=expected_transfer_outcome,
+            )
+        except asyncio.CancelledError as exc:
+            terminalized = False
+            terminal_error = exc
+        except Exception as exc:
+            terminalized = False
+            terminal_error = exc
+        if not terminalized:
+            current = await self.db.get_call(call_id)
+            exact_terminal = bool(
+                current
+                and current.get("state") == terminal.value
+                and current.get("termination_claimed")
+                and current.get("termination_reason") == reason
+                and current.get("transfer_outcome") == expected_transfer_outcome
+            )
+            if not exact_terminal:
+                if schedule_conference_retry and not preserve_conference:
+                    self._schedule_conference_completion_retry(
+                        call,
+                        reason=reason,
+                        expected_transfer_outcome=expected_transfer_outcome,
+                        await_finalizer=await_finalizer,
+                    )
+                if terminal_error is not None:
+                    raise terminal_error
+                logger.error(
+                    "claimed termination lost its durable state call_id=%s reason=%s",
+                    call_id,
+                    reason,
+                )
+                return False
+            call = current
+            logger.warning(
+                "reconciled ambiguous terminal transition call_id=%s state=%s",
+                call_id,
+                terminal.value,
+            )
         self._tombstone_call_activity(call_id)
-        await self.db.add_transcript_turn(
-            call_id=call_id,
-            turn_id=f"telephony_{secrets.token_urlsafe(10)}",
-            speaker="system",
-            text=f"Call ended with telephony reason: {reason}.",
-            source_event_type="telephony.terminal",
-            source_event_id=f"terminal:{call_id}:{reason}",
-        )
+        self._owner_join_events.pop(call_id, None)
+        self._owner_departure_events.pop(call_id, None)
+        self._owner_expected_sids.pop(call_id, None)
+        self._owner_joined_sids.pop(call_id, None)
+        self._owner_failures.pop(call_id, None)
+        self._owner_transfer_tasks.pop(call_id, None)
+        self._owner_transfer_locks.pop(call_id, None)
+        self._opening_transition_locks.pop(call_id, None)
+        self._tool_seen_calls.discard(call_id)
+        try:
+            await self.db.add_transcript_turn(
+                call_id=call_id,
+                turn_id=f"telephony_{secrets.token_urlsafe(10)}",
+                speaker="system",
+                text=f"Call ended with telephony reason: {reason}.",
+                source_event_type="telephony.terminal",
+                source_event_id=f"terminal:{call_id}:{reason}",
+            )
+        except asyncio.CancelledError:
+            # The terminal row is the linearization point. Cancellation after that
+            # commit may skip optional bookkeeping, but it must never unwind into
+            # transfer compensation and tear down a successful handoff.
+            logger.warning("terminal transcript bookkeeping cancelled call_id=%s", call_id)
+        except Exception:
+            logger.warning(
+                "terminal transcript bookkeeping failed call_id=%s", call_id, exc_info=True
+            )
+
+        async def finalize_best_effort() -> None:
+            try:
+                await self.finalizer.finalize(call_id)
+            except Exception:
+                logger.warning("terminal finalization failed call_id=%s", call_id, exc_info=True)
+
         if await_finalizer:
-            await self.finalizer.finalize(call_id)
+            await finalize_best_effort()
         else:
-            self._spawn(self.finalizer.finalize(call_id), name=f"finalize:{call_id}")
+            self._spawn(finalize_best_effort(), name=f"finalize:{call_id}")
         self._queued_latency_events = {
             key: mark for key, mark in self._queued_latency_events.items() if key[0] != call_id
         }
@@ -1086,25 +2027,148 @@ class CallService:
     async def recover_startup(self) -> None:
         recovered: set[str] = set()
         for call in await self.db.list_nonterminal_calls():
-            await self.db.reset_termination_claim(call["call_id"])
-            await self.terminate_call(call["call_id"], "startup_recovery", await_finalizer=True)
-            recovered.add(call["call_id"])
+            call_id = call["call_id"]
+            transfer_outcome = call.get("transfer_outcome")
+            completed_transfer = bool(
+                transfer_outcome and transfer_outcome.startswith("completed:")
+            )
+            claimed = await self.db.claim_startup_recovery(
+                call_id,
+                expected_transfer_outcome=transfer_outcome,
+                completed_transfer=completed_transfer,
+            )
+            if claimed is None:
+                continue
+            expected_transfer_outcome = (
+                transfer_outcome
+                if completed_transfer
+                else ("failed:startup_recovery" if transfer_outcome is not None else None)
+            )
+            if completed_transfer:
+                owner_call_sid = claimed.get("twilio_owner_call_sid")
+                owner_exit_armed = False
+                if owner_call_sid:
+                    arm_owner_exit = asyncio.create_task(
+                        self.twilio.enable_end_conference_on_exit(
+                            claimed.get("conference_sid") or claimed.get("conference_name"),
+                            owner_call_sid,
+                        ),
+                        name=f"recover-owner-conference-exit:{call_id}",
+                    )
+                    try:
+                        await self._await_network_task(arm_owner_exit)
+                        owner_exit_armed = True
+                    except Exception:
+                        logger.warning(
+                            "startup could not arm transferred owner exit call_id=%s",
+                            call_id,
+                            exc_info=True,
+                        )
+                if not owner_exit_armed:
+                    failure = "failed:owner_exit_unarmed"
+                    failure_reason = "transfer_failed:owner_exit_unarmed"
+                    try:
+                        failed_closed = await self.db.fail_promoted_transfer(
+                            call_id,
+                            transfer_outcome,
+                            failure,
+                            failure_reason,
+                        )
+                    except Exception:
+                        failed_closed = False
+                        logger.warning(
+                            "startup could not persist owner-exit failure call_id=%s",
+                            call_id,
+                            exc_info=True,
+                        )
+                    if failed_closed:
+                        await self._finish_claimed_termination(
+                            claimed,
+                            failure_reason,
+                            preserve_conference=False,
+                            await_finalizer=True,
+                            expected_transfer_outcome=failure,
+                        )
+                    else:
+                        await self._complete_conference_or_schedule(claimed)
+                    continue
+            try:
+                terminalized = await self._finish_claimed_termination(
+                    claimed,
+                    "transfer_completed" if completed_transfer else "startup_recovery",
+                    preserve_conference=completed_transfer,
+                    await_finalizer=True,
+                    expected_transfer_outcome=expected_transfer_outcome,
+                )
+            except Exception:
+                logger.exception("startup recovery failed call_id=%s", call_id)
+                continue
+            if not terminalized:
+                logger.error("startup recovery scheduled teardown retry call_id=%s", call_id)
+                continue
+            recovered.add(call_id)
         # A crash can occur after telephony is terminal but before finalization committed.
         for call in await self.db.list_terminal_calls_needing_finalization():
             if call["call_id"] not in recovered:
-                await self.finalizer.finalize(call["call_id"])
+                try:
+                    await self.finalizer.finalize(call["call_id"])
+                except Exception:
+                    logger.warning(
+                        "startup finalization failed call_id=%s",
+                        call["call_id"],
+                        exc_info=True,
+                    )
 
     async def start_watchdog(self) -> None:
-        if self._watchdog_task is None:
+        if not self._stopping and self._watchdog_task is None:
             self._watchdog_task = asyncio.create_task(self._watchdog(), name="call-watchdog")
 
     async def stop(self) -> None:
+        self._stopping = True
         if self._watchdog_task:
             self._watchdog_task.cancel()
             await asyncio.gather(self._watchdog_task, return_exceptions=True)
-        for task in list(self._background):
-            task.cancel()
-        await asyncio.gather(*self._background, return_exceptions=True)
+            self._watchdog_task = None
+        # Shutdown is fail-closed even if a deployment guard or operator invariant
+        # is violated. Claim ordinary calls before canceling transfer workers so the
+        # existing claim protocol owns late owner-leg cleanup and conference teardown.
+        try:
+            nonterminal = await self.db.list_nonterminal_calls()
+        except Exception:
+            nonterminal = []
+            logger.exception("failed to enumerate calls during shutdown")
+        current = asyncio.current_task()
+        shutdown_results = await asyncio.gather(
+            *(
+                self.terminate_call(
+                    call["call_id"],
+                    "service_shutdown",
+                    _initiating_task=current,
+                )
+                for call in nonterminal
+            ),
+            return_exceptions=True,
+        )
+        for call, result in zip(nonterminal, shutdown_results, strict=True):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "shutdown call teardown failed call_id=%s",
+                    call["call_id"],
+                    exc_info=(type(result), result, result.__traceback__),
+                )
+        await self.realtime.close_all()
+        # Drain to a stable empty set. Cancellation handlers may register shielded
+        # compensation after the first snapshot; must-finish tasks are awaited rather
+        # than cancelled, while the stopping gate turns all new ordinary work into no-ops.
+        while True:
+            pending = [task for task in self._background if task is not current]
+            if not pending:
+                break
+            for task in pending:
+                if task not in self._must_finish_background:
+                    task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            await asyncio.sleep(0)
         await self._flush_call_activity()
         if self._owns_openai_client:
             await self.openai.close()

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -22,6 +22,7 @@ from app.models import (
     StartPhoneCallOutput,
     VoiceEndCallRequest,
 )
+from app.openai_client import create_openai_client
 from app.openai_realtime import RealtimeBridge
 from app.policy import validate_context
 from app.settings import Settings
@@ -41,10 +42,8 @@ class CallService:
     ):
         self.settings = settings
         self.db = db
-        self.openai = openai or AsyncOpenAI(
-            api_key=Settings.reveal(settings.openai_api_key),
-            webhook_secret=Settings.reveal(settings.openai_webhook_secret),
-        )
+        self._owns_openai_client = openai is None
+        self.openai = openai if openai is not None else create_openai_client(settings)
         self.twilio = twilio or TwilioBridge(settings)
         self.realtime = RealtimeBridge(
             settings,
@@ -57,6 +56,7 @@ class CallService:
         self.finalizer = Finalizer(settings, db, self.openai)
         self._background: set[asyncio.Task[Any]] = set()
         self._owner_join_events: dict[str, asyncio.Event] = {}
+        self._opening_transition_locks: dict[str, asyncio.Lock] = {}
         self._voice_end_pending: dict[str, tuple[str, str | None]] = {}
         self._active_response_ids: dict[str, str | None] = {}
         self._queued_latency_events: dict[tuple[str, LatencyStage, str], LatencyMark] = {}
@@ -67,6 +67,9 @@ class CallService:
         self._background.add(task)
         task.add_done_callback(self._background.discard)
         return task
+
+    def _opening_transition_lock(self, call_id: str) -> asyncio.Lock:
+        return self._opening_transition_locks.setdefault(call_id, asyncio.Lock())
 
     async def _record_latency(
         self,
@@ -474,29 +477,30 @@ class CallService:
         completes, but ask the model for an opening turn immediately. The application supplies no
         response-specific script; the model chooses the opening from Poke's approved context.
         """
-        call = await self.db.get_call(call_id)
-        if call is None or CallState(call["state"]) in TERMINAL_STATES:
-            return
-        if not (
-            call["sideband_open"]
-            and call["callee_joined"]
-            and call["transcription_verified"]
-            and call["semantic_vad_verified"]
-        ):
-            return
-        if call.get("answer_handling") == "voicemail":
-            return
-        if not await self.db.set_flag_once(call_id, "opening_sent"):
-            return
+        async with self._opening_transition_lock(call_id):
+            call = await self.db.get_call(call_id)
+            if call is None or CallState(call["state"]) in TERMINAL_STATES:
+                return
+            if not (
+                call["sideband_open"]
+                and call["callee_joined"]
+                and call["transcription_verified"]
+                and call["semantic_vad_verified"]
+            ):
+                return
+            if call.get("answer_handling") == "voicemail":
+                return
+            if not await self.db.claim_opening_if_not_voicemail(call_id):
+                return
+
+            # Keep the atomic claim and its WebSocket write ordered against the voicemail
+            # cancel/write pair. The lock is per call and does not cover Twilio network I/O.
+            await self.realtime.create_opening(call_id)
 
         conference = call.get("conference_sid") or call.get("conference_name")
-        # Twilio auto-unmutes the agent leg at conference start; the explicit unmute is a
-        # race-safety net, so run it concurrently instead of letting its REST round-trip
-        # delay the opening turn.
-        await asyncio.gather(
-            self.realtime.create_opening(call_id),
-            self._unmute_agent(call_id, conference, call.get("twilio_ai_call_sid")),
-        )
+        # The explicit unmute is a race-safety net. Sending the opening first ensures its
+        # Twilio round-trip can never delay the model's response.create.
+        await self._unmute_agent(call_id, conference, call.get("twilio_ai_call_sid"))
 
     async def _unmute_agent(
         self, call_id: str, conference: str | None, agent_call_sid: str | None
@@ -513,30 +517,42 @@ class CallService:
     async def _activate(self, call_id: str) -> None:
         if not await self.db.cas_state(call_id, CallState.READY_TO_ACTIVATE, CallState.ACTIVATING):
             return
-        try:
-            updated = await self.realtime.enable_automatic_responses(call_id)
-        except Exception:
-            await self.terminate_call(call_id, "session_update_timeout")
+        call = await self.db.get_call(call_id)
+        if call is None:
             return
-        if not self.realtime.activation_update_confirmed(updated):
-            await self.terminate_call(call_id, "session_update_mismatch")
-            return
+        is_voicemail = call["answer_handling"] == "voicemail"
+        if not is_voicemail:
+            try:
+                updated = await self.realtime.enable_automatic_responses(call_id)
+            except Exception:
+                await self.terminate_call(call_id, "session_update_timeout")
+                return
+            if not self.realtime.activation_update_confirmed(updated):
+                await self.terminate_call(call_id, "session_update_mismatch")
+                return
         if not await self.db.cas_state(call_id, CallState.ACTIVATING, CallState.ACTIVE):
             return
-        call = await self.db.get_call(call_id)
-        if call["answer_handling"] == "voicemail":
+        if is_voicemail:
             conference = call.get("conference_sid") or call.get("conference_name")
-            tasks = [self._unmute_agent(call_id, conference, call.get("twilio_ai_call_sid"))]
-            if await self.db.set_flag_once(call_id, "voicemail_sent"):
-                # The opening turn starts on answer, before async AMD can classify the callee.
-                # If AMD then reports a machine, cancel the opening even when its
-                # response.created event has not arrived yet. WebSocket event ordering makes
-                # the following voicemail response.create run after the cancellation request.
-                if call.get("opening_sent"):
-                    response_id = self._active_response_ids.pop(call_id, None)
-                    await self.realtime.cancel_response(call_id, response_id)
-                tasks.append(self.realtime.create_voicemail(call_id))
-            await asyncio.gather(*tasks)
+            unmute = asyncio.create_task(
+                self._unmute_agent(call_id, conference, call.get("twilio_ai_call_sid")),
+                name=f"unmute:{call_id}:voicemail",
+            )
+            try:
+                async with self._opening_transition_lock(call_id):
+                    current = await self.db.get_call(call_id)
+                    if current is None:
+                        return
+                    if await self.db.set_flag_once(call_id, "voicemail_sent"):
+                        # If the opening claim won, its response.create completed under this
+                        # same lock. Otherwise AMD was persisted first and the atomic opening
+                        # claim cannot succeed after this voicemail write.
+                        if current.get("opening_sent"):
+                            response_id = self._active_response_ids.pop(call_id, None)
+                            await self.realtime.cancel_response(call_id, response_id)
+                        await self.realtime.create_voicemail(call_id)
+            finally:
+                await unmute
         else:
             await self._start_opening_on_answer(call_id)
 
@@ -967,6 +983,8 @@ class CallService:
         for task in list(self._background):
             task.cancel()
         await asyncio.gather(*self._background, return_exceptions=True)
+        if self._owns_openai_client:
+            await self.openai.close()
 
     async def _watchdog(self) -> None:
         while True:

--- a/app/db.py
+++ b/app/db.py
@@ -497,6 +497,17 @@ class Database:
             == 1
         )
 
+    async def claim_opening_if_not_voicemail(self, call_id: str) -> bool:
+        """Atomically claim the opening unless AMD has already classified voicemail."""
+        return (
+            await self.execute(
+                """UPDATE calls SET opening_sent=1, last_event_at=?
+                   WHERE call_id=? AND opening_sent=0 AND answer_handling IS NOT ?""",
+                (_iso_now(), call_id, "voicemail"),
+            )
+            == 1
+        )
+
     async def increment_tool_calls(
         self,
         call_id: str,

--- a/app/db.py
+++ b/app/db.py
@@ -507,6 +507,25 @@ class Database:
             "UPDATE calls SET last_event_at=? WHERE call_id=?", (_iso_now(), call_id)
         )
 
+    async def touch_calls(self, activity: Iterable[tuple[str, str]]) -> None:
+        """Persist latest observed activity for several calls in one durable transaction."""
+        terminal_states = tuple(sorted(state.value for state in TERMINAL_STATES))
+        placeholders = ",".join("?" for _ in terminal_states)
+        rows = [
+            (occurred_at, call_id, occurred_at, *terminal_states)
+            for call_id, occurred_at in activity
+        ]
+        if not rows:
+            return
+        async with self._write_connection() as conn:
+            await conn.executemany(
+                f"""UPDATE calls SET last_event_at=?
+                    WHERE call_id=? AND last_event_at<?
+                      AND state NOT IN ({placeholders})""",  # noqa: S608
+                rows,
+            )
+            await conn.commit()
+
     async def record_latency_events(
         self,
         call_id: str,

--- a/app/db.py
+++ b/app/db.py
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS calls (
     conference_sid TEXT,
     twilio_ai_call_sid TEXT,
     twilio_callee_call_sid TEXT,
+    twilio_owner_call_sid TEXT,
     openai_call_id TEXT UNIQUE,
     openai_accept_status INTEGER,
     transcription_verified INTEGER NOT NULL DEFAULT 0,
@@ -264,10 +265,14 @@ class Database:
             "tool_continuation_observed": "INTEGER NOT NULL DEFAULT 0",
             "interruption_observed": "INTEGER NOT NULL DEFAULT 0",
             "opening_sent": "INTEGER NOT NULL DEFAULT 0",
+            "twilio_owner_call_sid": "TEXT",
         }
         for name, definition in migrations.items():
             if name not in existing:
                 await conn.execute(f"ALTER TABLE calls ADD COLUMN {name} {definition}")
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS calls_twilio_owner_idx ON calls(twilio_owner_call_sid)"
+        )
         await conn.commit()
 
     @asynccontextmanager
@@ -631,32 +636,285 @@ class Database:
             == 1
         )
 
-    async def increment_tool_calls(
+    async def record_tool_call(
         self,
         call_id: str,
         *,
-        latency_mark: LatencyMark | None = None,
+        latency_mark: LatencyMark,
         event_key: str = "",
+        advisory_outcome: dict[str, Any] | None = None,
     ) -> None:
+        """Persist one tool receipt and its optional validated advisory in one commit."""
+
         async with self._write_connection() as conn:
+            now = _iso_now()
+            if advisory_outcome is None:
+                await conn.execute(
+                    """UPDATE calls SET tool_call_count=tool_call_count+1, last_event_at=?
+                       WHERE call_id=?""",
+                    (now, call_id),
+                )
+            else:
+                await conn.execute(
+                    """UPDATE calls
+                       SET tool_call_count=tool_call_count+1,
+                           advisory_outcome_json=?,
+                           last_event_at=?
+                       WHERE call_id=?""",
+                    (json.dumps(advisory_outcome), now, call_id),
+                )
             await conn.execute(
-                """UPDATE calls SET tool_call_count=tool_call_count+1, last_event_at=?
-                   WHERE call_id=?""",
+                UPSERT_LATENCY_EVENT,
+                (
+                    call_id,
+                    LatencyStage.TOOL_CALL_RECEIVED.value,
+                    event_key,
+                    latency_mark.occurred_at,
+                    latency_mark.monotonic_ns,
+                    self._latency_clock_id,
+                ),
+            )
+            await conn.commit()
+
+    async def mark_tool_continuation_observed(self, call_id: str) -> bool:
+        """Record a continuation only when at least one tool call was durably received."""
+
+        return (
+            await self.execute(
+                """UPDATE calls
+                   SET tool_continuation_observed=1, last_event_at=?
+                   WHERE call_id=?
+                     AND tool_call_count>0
+                     AND tool_continuation_observed=0""",
                 (_iso_now(), call_id),
             )
-            if latency_mark is not None:
-                await conn.execute(
-                    UPSERT_LATENCY_EVENT,
+            == 1
+        )
+
+    async def claim_transfer_joining(self, call_id: str, reason: str) -> bool:
+        """Durably allow at most one owner-transfer attempt for a live call."""
+
+        return (
+            await self.execute(
+                """UPDATE calls SET transfer_outcome=?, last_event_at=?
+                   WHERE call_id=?
+                     AND transfer_outcome IS NULL
+                     AND termination_claimed=0
+                     AND state='active'""",
+                (f"joining:{reason}", _iso_now(), call_id),
+            )
+            == 1
+        )
+
+    async def record_transfer_owner_sid(
+        self, call_id: str, expected: str, owner_call_sid: str
+    ) -> bool:
+        """Persist the owner leg before transfer promotion can become recoverable."""
+
+        return (
+            await self.execute(
+                """UPDATE calls SET twilio_owner_call_sid=?, last_event_at=?
+                   WHERE call_id=?
+                     AND transfer_outcome=?
+                     AND termination_claimed=0
+                     AND state='active'
+                     AND (twilio_owner_call_sid IS NULL OR twilio_owner_call_sid=?)""",
+                (owner_call_sid, _iso_now(), call_id, expected, owner_call_sid),
+            )
+            == 1
+        )
+
+    async def promote_transfer(self, call_id: str, reason: str) -> dict[str, Any] | None:
+        """Claim teardown ownership while promoting a joined owner transfer."""
+
+        async with self._write_connection() as conn:
+            cursor = await conn.execute(
+                """UPDATE calls
+                   SET transfer_outcome=?,
+                       termination_claimed=1,
+                       state=?,
+                       termination_reason='transfer_completed',
+                       last_event_at=?
+                   WHERE call_id=?
+                     AND transfer_outcome=?
+                     AND termination_claimed=0
+                     AND state='active'
+                   RETURNING *""",
+                (
+                    f"in_progress:{reason}",
+                    CallState.TERMINATING.value,
+                    _iso_now(),
+                    call_id,
+                    f"joining:{reason}",
+                ),
+            )
+            row = await cursor.fetchone()
+            await conn.commit()
+        return _decode_json_columns(dict(row)) if row else None
+
+    async def fail_joining_transfer(self, call_id: str, expected: str, failure: str) -> bool:
+        return (
+            await self.execute(
+                """UPDATE calls SET transfer_outcome=?, last_event_at=?
+                   WHERE call_id=?
+                     AND transfer_outcome=?
+                     AND termination_claimed=0
+                     AND state='active'""",
+                (failure, _iso_now(), call_id, expected),
+            )
+            == 1
+        )
+
+    async def complete_promoted_transfer(self, call_id: str, expected: str, completed: str) -> bool:
+        return (
+            await self.execute(
+                """UPDATE calls SET transfer_outcome=?, last_event_at=?
+                   WHERE call_id=?
+                     AND transfer_outcome=?
+                     AND termination_claimed=1
+                     AND state='terminating'
+                     AND termination_reason='transfer_completed'""",
+                (completed, _iso_now(), call_id, expected),
+            )
+            == 1
+        )
+
+    async def fail_promoted_transfer(
+        self,
+        call_id: str,
+        expected: str,
+        failure: str,
+        failure_reason: str,
+    ) -> bool:
+        return (
+            await self.execute(
+                """UPDATE calls
+                   SET transfer_outcome=?, termination_reason=?, last_event_at=?
+                   WHERE call_id=?
+                     AND transfer_outcome=?
+                     AND termination_claimed=1
+                     AND state='terminating'
+                     AND termination_reason='transfer_completed'""",
+                (failure, failure_reason, _iso_now(), call_id, expected),
+            )
+            == 1
+        )
+
+    async def claim_termination(self, call_id: str, reason: str) -> dict[str, Any] | None:
+        """Atomically claim and enter termination, returning the claimed current row."""
+
+        async with self._write_connection() as conn:
+            cursor = await conn.execute(
+                """UPDATE calls
+                   SET termination_claimed=1,
+                       state=?,
+                       termination_reason=?,
+                       transfer_outcome=CASE
+                           WHEN transfer_outcome LIKE 'joining:%'
+                           THEN 'failed:termination_won'
+                           ELSE transfer_outcome
+                       END,
+                       last_event_at=?
+                   WHERE call_id=?
+                     AND termination_claimed=0
+                     AND state NOT IN ('completed','failed','timed_out','transferred')
+                     AND COALESCE(transfer_outcome, '') NOT LIKE 'in_progress:%'
+                     AND COALESCE(transfer_outcome, '') NOT LIKE 'completed:%'
+                   RETURNING *""",
+                (CallState.TERMINATING.value, reason, _iso_now(), call_id),
+            )
+            row = await cursor.fetchone()
+            await conn.commit()
+        return _decode_json_columns(dict(row)) if row else None
+
+    async def claim_startup_recovery(
+        self,
+        call_id: str,
+        *,
+        expected_transfer_outcome: str | None,
+        completed_transfer: bool,
+    ) -> dict[str, Any] | None:
+        """Adopt a stranded nonterminal call without a reset/reclaim race."""
+
+        reason = "transfer_completed" if completed_transfer else "startup_recovery"
+        replacement = (
+            expected_transfer_outcome
+            if completed_transfer
+            else ("failed:startup_recovery" if expected_transfer_outcome is not None else None)
+        )
+        async with self._write_connection() as conn:
+            if expected_transfer_outcome is None:
+                cursor = await conn.execute(
+                    """UPDATE calls
+                       SET termination_claimed=1,
+                           state='terminating',
+                           termination_reason=?,
+                           last_event_at=?
+                       WHERE call_id=?
+                         AND transfer_outcome IS NULL
+                         AND state NOT IN ('completed','failed','timed_out','transferred')
+                       RETURNING *""",
+                    (reason, _iso_now(), call_id),
+                )
+            else:
+                cursor = await conn.execute(
+                    """UPDATE calls
+                       SET termination_claimed=1,
+                           state='terminating',
+                           termination_reason=?,
+                           transfer_outcome=?,
+                           last_event_at=?
+                       WHERE call_id=?
+                         AND transfer_outcome=?
+                         AND state NOT IN ('completed','failed','timed_out','transferred')
+                       RETURNING *""",
                     (
+                        reason,
+                        replacement,
+                        _iso_now(),
                         call_id,
-                        LatencyStage.TOOL_CALL_RECEIVED.value,
-                        event_key,
-                        latency_mark.occurred_at,
-                        latency_mark.monotonic_ns,
-                        self._latency_clock_id,
+                        expected_transfer_outcome,
                     ),
                 )
+            row = await cursor.fetchone()
             await conn.commit()
+        return _decode_json_columns(dict(row)) if row else None
+
+    async def finish_claimed_termination(
+        self,
+        call_id: str,
+        *,
+        expected_reason: str,
+        terminal_state: CallState,
+        ended_at: str,
+        duration_seconds: int,
+        expected_transfer_outcome: str | None = None,
+    ) -> bool:
+        params: list[Any] = [
+            terminal_state.value,
+            ended_at,
+            duration_seconds,
+            _iso_now(),
+            call_id,
+            expected_reason,
+        ]
+        if expected_transfer_outcome is None:
+            transfer_predicate = " AND transfer_outcome IS NULL"
+        else:
+            transfer_predicate = " AND transfer_outcome=?"
+            params.append(expected_transfer_outcome)
+        return (
+            await self.execute(
+                f"""UPDATE calls
+                    SET state=?, ended_at=?, duration_seconds=?, last_event_at=?
+                    WHERE call_id=?
+                      AND state='terminating'
+                      AND termination_claimed=1
+                      AND termination_reason=?{transfer_predicate}""",  # noqa: S608
+                params,
+            )
+            == 1
+        )
 
     async def reset_termination_claim(self, call_id: str) -> None:
         await self.execute(

--- a/app/db.py
+++ b/app/db.py
@@ -189,68 +189,172 @@ def _decode_json_columns(row: dict[str, Any]) -> dict[str, Any]:
 class Database:
     def __init__(self, path: Path):
         self.path = path
+        self._lifecycle_lock = asyncio.Lock()
         self._write_lock = asyncio.Lock()
+        self._read_lock = asyncio.Lock()
+        self._writer: aiosqlite.Connection | None = None
+        self._reader: aiosqlite.Connection | None = None
         # Monotonic values are comparable only when this process-local clock ID matches.
         self._latency_clock_id = uuid4().hex
 
     async def initialize(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        async with aiosqlite.connect(self.path) as conn:
-            await conn.executescript(SCHEMA)
-            cursor = await conn.execute("PRAGMA table_info(calls)")
+        async with self._lifecycle_lock:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            if (self._writer is None) != (self._reader is None):
+                raise RuntimeError("database connection state is inconsistent")
+            created_connections = self._writer is None
+            if created_connections:
+                writer: aiosqlite.Connection | None = None
+                reader: aiosqlite.Connection | None = None
+                try:
+                    writer = await self._connect(query_only=False)
+                    reader = await self._connect(query_only=True)
+                except BaseException:
+                    if reader is not None:
+                        await reader.close()
+                    if writer is not None:
+                        await writer.close()
+                    raise
+                self._writer = writer
+                self._reader = reader
+
+            try:
+                async with self._write_connection() as conn:
+                    await self._run_migrations(conn)
+            except BaseException:
+                if created_connections:
+                    await self._close_connections()
+                raise
+
+    async def _connect(self, *, query_only: bool) -> aiosqlite.Connection:
+        conn = await aiosqlite.connect(self.path)
+        try:
+            conn.row_factory = aiosqlite.Row
+            await conn.execute("PRAGMA foreign_keys=ON")
+            await conn.execute("PRAGMA busy_timeout=5000")
+            await conn.execute("PRAGMA journal_mode=WAL")
+            await conn.execute("PRAGMA synchronous=FULL")
+            if query_only:
+                await conn.execute("PRAGMA query_only=ON")
+            return conn
+        except BaseException:
+            await conn.close()
+            raise
+
+    async def _run_migrations(self, conn: aiosqlite.Connection) -> None:
+        await conn.executescript(SCHEMA)
+        async with conn.execute("PRAGMA table_info(calls)") as cursor:
             existing = {row[1] for row in await cursor.fetchall()}
-            if "greeting_sent" in existing and "opening_sent" not in existing:
-                await conn.execute("ALTER TABLE calls RENAME COLUMN greeting_sent TO opening_sent")
-                existing.remove("greeting_sent")
-                existing.add("opening_sent")
-            await conn.execute(
-                "UPDATE calls SET state=? WHERE state=?",
-                (
-                    CallState.ACTIVE.value,
-                    "greeting_started",
-                ),
-            )
-            migrations = {
-                "openai_accept_status": "INTEGER",
-                "transcription_verified": "INTEGER NOT NULL DEFAULT 0",
-                "semantic_vad_verified": "INTEGER NOT NULL DEFAULT 0",
-                "tool_call_count": "INTEGER NOT NULL DEFAULT 0",
-                "tool_continuation_observed": "INTEGER NOT NULL DEFAULT 0",
-                "interruption_observed": "INTEGER NOT NULL DEFAULT 0",
-                "opening_sent": "INTEGER NOT NULL DEFAULT 0",
-            }
-            for name, definition in migrations.items():
-                if name not in existing:
-                    await conn.execute(f"ALTER TABLE calls ADD COLUMN {name} {definition}")
-            await conn.commit()
+        if "greeting_sent" in existing and "opening_sent" not in existing:
+            await conn.execute("ALTER TABLE calls RENAME COLUMN greeting_sent TO opening_sent")
+            existing.remove("greeting_sent")
+            existing.add("opening_sent")
+        await conn.execute(
+            "UPDATE calls SET state=? WHERE state=?",
+            (
+                CallState.ACTIVE.value,
+                "greeting_started",
+            ),
+        )
+        migrations = {
+            "openai_accept_status": "INTEGER",
+            "transcription_verified": "INTEGER NOT NULL DEFAULT 0",
+            "semantic_vad_verified": "INTEGER NOT NULL DEFAULT 0",
+            "tool_call_count": "INTEGER NOT NULL DEFAULT 0",
+            "tool_continuation_observed": "INTEGER NOT NULL DEFAULT 0",
+            "interruption_observed": "INTEGER NOT NULL DEFAULT 0",
+            "opening_sent": "INTEGER NOT NULL DEFAULT 0",
+        }
+        for name, definition in migrations.items():
+            if name not in existing:
+                await conn.execute(f"ALTER TABLE calls ADD COLUMN {name} {definition}")
+        await conn.commit()
 
     @asynccontextmanager
-    async def connection(self):
-        conn = await aiosqlite.connect(self.path)
-        conn.row_factory = aiosqlite.Row
-        await conn.execute("PRAGMA foreign_keys=ON")
-        await conn.execute("PRAGMA busy_timeout=5000")
-        try:
+    async def _write_connection(self):
+        async with self._write_lock:
+            conn = self._writer
+            if conn is None:
+                raise RuntimeError("database is not initialized")
+            try:
+                yield conn
+            except BaseException:
+                # aiosqlite queues work on a worker thread. Cancellation can arrive after an
+                # operation is queued but before it starts, when in_transaction is still false.
+                # Queue an unconditional rollback behind that work and keep the lock until the
+                # rollback finishes so the next writer never inherits the abandoned transaction.
+                await self._rollback_writer(conn)
+                raise
+            else:
+                # Do not let a missed commit poison the persistent writer for the
+                # next operation. Transactional methods commit explicitly.
+                if conn.in_transaction:
+                    await self._rollback_writer(conn)
+
+    @staticmethod
+    async def _rollback_writer(conn: aiosqlite.Connection) -> None:
+        rollback = asyncio.create_task(conn.rollback(), name="sqlite-writer-rollback")
+        interrupted = False
+        while not rollback.done():
+            try:
+                await asyncio.shield(rollback)
+            except asyncio.CancelledError:
+                # A repeated cancellation must still not release the writer lock ahead of the
+                # queued rollback. Re-raise it once the connection has been restored.
+                interrupted = True
+        rollback.result()
+        if interrupted:
+            raise asyncio.CancelledError
+
+    @asynccontextmanager
+    async def _read_connection(self):
+        async with self._read_lock:
+            conn = self._reader
+            if conn is None:
+                raise RuntimeError("database is not initialized")
             yield conn
-        finally:
-            await conn.close()
+
+    async def close(self) -> None:
+        """Close both persistent connections; safe to call more than once."""
+        async with self._lifecycle_lock:
+            await self._close_connections()
+
+    async def _close_connections(self) -> None:
+        async with self._write_lock, self._read_lock:
+            writer = self._writer
+            reader = self._reader
+            self._writer = None
+            self._reader = None
+
+            first_error: BaseException | None = None
+            for conn in (reader, writer):
+                if conn is None:
+                    continue
+                try:
+                    await conn.close()
+                except BaseException as exc:  # pragma: no cover - defensive cleanup
+                    if first_error is None:
+                        first_error = exc
+            if first_error is not None:
+                raise first_error
 
     async def execute(self, sql: str, params: Iterable[Any] = ()) -> int:
-        async with self._write_lock, self.connection() as conn:
-            cursor = await conn.execute(sql, tuple(params))
+        async with self._write_connection() as conn:
+            async with conn.execute(sql, tuple(params)) as cursor:
+                rowcount = cursor.rowcount
             await conn.commit()
-            return cursor.rowcount
+            return rowcount
 
     async def fetch_one(self, sql: str, params: Iterable[Any] = ()) -> dict[str, Any] | None:
-        async with self.connection() as conn:
-            cursor = await conn.execute(sql, tuple(params))
-            row = await cursor.fetchone()
+        async with self._read_connection() as conn:
+            async with conn.execute(sql, tuple(params)) as cursor:
+                row = await cursor.fetchone()
         return _decode_json_columns(dict(row)) if row else None
 
     async def fetch_all(self, sql: str, params: Iterable[Any] = ()) -> list[dict[str, Any]]:
-        async with self.connection() as conn:
-            cursor = await conn.execute(sql, tuple(params))
-            rows = await cursor.fetchall()
+        async with self._read_connection() as conn:
+            async with conn.execute(sql, tuple(params)) as cursor:
+                rows = await cursor.fetchall()
         return [_decode_json_columns(dict(row)) for row in rows]
 
     async def create_plan(
@@ -280,7 +384,7 @@ class Database:
         confirmation_text: str,
     ) -> bool:
         now = _iso_now()
-        async with self._write_lock, self.connection() as conn:
+        async with self._write_connection() as conn:
             await conn.execute("BEGIN IMMEDIATE")
             cursor = await conn.execute(
                 "SELECT locked, locked_at FROM deployment_control WHERE singleton=1"
@@ -327,7 +431,7 @@ class Database:
         """
 
         placeholders = ",".join("?" for _ in TERMINAL_STATES)
-        async with self._write_lock, self.connection() as conn:
+        async with self._write_connection() as conn:
             await conn.execute("BEGIN IMMEDIATE")
             cursor = await conn.execute(
                 f"SELECT COUNT(*) FROM calls WHERE state NOT IN ({placeholders})",  # noqa: S608
@@ -421,7 +525,7 @@ class Database:
         ]
         if not rows:
             return
-        async with self._write_lock, self.connection() as conn:
+        async with self._write_connection() as conn:
             await conn.executemany(UPSERT_LATENCY_EVENT, rows)
             await conn.commit()
 
@@ -515,7 +619,7 @@ class Database:
         latency_mark: LatencyMark | None = None,
         event_key: str = "",
     ) -> None:
-        async with self._write_lock, self.connection() as conn:
+        async with self._write_connection() as conn:
             await conn.execute(
                 """UPDATE calls SET tool_call_count=tool_call_count+1, last_event_at=?
                    WHERE call_id=?""",
@@ -564,7 +668,7 @@ class Database:
         source_event_type: str,
         source_event_id: str,
     ) -> TranscriptTurn | None:
-        async with self._write_lock, self.connection() as conn:
+        async with self._write_connection() as conn:
             await conn.execute("BEGIN IMMEDIATE")
             cursor = await conn.execute(
                 "SELECT COALESCE(MAX(sequence_number), 0) + 1 FROM transcripts WHERE call_id=?",
@@ -617,7 +721,7 @@ class Database:
         transcript: list[TranscriptTurn],
     ) -> None:
         now = _iso_now()
-        async with self._write_lock, self.connection() as conn:
+        async with self._write_connection() as conn:
             await conn.execute("BEGIN IMMEDIATE")
             await conn.execute(
                 """INSERT INTO call_results(call_id, result_json, transcript_json, updated_at)

--- a/app/db.py
+++ b/app/db.py
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS calls (
     voicemail_sent INTEGER NOT NULL DEFAULT 0,
     termination_claimed INTEGER NOT NULL DEFAULT 0,
     termination_reason TEXT,
+    conference_cleanup_pending INTEGER NOT NULL DEFAULT 0,
     advisory_outcome_json TEXT,
     transfer_outcome TEXT,
     last_event_at TEXT NOT NULL,
@@ -266,6 +267,7 @@ class Database:
             "interruption_observed": "INTEGER NOT NULL DEFAULT 0",
             "opening_sent": "INTEGER NOT NULL DEFAULT 0",
             "twilio_owner_call_sid": "TEXT",
+            "conference_cleanup_pending": "INTEGER NOT NULL DEFAULT 0",
         }
         for name, definition in migrations.items():
             if name not in existing:
@@ -506,6 +508,15 @@ class Database:
                   )""",  # noqa: S608
             tuple(state.value for state in TERMINAL_STATES),
         )
+
+    async def set_conference_cleanup_pending(self, call_id: str, pending: bool) -> None:
+        await self.execute(
+            "UPDATE calls SET conference_cleanup_pending=? WHERE call_id=?",
+            (1 if pending else 0, call_id),
+        )
+
+    async def list_conference_cleanup_pending(self) -> list[dict[str, Any]]:
+        return await self.fetch_all("SELECT * FROM calls WHERE conference_cleanup_pending=1")
 
     async def touch_call(self, call_id: str) -> None:
         await self.execute(

--- a/app/db.py
+++ b/app/db.py
@@ -145,6 +145,11 @@ WHERE
 
 DEPLOYMENT_LOCK_TTL = timedelta(minutes=15)
 
+# Transfers are legal once the callee has joined, even while async AMD/activation is
+# still converging toward 'active'. The promote CAS moves state to terminating
+# regardless of which live state it started from.
+TRANSFER_ELIGIBLE_STATES = ("prewarming", "ready_to_activate", "activating", "active")
+
 
 class LatencyStage(StrEnum):
     TWILIO_AGENT_REQUEST = "twilio_agent_request"
@@ -703,16 +708,21 @@ class Database:
         )
 
     async def claim_transfer_joining(self, call_id: str, reason: str) -> bool:
-        """Durably allow at most one owner-transfer attempt for a live call."""
+        """Durably allow at most one owner-transfer attempt for a live call.
 
+        Eligible once the callee has joined, even before activation completes.
+        """
+
+        placeholders = ",".join("?" for _ in TRANSFER_ELIGIBLE_STATES)
         return (
             await self.execute(
-                """UPDATE calls SET transfer_outcome=?, last_event_at=?
+                f"""UPDATE calls SET transfer_outcome=?, last_event_at=?
                    WHERE call_id=?
                      AND transfer_outcome IS NULL
                      AND termination_claimed=0
-                     AND state='active'""",
-                (f"joining:{reason}", _iso_now(), call_id),
+                     AND callee_joined=1
+                     AND state IN ({placeholders})""",  # noqa: S608
+                (f"joining:{reason}", _iso_now(), call_id, *TRANSFER_ELIGIBLE_STATES),
             )
             == 1
         )
@@ -722,15 +732,23 @@ class Database:
     ) -> bool:
         """Persist the owner leg before transfer promotion can become recoverable."""
 
+        placeholders = ",".join("?" for _ in TRANSFER_ELIGIBLE_STATES)
         return (
             await self.execute(
-                """UPDATE calls SET twilio_owner_call_sid=?, last_event_at=?
+                f"""UPDATE calls SET twilio_owner_call_sid=?, last_event_at=?
                    WHERE call_id=?
                      AND transfer_outcome=?
                      AND termination_claimed=0
-                     AND state='active'
-                     AND (twilio_owner_call_sid IS NULL OR twilio_owner_call_sid=?)""",
-                (owner_call_sid, _iso_now(), call_id, expected, owner_call_sid),
+                     AND state IN ({placeholders})
+                     AND (twilio_owner_call_sid IS NULL OR twilio_owner_call_sid=?)""",  # noqa: S608
+                (
+                    owner_call_sid,
+                    _iso_now(),
+                    call_id,
+                    expected,
+                    *TRANSFER_ELIGIBLE_STATES,
+                    owner_call_sid,
+                ),
             )
             == 1
         )
@@ -738,9 +756,10 @@ class Database:
     async def promote_transfer(self, call_id: str, reason: str) -> dict[str, Any] | None:
         """Claim teardown ownership while promoting a joined owner transfer."""
 
+        placeholders = ",".join("?" for _ in TRANSFER_ELIGIBLE_STATES)
         async with self._write_connection() as conn:
             cursor = await conn.execute(
-                """UPDATE calls
+                f"""UPDATE calls
                    SET transfer_outcome=?,
                        termination_claimed=1,
                        state=?,
@@ -749,14 +768,15 @@ class Database:
                    WHERE call_id=?
                      AND transfer_outcome=?
                      AND termination_claimed=0
-                     AND state='active'
-                   RETURNING *""",
+                     AND state IN ({placeholders})
+                   RETURNING *""",  # noqa: S608
                 (
                     f"in_progress:{reason}",
                     CallState.TERMINATING.value,
                     _iso_now(),
                     call_id,
                     f"joining:{reason}",
+                    *TRANSFER_ELIGIBLE_STATES,
                 ),
             )
             row = await cursor.fetchone()
@@ -764,14 +784,15 @@ class Database:
         return _decode_json_columns(dict(row)) if row else None
 
     async def fail_joining_transfer(self, call_id: str, expected: str, failure: str) -> bool:
+        placeholders = ",".join("?" for _ in TRANSFER_ELIGIBLE_STATES)
         return (
             await self.execute(
-                """UPDATE calls SET transfer_outcome=?, last_event_at=?
+                f"""UPDATE calls SET transfer_outcome=?, last_event_at=?
                    WHERE call_id=?
                      AND transfer_outcome=?
                      AND termination_claimed=0
-                     AND state='active'""",
-                (failure, _iso_now(), call_id, expected),
+                     AND state IN ({placeholders})""",  # noqa: S608
+                (failure, _iso_now(), call_id, expected, *TRANSFER_ELIGIBLE_STATES),
             )
             == 1
         )

--- a/app/db.py
+++ b/app/db.py
@@ -4,9 +4,13 @@ import asyncio
 import json
 from collections.abc import Iterable
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from enum import StrEnum
 from pathlib import Path
+from time import monotonic_ns
 from typing import Any
+from uuid import uuid4
 
 import aiosqlite
 
@@ -67,6 +71,20 @@ CREATE INDEX IF NOT EXISTS calls_state_idx ON calls(state);
 CREATE INDEX IF NOT EXISTS calls_twilio_ai_idx ON calls(twilio_ai_call_sid);
 CREATE INDEX IF NOT EXISTS calls_twilio_callee_idx ON calls(twilio_callee_call_sid);
 
+CREATE TABLE IF NOT EXISTS call_latency_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    call_id TEXT NOT NULL REFERENCES calls(call_id),
+    stage TEXT NOT NULL,
+    event_key TEXT NOT NULL DEFAULT '',
+    occurred_at TEXT NOT NULL,
+    monotonic_ns INTEGER NOT NULL,
+    clock_id TEXT NOT NULL,
+    UNIQUE(call_id, stage, event_key)
+);
+
+CREATE INDEX IF NOT EXISTS call_latency_events_call_idx
+    ON call_latency_events(call_id, id);
+
 CREATE TABLE IF NOT EXISTS transcripts (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     call_id TEXT NOT NULL REFERENCES calls(call_id),
@@ -102,8 +120,55 @@ CREATE TABLE IF NOT EXISTS deployment_control (
 INSERT OR IGNORE INTO deployment_control (singleton, locked) VALUES (1, 0);
 """
 
+UPSERT_LATENCY_EVENT = """
+INSERT INTO call_latency_events
+    (call_id, stage, event_key, occurred_at, monotonic_ns, clock_id)
+VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT(call_id, stage, event_key) DO UPDATE SET
+    occurred_at=excluded.occurred_at,
+    monotonic_ns=excluded.monotonic_ns,
+    clock_id=excluded.clock_id
+WHERE
+    (
+        call_latency_events.clock_id=excluded.clock_id
+        AND excluded.monotonic_ns < call_latency_events.monotonic_ns
+    )
+    OR
+    (
+        call_latency_events.clock_id<>excluded.clock_id
+        AND excluded.occurred_at < call_latency_events.occurred_at
+    )
+"""
+
 
 DEPLOYMENT_LOCK_TTL = timedelta(minutes=15)
+
+
+class LatencyStage(StrEnum):
+    TWILIO_AGENT_REQUEST = "twilio_agent_request"
+    TWILIO_AGENT_CREATED = "twilio_agent_created"
+    OPENAI_ACCEPT_REQUEST = "openai_accept_request"
+    OPENAI_ACCEPT_COMPLETED = "openai_accept_completed"
+    SIDEBAND_OPEN = "sideband_open"
+    INITIAL_SESSION_ACK = "initial_session_ack"
+    TWILIO_CALLEE_REQUEST = "twilio_callee_request"
+    TWILIO_CALLEE_CREATED = "twilio_callee_created"
+    CALLEE_ANSWERED = "callee_answered"
+    FIRST_RESPONSE_CREATE = "first_response_create"
+    FIRST_ASSISTANT_TRANSCRIPT = "first_assistant_transcript"
+    FIRST_OPENAI_AUDIO_DELTA = "first_openai_audio_delta"
+    TOOL_CALL_RECEIVED = "tool_call_received"
+    TOOL_RESULT_SENT = "tool_result_sent"
+
+
+@dataclass(frozen=True, slots=True)
+class LatencyMark:
+    occurred_at: str
+    monotonic_ns: int
+
+    @classmethod
+    def now(cls) -> LatencyMark:
+        return cls(datetime.now(UTC).isoformat(), monotonic_ns())
 
 
 class DeploymentLockedError(RuntimeError):
@@ -125,6 +190,8 @@ class Database:
     def __init__(self, path: Path):
         self.path = path
         self._write_lock = asyncio.Lock()
+        # Monotonic values are comparable only when this process-local clock ID matches.
+        self._latency_clock_id = uuid4().hex
 
     async def initialize(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -336,6 +403,48 @@ class Database:
             "UPDATE calls SET last_event_at=? WHERE call_id=?", (_iso_now(), call_id)
         )
 
+    async def record_latency_events(
+        self,
+        call_id: str,
+        events: Iterable[tuple[LatencyStage, LatencyMark, str]],
+    ) -> None:
+        rows = [
+            (
+                call_id,
+                stage.value,
+                event_key,
+                mark.occurred_at,
+                mark.monotonic_ns,
+                self._latency_clock_id,
+            )
+            for stage, mark, event_key in events
+        ]
+        if not rows:
+            return
+        async with self._write_lock, self.connection() as conn:
+            await conn.executemany(UPSERT_LATENCY_EVENT, rows)
+            await conn.commit()
+
+    async def record_latency_event(
+        self,
+        call_id: str,
+        stage: LatencyStage,
+        mark: LatencyMark | None = None,
+        *,
+        event_key: str = "",
+    ) -> None:
+        await self.record_latency_events(
+            call_id,
+            [(stage, mark or LatencyMark.now(), event_key)],
+        )
+
+    async def get_latency_events(self, call_id: str) -> list[dict[str, Any]]:
+        return await self.fetch_all(
+            """SELECT stage, event_key, occurred_at, monotonic_ns, clock_id
+               FROM call_latency_events WHERE call_id=? ORDER BY occurred_at, id""",
+            (call_id,),
+        )
+
     async def update_call(self, call_id: str, **values: Any) -> bool:
         if not values:
             return True
@@ -388,12 +497,32 @@ class Database:
             == 1
         )
 
-    async def increment_tool_calls(self, call_id: str) -> None:
-        await self.execute(
-            """UPDATE calls SET tool_call_count=tool_call_count+1, last_event_at=?
-               WHERE call_id=?""",
-            (_iso_now(), call_id),
-        )
+    async def increment_tool_calls(
+        self,
+        call_id: str,
+        *,
+        latency_mark: LatencyMark | None = None,
+        event_key: str = "",
+    ) -> None:
+        async with self._write_lock, self.connection() as conn:
+            await conn.execute(
+                """UPDATE calls SET tool_call_count=tool_call_count+1, last_event_at=?
+                   WHERE call_id=?""",
+                (_iso_now(), call_id),
+            )
+            if latency_mark is not None:
+                await conn.execute(
+                    UPSERT_LATENCY_EVENT,
+                    (
+                        call_id,
+                        LatencyStage.TOOL_CALL_RECEIVED.value,
+                        event_key,
+                        latency_mark.occurred_at,
+                        latency_mark.monotonic_ns,
+                        self._latency_clock_id,
+                    ),
+                )
+            await conn.commit()
 
     async def reset_termination_claim(self, call_id: str) -> None:
         await self.execute(

--- a/app/finalizer.py
+++ b/app/finalizer.py
@@ -8,9 +8,9 @@ from typing import Any
 import httpx
 from openai import (
     APIConnectionError,
+    APIStatusError,
     APITimeoutError,
     AsyncOpenAI,
-    RateLimitError,
 )
 
 from app.db import Database
@@ -41,6 +41,14 @@ class Finalizer:
         if state == CallState.TIMED_OUT.value:
             return "timed_out"
         return "failed"
+
+    @staticmethod
+    def _retryable_extraction_error(exc: Exception) -> bool:
+        if isinstance(exc, (APIConnectionError, APITimeoutError)):
+            return True
+        if isinstance(exc, APIStatusError):
+            return exc.status_code in {408, 409, 429} or exc.status_code >= 500
+        return False
 
     async def finalize(self, call_id: str) -> StoredCallResult:
         lock = self._locks.setdefault(call_id, asyncio.Lock())
@@ -154,7 +162,6 @@ class Finalizer:
             "realtime_advisory_outcome": call.get("advisory_outcome"),
             "transcript": [turn.model_dump(mode="json") for turn in transcript],
         }
-        retryable = (APIConnectionError, APITimeoutError, RateLimitError)
         for attempt in range(2):
             try:
                 response = await self.openai.responses.parse(
@@ -163,6 +170,7 @@ class Finalizer:
                     input=json.dumps(payload, ensure_ascii=False),
                     text_format=ExtractedCallResult,
                     store=False,
+                    timeout=self.settings.openai_extraction_timeout_seconds,
                 )
                 parsed = response.output_parsed
                 if parsed is None:
@@ -176,8 +184,8 @@ class Finalizer:
                         if not set(item.evidence_turn_ids).issubset(evidence_ids):
                             raise ValueError("extractor cited an unknown transcript turn_id")
                 return parsed
-            except retryable:
-                if attempt == 0:
+            except Exception as exc:
+                if attempt == 0 and self._retryable_extraction_error(exc):
                     await asyncio.sleep(0.25)
                     continue
                 raise

--- a/app/main.py
+++ b/app/main.py
@@ -6,11 +6,11 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastmcp import FastMCP
-from openai import AsyncOpenAI
 
 from app.call_state import CallService
 from app.db import Database
 from app.mcp_tools import register_tools
+from app.openai_client import create_openai_client
 from app.routes import debug, deployment, openai_webhooks, twilio_webhooks
 from app.security import MCPAuthMiddleware
 from app.settings import Settings
@@ -45,24 +45,29 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         settings.require_runtime_configuration()
         db = Database(settings.database_path)
         await db.initialize()
-        openai = AsyncOpenAI(
-            api_key=Settings.reveal(settings.openai_api_key),
-            webhook_secret=Settings.reveal(settings.openai_webhook_secret),
-        )
-        service = CallService(settings, db, openai=openai)
-        holder["service"] = service
-        app.state.call_service = service
-        # Recovery happens before the server accepts traffic.
-        await service.recover_startup()
-        # A successful restart completes the deployment lease. Failed or canceled
-        # deployments are also bounded by the database lock's TTL.
-        await db.release_deployment_lock()
-        await service.start_watchdog()
-        async with mcp_http_app.lifespan(app):
-            yield
-        await service.stop()
-        await openai.close()
-        holder.clear()
+        openai = create_openai_client(settings)
+        service: CallService | None = None
+        try:
+            service = CallService(settings, db, openai=openai)
+            holder["service"] = service
+            app.state.call_service = service
+            # Recovery happens before the server accepts traffic.
+            await service.recover_startup()
+            # A successful restart completes the deployment lease. Failed or canceled
+            # deployments are also bounded by the database lock's TTL.
+            await db.release_deployment_lock()
+            await service.start_watchdog()
+            async with mcp_http_app.lifespan(app):
+                yield
+        finally:
+            try:
+                if service is not None:
+                    await service.stop()
+            finally:
+                try:
+                    await openai.close()
+                finally:
+                    holder.clear()
 
     app = FastAPI(title="Poke Phone-Call Bridge", version="1.0.0", lifespan=lifespan)
     app.state.settings = settings

--- a/app/main.py
+++ b/app/main.py
@@ -45,9 +45,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         settings.require_runtime_configuration()
         db = Database(settings.database_path)
         await db.initialize()
-        openai = create_openai_client(settings)
+        openai = None
         service: CallService | None = None
+        primary_error: BaseException | None = None
+        cleanup_errors: list[BaseException] = []
         try:
+            openai = create_openai_client(settings)
             service = CallService(settings, db, openai=openai)
             holder["service"] = service
             app.state.call_service = service
@@ -59,15 +62,37 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             await service.start_watchdog()
             async with mcp_http_app.lifespan(app):
                 yield
+        except BaseException as exc:
+            primary_error = exc
         finally:
-            try:
-                if service is not None:
-                    await service.stop()
-            finally:
+            cleanup_steps = []
+            if service is not None:
+                cleanup_steps.append(service.stop)
+            if openai is not None:
+                cleanup_steps.append(openai.close)
+            cleanup_steps.append(db.close)
+
+            for cleanup in cleanup_steps:
                 try:
-                    await openai.close()
-                finally:
-                    holder.clear()
+                    await cleanup()
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+            try:
+                holder.clear()
+            except BaseException as exc:  # pragma: no cover - dict.clear is defensive here
+                cleanup_errors.append(exc)
+
+        if primary_error is not None:
+            if cleanup_errors:
+                raise BaseExceptionGroup(
+                    "application lifespan failed and cleanup also failed",
+                    [primary_error, *cleanup_errors],
+                )
+            raise primary_error
+        if len(cleanup_errors) == 1:
+            raise cleanup_errors[0]
+        if cleanup_errors:
+            raise BaseExceptionGroup("application lifespan cleanup failed", cleanup_errors)
 
     app = FastAPI(title="Poke Phone-Call Bridge", version="1.0.0", lifespan=lifespan)
     app.state.settings = settings

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -19,6 +20,12 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
 )
+
+logger = logging.getLogger(__name__)
+
+# Each cleanup step must finish within this bound so a supervisor-issued cancel
+# (or a hung client) cannot stall shutdown indefinitely.
+LIFESPAN_CLEANUP_STEP_TIMEOUT_SECONDS = 15.0
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -65,6 +72,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         except BaseException as exc:
             primary_error = exc
         finally:
+            cancelled = isinstance(primary_error, asyncio.CancelledError)
             cleanup_steps = []
             if service is not None:
                 cleanup_steps.append(service.stop)
@@ -72,15 +80,32 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 cleanup_steps.append(openai.close)
             cleanup_steps.append(db.close)
 
+            # Cleanup steps are individually time-bounded and cancellation is
+            # tracked separately from ordinary failures: cancellation must keep
+            # running the remaining (now bounded) steps and ultimately propagate
+            # as CancelledError, never get swallowed or wrapped in a group, or an
+            # external cancel could not bound how long shutdown takes.
             for cleanup in cleanup_steps:
                 try:
-                    await cleanup()
+                    async with asyncio.timeout(LIFESPAN_CLEANUP_STEP_TIMEOUT_SECONDS):
+                        await cleanup()
+                except asyncio.CancelledError:
+                    cancelled = True
                 except BaseException as exc:
                     cleanup_errors.append(exc)
             try:
                 holder.clear()
             except BaseException as exc:  # pragma: no cover - dict.clear is defensive here
                 cleanup_errors.append(exc)
+
+        if cancelled:
+            # Cancellation wins the raise, so anything else that went wrong must be
+            # logged here or it is lost entirely.
+            if primary_error is not None and not isinstance(primary_error, asyncio.CancelledError):
+                logger.error("lifespan failed before cancellation", exc_info=primary_error)
+            for error in cleanup_errors:
+                logger.error("lifespan cleanup step failed during cancellation", exc_info=error)
+            raise asyncio.CancelledError
 
         if primary_error is not None:
             if cleanup_errors:

--- a/app/models.py
+++ b/app/models.py
@@ -193,7 +193,7 @@ class RealtimeAudioInput(BaseModel):
 class RealtimeAudioOutput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    voice: Literal["marin"] = "marin"
+    voice: Literal["echo"] = "echo"
     speed: float = Field(default=1.0, ge=0.25, le=1.5)
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -197,7 +197,7 @@ class SemanticVad(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["semantic_vad"] = "semantic_vad"
-    eagerness: Literal["low", "medium", "high", "auto"] = "high"
+    eagerness: Literal["low", "medium", "high", "auto"] = "auto"
     create_response: bool
     interrupt_response: bool
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Annotated, Any, Literal
@@ -7,6 +8,7 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
 
 E164 = Annotated[str, StringConstraints(pattern=r"^\+[1-9]\d{1,14}$")]
+CONTEXT_PACKET_MAX_BYTES = 16 * 1024
 
 
 def utc_now() -> datetime:
@@ -63,6 +65,25 @@ class ContextPacket(BaseModel):
     allowed_commitments: list[str] = Field(default_factory=list, max_length=100)
     prohibited_actions: list[str] = Field(default_factory=list, max_length=100)
     escalation: EscalationContext
+
+    def approved_context_json(self) -> str:
+        approved = json.dumps(
+            self.model_dump(mode="json"),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        size_bytes = len(approved.encode("utf-8"))
+        if size_bytes > CONTEXT_PACKET_MAX_BYTES:
+            raise ValueError(
+                "ContextPacket compact JSON exceeds "
+                f"{CONTEXT_PACKET_MAX_BYTES} UTF-8 bytes (received {size_bytes})"
+            )
+        return approved
+
+    @model_validator(mode="after")
+    def validate_serialized_size(self) -> ContextPacket:
+        self.approved_context_json()
+        return self
 
 
 class PreparePhoneCallInput(BaseModel):
@@ -176,7 +197,7 @@ class SemanticVad(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["semantic_vad"] = "semantic_vad"
-    eagerness: Literal["auto"] = "auto"
+    eagerness: Literal["low", "medium", "high", "auto"] = "high"
     create_response: bool
     interrupt_response: bool
 

--- a/app/openai_client.py
+++ b/app/openai_client.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import httpx
+from openai import AsyncOpenAI
+
+from app.settings import Settings
+
+
+def create_openai_client(settings: Settings) -> AsyncOpenAI:
+    """Build the shared OpenAI client with bounded control-plane requests.
+
+    The SDK owns and closes a custom HTTPX client passed through ``http_client``.
+    Keep the SDK's normal connection-pool policy unless an explicit keepalive
+    expiry is configured for a measured deployment experiment.
+    """
+    timeout = httpx.Timeout(
+        settings.openai_http_timeout_seconds,
+        connect=settings.openai_connect_timeout_seconds,
+    )
+    options: dict[str, object] = {
+        "api_key": Settings.reveal(settings.openai_api_key),
+        "webhook_secret": Settings.reveal(settings.openai_webhook_secret),
+        "timeout": timeout,
+        "max_retries": 0,
+    }
+    if settings.openai_keepalive_expiry_seconds is not None:
+        options["http_client"] = httpx.AsyncClient(
+            timeout=timeout,
+            follow_redirects=True,
+            limits=httpx.Limits(
+                max_connections=1000,
+                max_keepalive_connections=100,
+                keepalive_expiry=settings.openai_keepalive_expiry_seconds,
+            ),
+        )
+    return AsyncOpenAI(**options)

--- a/app/openai_client.py
+++ b/app/openai_client.py
@@ -10,8 +10,8 @@ def create_openai_client(settings: Settings) -> AsyncOpenAI:
     """Build the shared OpenAI client with bounded control-plane requests.
 
     The SDK owns and closes a custom HTTPX client passed through ``http_client``.
-    Keep the SDK's normal connection-pool policy unless an explicit keepalive
-    expiry is configured for a measured deployment experiment.
+    Use the configured keepalive expiry (60 seconds by default) so sporadic calls
+    can reuse a measured-warm TLS connection. ``None`` retains the SDK pool policy.
     """
     timeout = httpx.Timeout(
         settings.openai_http_timeout_seconds,

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 from collections.abc import Awaitable, Callable
@@ -30,6 +31,8 @@ REALTIME_MEDIA_DRAIN_SECONDS = 1.5
 REALTIME_CLOSE_TIMEOUT_SECONDS = 2.5
 REALTIME_TASK_DRAIN_TIMEOUT_SECONDS = 2.0
 REALTIME_TASK_CANCEL_TIMEOUT_SECONDS = 1.0
+REALTIME_SEND_TIMEOUT_SECONDS = 10.0
+REALTIME_SHUTDOWN_FINAL_TIMEOUT_SECONDS = 10.0
 _EVENT_QUEUE_CLOSED = object()
 
 
@@ -164,6 +167,13 @@ class RealtimeBridge:
                 exc.status_code,
                 dict(exc.response.headers),
                 exc.response.text,
+            )
+            raise
+        except TimeoutError:
+            logger.error(
+                "OpenAI call accept timed out call_id=%s timeout=%ss",
+                call_id,
+                self.settings.openai_http_timeout_seconds,
             )
             raise
         # The accept response is bodyless today; log every non-secret response field.
@@ -375,7 +385,10 @@ class RealtimeBridge:
                 if websocket is None:
                     raise RuntimeError("sideband is not open")
                 for event, payload in serialized:
-                    await websocket.send(payload)
+                    # An unbounded stalled send makes the sender cancellation-proof via
+                    # _send_batch's shield loop, so bound every write on the wire.
+                    async with asyncio.timeout(REALTIME_SEND_TIMEOUT_SECONDS):
+                        await websocket.send(payload)
                     sent.append(event)
         finally:
             await self._notify_sent(call_id, sent)
@@ -393,7 +406,10 @@ class RealtimeBridge:
             if websocket is None:
                 raise RuntimeError("sideband is not open")
             for event, payload in serialized:
-                await websocket.send(payload)
+                # An unbounded stalled send makes the sender cancellation-proof via
+                # _send_batch's shield loop, so bound every write on the wire.
+                async with asyncio.timeout(REALTIME_SEND_TIMEOUT_SECONDS):
+                    await websocket.send(payload)
                 sent.append(event)
         except BaseException as exc:
             failure = exc
@@ -638,8 +654,10 @@ class RealtimeBridge:
 
         # drain_and_close deliberately retains a cancellation-resistant runtime so
         # a later teardown can see it. Application shutdown has no later owner, so
-        # make one final bounded cancellation pass and keep dependencies open until
-        # every supervisor has actually returned.
+        # make one final bounded cancellation pass. A stalled send (see
+        # REALTIME_SEND_TIMEOUT_SECONDS) can still outlive cancellation briefly, so this
+        # wait itself is bounded rather than left to hang process shutdown; any task still
+        # outstanding after the timeout is logged and abandoned rather than awaited further.
         remaining = tuple(self._runtime.values())
         tasks = {
             task
@@ -655,7 +673,18 @@ class RealtimeBridge:
         for task in tasks:
             task.cancel()
         if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+            done, pending = await asyncio.wait(
+                tasks, timeout=REALTIME_SHUTDOWN_FINAL_TIMEOUT_SECONDS
+            )
+            for task in done:
+                with contextlib.suppress(asyncio.CancelledError):
+                    task.exception()
+            if pending:
+                logger.error(
+                    "Realtime shutdown gave up waiting for %d task(s) to stop: %s",
+                    len(pending),
+                    ", ".join(sorted(task.get_name() for task in pending)),
+                )
         for runtime in remaining:
             if runtime.task is None or runtime.task.done():
                 self._runtime.pop(runtime.call_id, None)

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -21,6 +21,20 @@ OpenHandler = Callable[[str], Awaitable[None]]
 FatalHandler = Callable[[str, str], Awaitable[None]]
 SendHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
 
+# Realtime events are normally consumed as quickly as they arrive. A bounded queue protects a
+# call from unbounded memory growth if application handling stalls while still leaving ample room
+# for short bursts of audio/transcript events.
+REALTIME_EVENT_QUEUE_MAXSIZE = 512
+REALTIME_MEDIA_DRAIN_SECONDS = 1.5
+REALTIME_CLOSE_TIMEOUT_SECONDS = 2.5
+REALTIME_TASK_DRAIN_TIMEOUT_SECONDS = 2.0
+REALTIME_TASK_CANCEL_TIMEOUT_SECONDS = 1.0
+_EVENT_QUEUE_CLOSED = object()
+
+
+class RealtimeEventQueueOverflow(RuntimeError):
+    """Raised when application event handling cannot keep up with the sideband stream."""
+
 
 @dataclass(slots=True)
 class RealtimeRuntime:
@@ -31,7 +45,14 @@ class RealtimeRuntime:
     send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     update_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     update_waiter: asyncio.Future[dict[str, Any]] | None = None
+    event_queue: asyncio.Queue[Any] = field(
+        default_factory=lambda: asyncio.Queue(maxsize=REALTIME_EVENT_QUEUE_MAXSIZE)
+    )
+    open_task: asyncio.Task[None] | None = None
+    receiver_task: asyncio.Task[None] | None = None
+    dispatcher_task: asyncio.Task[None] | None = None
     closing: bool = False
+    stop_after_current: bool = False
 
 
 class RealtimeBridge:
@@ -160,6 +181,8 @@ class RealtimeBridge:
     async def _run(self, runtime: RealtimeRuntime) -> None:
         url = f"wss://api.openai.com/v1/realtime?call_id={runtime.openai_call_id}"
         receiver: asyncio.Task[None] | None = None
+        dispatcher: asyncio.Task[None] | None = None
+        open_task: asyncio.Task[None] | None = None
         try:
             async with websockets.connect(
                 url,
@@ -170,6 +193,9 @@ class RealtimeBridge:
                 close_timeout=2,
             ) as websocket:
                 runtime.websocket = websocket
+                # A runtime is single-use today, but resetting here makes the lifecycle explicit
+                # and prevents stale queued events if that ever changes.
+                runtime.event_queue = asyncio.Queue(maxsize=REALTIME_EVENT_QUEUE_MAXSIZE)
                 # The SIP session already exists by the time this sideband attaches, so its
                 # session.created event may not be replayed. Start receiving before on_open so
                 # that the readiness handshake can send session.update and await session.updated.
@@ -177,8 +203,41 @@ class RealtimeBridge:
                     self._receive_events(runtime, websocket),
                     name=f"sideband-receiver:{runtime.call_id}",
                 )
-                await self.on_open(runtime.call_id)
-                await receiver
+                dispatcher = asyncio.create_task(
+                    self._dispatch_events(runtime),
+                    name=f"sideband-dispatcher:{runtime.call_id}",
+                )
+                runtime.receiver_task = receiver
+                runtime.dispatcher_task = dispatcher
+
+                # Supervise on_open as well: it may be awaiting the session.updated readiness
+                # echo, while either event task may fail independently.
+                open_task = asyncio.create_task(
+                    self.on_open(runtime.call_id),
+                    name=f"sideband-open:{runtime.call_id}",
+                )
+                runtime.open_task = open_task
+                done, _ = await asyncio.wait(
+                    {open_task, receiver, dispatcher},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if open_task not in done:
+                    # on_open may intentionally terminate the call. Its teardown closes the
+                    # websocket from this child task; let that child finish instead of treating
+                    # the resulting receiver close as a readiness failure and canceling it.
+                    if runtime.closing:
+                        await open_task
+                        if runtime.stop_after_current:
+                            return
+                        await self._supervise_event_tasks(receiver, dispatcher)
+                        return
+                    failed = receiver if receiver in done else dispatcher
+                    await failed
+                    raise RuntimeError("Realtime sideband closed before readiness completed")
+                await open_task
+                if runtime.stop_after_current:
+                    return
+                await self._supervise_event_tasks(receiver, dispatcher)
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -186,10 +245,15 @@ class RealtimeBridge:
                 logger.exception("Realtime sideband failed for %s", runtime.call_id)
                 await self.on_fatal(runtime.call_id, f"sideband_error:{type(exc).__name__}")
         finally:
-            if receiver is not None and not receiver.done():
-                receiver.cancel()
-                await asyncio.gather(receiver, return_exceptions=True)
+            tasks = [task for task in (open_task, receiver, dispatcher) if task is not None]
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
             runtime.websocket = None
+            if runtime.closing and self._runtime.get(runtime.call_id) is runtime:
+                self._runtime.pop(runtime.call_id, None)
 
     async def _receive_events(self, runtime: RealtimeRuntime, websocket: Any) -> None:
         async for message in websocket:
@@ -197,7 +261,47 @@ class RealtimeBridge:
             if event.get("type") == "session.updated" and runtime.update_waiter:
                 if not runtime.update_waiter.done():
                     runtime.update_waiter.set_result(event)
-            await self.on_event(runtime.call_id, event)
+            try:
+                runtime.event_queue.put_nowait(event)
+            except asyncio.QueueFull as exc:
+                raise RealtimeEventQueueOverflow(
+                    f"Realtime event queue exceeded {REALTIME_EVENT_QUEUE_MAXSIZE} events"
+                ) from exc
+
+        # A normal websocket close drains events already accepted by the reader before stopping
+        # the dispatcher. This control marker is not an incoming event, so waiting for capacity is
+        # safe and must not be treated as an overflow.
+        await runtime.event_queue.put(_EVENT_QUEUE_CLOSED)
+
+    async def _dispatch_events(self, runtime: RealtimeRuntime) -> None:
+        while True:
+            event = await runtime.event_queue.get()
+            try:
+                if event is _EVENT_QUEUE_CLOSED:
+                    return
+                await self.on_event(runtime.call_id, event)
+                if runtime.stop_after_current:
+                    return
+            finally:
+                runtime.event_queue.task_done()
+
+    @staticmethod
+    async def _supervise_event_tasks(
+        receiver: asyncio.Task[None], dispatcher: asyncio.Task[None]
+    ) -> None:
+        done, _ = await asyncio.wait(
+            {receiver, dispatcher},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if dispatcher in done:
+            # A dispatcher failure must immediately stop the reader. A successful dispatcher can
+            # only consume its close marker after the reader has reached a clean websocket close.
+            await dispatcher
+            if not receiver.done():
+                raise RuntimeError("Realtime dispatcher stopped before the receiver")
+
+        await receiver
+        await dispatcher
 
     async def send(self, call_id: str, event: dict[str, Any]) -> None:
         runtime = self._runtime.get(call_id)
@@ -360,14 +464,61 @@ class RealtimeBridge:
         if runtime is None:
             return
         runtime.closing = True
-        await asyncio.sleep(1.5)
-        if runtime.websocket is not None:
-            await runtime.websocket.close()
+        await asyncio.sleep(REALTIME_MEDIA_DRAIN_SECONDS)
         current = asyncio.current_task()
-        if runtime.task and runtime.task is not current and not runtime.task.done():
-            runtime.task.cancel()
-            await asyncio.gather(runtime.task, return_exceptions=True)
-        self._runtime.pop(call_id, None)
+        runtime_tasks = {
+            task
+            for task in (
+                runtime.task,
+                runtime.open_task,
+                runtime.receiver_task,
+                runtime.dispatcher_task,
+            )
+            if task is not None
+        }
+        close_error: BaseException | None = None
+        if runtime.websocket is not None:
+            try:
+                await asyncio.wait_for(
+                    runtime.websocket.close(), timeout=REALTIME_CLOSE_TIMEOUT_SECONDS
+                )
+            except TimeoutError as exc:
+                close_error = exc
+                logger.warning("timed out closing Realtime websocket call_id=%s", call_id)
+            except Exception as exc:
+                close_error = exc
+                logger.warning(
+                    "failed to close Realtime websocket call_id=%s", call_id, exc_info=True
+                )
+
+        if current in runtime_tasks:
+            # The supervisor owns child cancellation. Awaiting or canceling it from one of its
+            # own children creates a parent/child cancellation cycle; normal websocket close will
+            # instead let the reader and FIFO dispatcher finish under _run's supervision.
+            if close_error is not None:
+                # The current callback may still need to persist terminal state and schedule its
+                # finalizer after drain_and_close returns. Let it finish, then have on_open/_run or
+                # the dispatcher stop at the callback boundary so the supervisor can clean up.
+                runtime.stop_after_current = True
+            return
+
+        task = runtime.task
+        if task is not None and not task.done():
+            done, _ = await asyncio.wait({task}, timeout=REALTIME_TASK_DRAIN_TIMEOUT_SECONDS)
+            if not done:
+                task.cancel()
+                done, _ = await asyncio.wait({task}, timeout=REALTIME_TASK_CANCEL_TIMEOUT_SECONDS)
+                if not done:
+                    # asyncio cannot forcibly destroy a cancellation-resistant task. Keep the
+                    # runtime registered so a later teardown can retry rather than hiding a leak.
+                    logger.error(
+                        "Realtime sideband did not stop after cancellation call_id=%s", call_id
+                    )
+                    return
+            await asyncio.gather(task, return_exceptions=True)
+
+        if self._runtime.get(call_id) is runtime:
+            self._runtime.pop(call_id, None)
 
     def expected_transcription_echoed(self, event: dict[str, Any]) -> bool:
         session = event.get("session", {})

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -56,7 +56,7 @@ class RealtimeBridge:
             audio={
                 "input": self._input_audio_config(create_response=False, interrupt_response=False),
                 "output": {
-                    "voice": "marin",
+                    "voice": "echo",
                     "speed": 1.0,
                 },
             },

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -20,6 +20,7 @@ EventHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
 OpenHandler = Callable[[str], Awaitable[None]]
 FatalHandler = Callable[[str, str], Awaitable[None]]
 SendHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
+ActivityHandler = Callable[[str], None]
 
 # Realtime events are normally consumed as quickly as they arrive. A bounded queue protects a
 # call from unbounded memory growth if application handling stalls while still leaving ample room
@@ -65,6 +66,7 @@ class RealtimeBridge:
         on_open: OpenHandler,
         on_fatal: FatalHandler,
         on_send: SendHandler | None = None,
+        on_activity: ActivityHandler | None = None,
     ):
         self.settings = settings
         self.client = client
@@ -72,6 +74,7 @@ class RealtimeBridge:
         self.on_open = on_open
         self.on_fatal = on_fatal
         self.on_send = on_send
+        self.on_activity = on_activity
         self._runtime: dict[str, RealtimeRuntime] = {}
 
     def build_accept_payload(self, packet: ContextPacket) -> AcceptPayload:
@@ -258,6 +261,11 @@ class RealtimeBridge:
     async def _receive_events(self, runtime: RealtimeRuntime, websocket: Any) -> None:
         async for message in websocket:
             event = json.loads(message)
+            # Record liveness on the reader fast path. Application dispatch may be
+            # intentionally backlogged, but a frame already read from the socket is
+            # authoritative evidence that the call is still alive.
+            if self.on_activity is not None:
+                self.on_activity(runtime.call_id)
             if event.get("type") == "session.updated" and runtime.update_waiter:
                 if not runtime.update_waiter.done():
                     runtime.update_waiter.set_result(event)
@@ -304,12 +312,102 @@ class RealtimeBridge:
         await dispatcher
 
     async def send(self, call_id: str, event: dict[str, Any]) -> None:
+        await self._send_batch(call_id, [event])
+
+    async def _send_batch(self, call_id: str, events: list[dict[str, Any]]) -> None:
+        serialized = [(event, json.dumps(event)) for event in events]
+        if not serialized:
+            return
         runtime = self._runtime.get(call_id)
-        if runtime is None or runtime.websocket is None:
+        if runtime is None:
             raise RuntimeError("sideband is not open")
-        async with runtime.send_lock:
-            await runtime.websocket.send(json.dumps(event))
-        if self.on_send is not None:
+
+        # Single control frames retain normal asyncio cancellation semantics. Only
+        # a multi-frame protocol pair needs cancellation shielding after it starts.
+        if len(serialized) == 1:
+            await self._send_locked_batch(call_id, runtime, serialized)
+            return
+
+        # Waiting for ownership is still normally cancellable. Once acquired,
+        # however, the protocol pair must either finish or hit a wire failure.
+        await runtime.send_lock.acquire()
+        try:
+            send_task = asyncio.create_task(
+                self._send_owned_batch(call_id, runtime, serialized),
+                name=f"sideband-send:{call_id}",
+            )
+        except BaseException:
+            runtime.send_lock.release()
+            raise
+        interrupted = False
+        while not send_task.done():
+            try:
+                await asyncio.shield(send_task)
+            except asyncio.CancelledError:
+                # Once a batch is eligible to write, cancellation cannot split its
+                # function output from its continuation. Re-raise only after the
+                # shielded sender has released the per-call lock and recorded every
+                # frame that actually reached the websocket.
+                interrupted = True
+            except BaseException:
+                break
+
+        failure: BaseException | None = None
+        try:
+            send_task.result()
+        except BaseException as exc:
+            failure = exc
+        if interrupted:
+            raise asyncio.CancelledError
+        if failure is not None:
+            raise failure
+
+    async def _send_locked_batch(
+        self,
+        call_id: str,
+        runtime: RealtimeRuntime,
+        serialized: list[tuple[dict[str, Any], str]],
+    ) -> None:
+        sent: list[dict[str, Any]] = []
+        try:
+            async with runtime.send_lock:
+                websocket = runtime.websocket
+                if websocket is None:
+                    raise RuntimeError("sideband is not open")
+                for event, payload in serialized:
+                    await websocket.send(payload)
+                    sent.append(event)
+        finally:
+            await self._notify_sent(call_id, sent)
+
+    async def _send_owned_batch(
+        self,
+        call_id: str,
+        runtime: RealtimeRuntime,
+        serialized: list[tuple[dict[str, Any], str]],
+    ) -> None:
+        sent: list[dict[str, Any]] = []
+        failure: BaseException | None = None
+        try:
+            websocket = runtime.websocket
+            if websocket is None:
+                raise RuntimeError("sideband is not open")
+            for event, payload in serialized:
+                await websocket.send(payload)
+                sent.append(event)
+        except BaseException as exc:
+            failure = exc
+        finally:
+            runtime.send_lock.release()
+
+        await self._notify_sent(call_id, sent)
+        if failure is not None:
+            raise failure
+
+    async def _notify_sent(self, call_id: str, events: list[dict[str, Any]]) -> None:
+        if self.on_send is None:
+            return
+        for event in events:
             try:
                 await self.on_send(call_id, event)
             except Exception:
@@ -418,8 +516,7 @@ class RealtimeBridge:
         continue_response: bool = True,
         continuation_instructions: str | None = None,
     ) -> None:
-        await self.send(
-            call_id,
+        events: list[dict[str, Any]] = [
             {
                 "type": "conversation.item.create",
                 "item": {
@@ -427,8 +524,8 @@ class RealtimeBridge:
                     "call_id": tool_call_id,
                     "output": json.dumps(output),
                 },
-            },
-        )
+            }
+        ]
         if continue_response:
             continuation: dict[str, Any] = {"type": "response.create"}
             if continuation_instructions:
@@ -436,7 +533,8 @@ class RealtimeBridge:
                     "output_modalities": ["audio"],
                     "instructions": continuation_instructions,
                 }
-            await self.send(call_id, continuation)
+            events.append(continuation)
+        await self._send_batch(call_id, events)
 
     async def hangup(self, openai_call_id: str | None) -> None:
         if not openai_call_id:

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -129,9 +129,10 @@ class RealtimeBridge:
     ) -> int:
         payload = self.build_accept_payload(packet)
         try:
-            raw = await self.client.realtime.calls.with_raw_response.accept(
-                openai_call_id, **payload.model_dump(exclude_none=True)
-            )
+            async with asyncio.timeout(self.settings.openai_http_timeout_seconds):
+                raw = await self.client.realtime.calls.with_raw_response.accept(
+                    openai_call_id, **payload.model_dump(exclude_none=True)
+                )
         except APIStatusError as exc:
             logger.error(
                 "OpenAI call accept response call_id=%s status=%s headers=%s body=%r",
@@ -256,7 +257,7 @@ class RealtimeBridge:
             "transcription": self._transcription_config(),
             "turn_detection": {
                 "type": "semantic_vad",
-                "eagerness": "auto",
+                "eagerness": self.settings.semantic_vad_eagerness,
                 "create_response": create_response,
                 "interrupt_response": interrupt_response,
             },
@@ -376,17 +377,20 @@ class RealtimeBridge:
         expected_delay = self.settings.input_transcription_delay
         return expected_delay is None or transcription.get("delay") == expected_delay
 
-    @staticmethod
-    def expected_initial_vad_echoed(event: dict[str, Any]) -> bool:
+    def expected_initial_vad_echoed(self, event: dict[str, Any]) -> bool:
         turn = event.get("session", {}).get("audio", {}).get("input", {}).get("turn_detection", {})
         return (
             turn.get("type") == "semantic_vad"
-            and turn.get("eagerness") == "auto"
+            and turn.get("eagerness") == self.settings.semantic_vad_eagerness
             and turn.get("create_response") is False
             and turn.get("interrupt_response") is False
         )
 
-    @staticmethod
-    def activation_update_confirmed(event: dict[str, Any]) -> bool:
+    def activation_update_confirmed(self, event: dict[str, Any]) -> bool:
         turn = event.get("session", {}).get("audio", {}).get("input", {}).get("turn_detection", {})
-        return turn.get("create_response") is True and turn.get("interrupt_response") is True
+        return (
+            turn.get("type") == "semantic_vad"
+            and turn.get("eagerness") == self.settings.semantic_vad_eagerness
+            and turn.get("create_response") is True
+            and turn.get("interrupt_response") is True
+        )

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -618,6 +618,48 @@ class RealtimeBridge:
         if self._runtime.get(call_id) is runtime:
             self._runtime.pop(call_id, None)
 
+    async def close_all(self) -> None:
+        """Stop every sideband runtime before its callback dependencies are closed."""
+
+        if not self._runtime:
+            return
+        call_ids = tuple(self._runtime)
+        results = await asyncio.gather(
+            *(self.drain_and_close(call_id) for call_id in call_ids),
+            return_exceptions=True,
+        )
+        for call_id, result in zip(call_ids, results, strict=True):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "failed to close Realtime runtime call_id=%s",
+                    call_id,
+                    exc_info=(type(result), result, result.__traceback__),
+                )
+
+        # drain_and_close deliberately retains a cancellation-resistant runtime so
+        # a later teardown can see it. Application shutdown has no later owner, so
+        # make one final bounded cancellation pass and keep dependencies open until
+        # every supervisor has actually returned.
+        remaining = tuple(self._runtime.values())
+        tasks = {
+            task
+            for runtime in remaining
+            for task in (
+                runtime.task,
+                runtime.open_task,
+                runtime.receiver_task,
+                runtime.dispatcher_task,
+            )
+            if task is not None and not task.done()
+        }
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        for runtime in remaining:
+            if runtime.task is None or runtime.task.done():
+                self._runtime.pop(runtime.call_id, None)
+
     def expected_transcription_echoed(self, event: dict[str, Any]) -> bool:
         session = event.get("session", {})
         transcription = session.get("audio", {}).get("input", {}).get("transcription") or {}

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 EventHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
 OpenHandler = Callable[[str], Awaitable[None]]
 FatalHandler = Callable[[str, str], Awaitable[None]]
+SendHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
 
 
 @dataclass(slots=True)
@@ -42,12 +43,14 @@ class RealtimeBridge:
         on_event: EventHandler,
         on_open: OpenHandler,
         on_fatal: FatalHandler,
+        on_send: SendHandler | None = None,
     ):
         self.settings = settings
         self.client = client
         self.on_event = on_event
         self.on_open = on_open
         self.on_fatal = on_fatal
+        self.on_send = on_send
         self._runtime: dict[str, RealtimeRuntime] = {}
 
     def build_accept_payload(self, packet: ContextPacket) -> AcceptPayload:
@@ -201,6 +204,17 @@ class RealtimeBridge:
             raise RuntimeError("sideband is not open")
         async with runtime.send_lock:
             await runtime.websocket.send(json.dumps(event))
+        if self.on_send is not None:
+            try:
+                await self.on_send(call_id, event)
+            except Exception:
+                # Telemetry must never turn a successfully sent Realtime event into a call failure.
+                logger.warning(
+                    "failed to record outbound Realtime event call_id=%s type=%s",
+                    call_id,
+                    event.get("type"),
+                    exc_info=True,
+                )
 
     async def _update_session(self, call_id: str, audio_input: dict[str, Any]) -> dict[str, Any]:
         runtime = self._runtime.get(call_id)

--- a/app/prompts.py
+++ b/app/prompts.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import json
-
 from app.models import ContextPacket
+
+REALTIME_INSTRUCTIONS_MAX_BYTES = 20 * 1024
 
 
 def realtime_instructions(packet: ContextPacket) -> str:
-    approved = json.dumps(packet.model_dump(mode="json"), ensure_ascii=False)
-    return f"""# Objective
+    approved = packet.approved_context_json()
+    instructions = f"""# Objective
 Complete only the approved objective in the context below.
 Choose how to open the call from the approved context; the application does not prescribe an opening.
 
@@ -41,6 +41,13 @@ Use end_call when the conversation is finished; the application coordinates the 
 # Approved context
 {approved}
 """
+    size_bytes = len(instructions.encode("utf-8"))
+    if size_bytes > REALTIME_INSTRUCTIONS_MAX_BYTES:
+        raise ValueError(
+            "Realtime instructions exceed "
+            f"{REALTIME_INSTRUCTIONS_MAX_BYTES} UTF-8 bytes (received {size_bytes})"
+        )
+    return instructions
 
 
 EXTRACTOR_INSTRUCTIONS = """Extract a conservative structured call result.

--- a/app/routes/debug.py
+++ b/app/routes/debug.py
@@ -15,6 +15,7 @@ async def get_call(call_id: str, request: Request):
         raise HTTPException(status_code=404, detail="call not found") from exc
     row = await request.app.state.call_service.db.get_call(call_id)
     transcript = await request.app.state.call_service.db.get_transcript(call_id)
+    latency_events = await request.app.state.call_service.db.get_latency_events(call_id)
     audit_keys = {
         "openai_accept_status",
         "transcription_verified",
@@ -40,6 +41,7 @@ async def get_call(call_id: str, request: Request):
     return {
         **snapshot.model_dump(mode="json"),
         "canary_evidence": {key: row.get(key) for key in audit_keys},
+        "latency_events": latency_events,
         "transcript": [turn.model_dump(mode="json") for turn in transcript],
     }
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
     twilio_account_sid: str | None = None
     twilio_auth_token: SecretStr | None = None
     twilio_caller_id: str | None = None
+    twilio_http_timeout_seconds: float = Field(default=10.0, gt=0, le=60)
     owner_phone_e164: str | None = None
     allowed_poke_user_id: str | None = None
     mcp_bearer_token: SecretStr | None = None
@@ -46,6 +47,11 @@ class Settings(BaseSettings):
     allowed_country_codes: list[str] = Field(default_factory=lambda: ["+1"])
     input_transcription_model: str = "gpt-4o-mini-transcribe"
     input_transcription_delay: str | None = None
+    semantic_vad_eagerness: Literal["low", "medium", "high", "auto"] = "high"
+    openai_connect_timeout_seconds: float = Field(default=3.0, gt=0, le=30)
+    openai_http_timeout_seconds: float = Field(default=10.0, gt=0, le=60)
+    openai_keepalive_expiry_seconds: float | None = Field(default=None, ge=5, le=300)
+    openai_extraction_timeout_seconds: float = Field(default=30.0, gt=0, le=120)
     extractor_model: str = "gpt-5.4-nano-2026-03-17"
     database_url: str = "sqlite:///./poke_call.db"
     public_base_url: str | None = None
@@ -113,6 +119,10 @@ class Settings(BaseSettings):
                 raise ValueError("invalid INPUT_TRANSCRIPTION_DELAY")
         if self.mini_models_enabled:
             raise ValueError("mini realtime models are release-gated and disabled in v1")
+        if self.openai_connect_timeout_seconds > self.openai_http_timeout_seconds:
+            raise ValueError(
+                "OPENAI_CONNECT_TIMEOUT_SECONDS cannot exceed OPENAI_HTTP_TIMEOUT_SECONDS"
+            )
         return self
 
     @cached_property

--- a/app/settings.py
+++ b/app/settings.py
@@ -50,7 +50,7 @@ class Settings(BaseSettings):
     semantic_vad_eagerness: Literal["low", "medium", "high", "auto"] = "high"
     openai_connect_timeout_seconds: float = Field(default=3.0, gt=0, le=30)
     openai_http_timeout_seconds: float = Field(default=10.0, gt=0, le=60)
-    openai_keepalive_expiry_seconds: float | None = Field(default=None, ge=5, le=300)
+    openai_keepalive_expiry_seconds: float | None = Field(default=60.0, ge=5, le=300)
     openai_extraction_timeout_seconds: float = Field(default=30.0, gt=0, le=120)
     extractor_model: str = "gpt-5.4-nano-2026-03-17"
     database_url: str = "sqlite:///./poke_call.db"

--- a/app/settings.py
+++ b/app/settings.py
@@ -47,7 +47,7 @@ class Settings(BaseSettings):
     allowed_country_codes: list[str] = Field(default_factory=lambda: ["+1"])
     input_transcription_model: str = "gpt-4o-mini-transcribe"
     input_transcription_delay: str | None = None
-    semantic_vad_eagerness: Literal["low", "medium", "high", "auto"] = "high"
+    semantic_vad_eagerness: Literal["low", "medium", "high", "auto"] = "auto"
     openai_connect_timeout_seconds: float = Field(default=3.0, gt=0, le=30)
     openai_http_timeout_seconds: float = Field(default=10.0, gt=0, le=60)
     openai_keepalive_expiry_seconds: float | None = Field(default=60.0, ge=5, le=300)

--- a/app/twilio_bridge.py
+++ b/app/twilio_bridge.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass
 from urllib.parse import urlencode
 
+from twilio.base.exceptions import TwilioRestException
 from twilio.http.http_client import TwilioHttpClient
 from twilio.rest import Client
 
@@ -149,7 +150,14 @@ class TwilioBridge:
         def complete() -> None:
             self.client.conferences(conference_sid_or_name).update(status="completed")
 
-        await asyncio.to_thread(complete)
+        try:
+            await asyncio.to_thread(complete)
+        except TwilioRestException as exc:
+            # A missing conference is already fully torn down, which is the desired
+            # idempotent outcome for retry and startup recovery paths.
+            if exc.status == 404:
+                return
+            raise
 
     async def remove_participant(
         self, conference_sid_or_name: str | None, participant_call_sid: str | None
@@ -163,6 +171,21 @@ class TwilioBridge:
             ).delete()
 
         await asyncio.to_thread(remove)
+
+    async def enable_end_conference_on_exit(
+        self, conference_sid_or_name: str | None, participant_call_sid: str | None
+    ) -> None:
+        """Make the transferred owner leg the conference lifetime owner."""
+
+        if not conference_sid_or_name or not participant_call_sid:
+            return
+
+        def enable() -> None:
+            self.client.conferences(conference_sid_or_name).participants(
+                participant_call_sid
+            ).update(end_conference_on_exit=True)
+
+        await asyncio.to_thread(enable)
 
     async def unmute_participant(
         self, conference_sid_or_name: str | None, participant_call_sid: str | None

--- a/app/twilio_bridge.py
+++ b/app/twilio_bridge.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass
 from urllib.parse import urlencode
 
+from twilio.http.http_client import TwilioHttpClient
 from twilio.rest import Client
 
 from app.models import ContextPacket
@@ -22,6 +23,11 @@ class TwilioBridge:
         self.client = client or Client(
             settings.twilio_account_sid,
             Settings.reveal(settings.twilio_auth_token),
+            http_client=TwilioHttpClient(
+                pool_connections=True,
+                timeout=settings.twilio_http_timeout_seconds,
+                max_retries=0,
+            ),
         )
 
     def _callback(self, path: str, *, call_id: str, plan_id: str, **extra: str) -> str:
@@ -49,6 +55,7 @@ class TwilioBridge:
                 # while the agent is alone on hold before the callee joins.
                 early_media=False,
                 muted=False,
+                jitter_buffer_size="small",
                 status_callback=self._callback(
                     "/webhooks/twilio/participant-status",
                     call_id=call_id,
@@ -87,6 +94,7 @@ class TwilioBridge:
                 beep="false",
                 timeout=self.settings.setup_deadline_seconds,
                 machine_detection="DetectMessageEnd",
+                jitter_buffer_size="small",
                 amd_status_callback=self._callback(
                     "/webhooks/twilio/amd", call_id=call_id, plan_id=plan_id
                 ),
@@ -121,6 +129,7 @@ class TwilioBridge:
                 time_limit=self.settings.max_call_seconds,
                 timeout=30,
                 beep="false",
+                jitter_buffer_size="small",
                 status_callback=self._callback(
                     "/webhooks/twilio/participant-status",
                     call_id=call_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,6 +289,9 @@ async def seed_call(
         confirmation_text="Confirmed",
     )
     assert claimed
+    # Every state past PREWARMING is only reachable in production after the callee has
+    # answered, so default callee_joined accordingly. Callers testing the pre-answer
+    # window keep the default PREWARMING state and set callee_joined explicitly.
     await db.update_call(
         call_id,
         state=state.value,
@@ -298,6 +301,7 @@ async def seed_call(
         openai_call_id=openai_call_id,
         transcription_verified=1,
         semantic_vad_verified=1,
+        callee_joined=int(state != CallState.PREWARMING),
     )
     return call_id
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,8 @@ class FakeRealtime:
                 "audio": {
                     "input": {
                         "turn_detection": {
+                            "type": "semantic_vad",
+                            "eagerness": "high",
                             "create_response": True,
                             "interrupt_response": True,
                         }
@@ -134,7 +136,7 @@ class FakeRealtime:
                         "transcription": {"model": "gpt-4o-mini-transcribe"},
                         "turn_detection": {
                             "type": "semantic_vad",
-                            "eagerness": "auto",
+                            "eagerness": "high",
                             "create_response": False,
                             "interrupt_response": False,
                         },
@@ -157,10 +159,14 @@ class FakeRealtime:
         self.accepts.append((call_id, openai_call_id))
         return 200
 
-    @staticmethod
-    def activation_update_confirmed(event):
+    def activation_update_confirmed(self, event):
         turn = event["session"]["audio"]["input"]["turn_detection"]
-        return turn["create_response"] is True and turn["interrupt_response"] is True
+        return (
+            turn["type"] == "semantic_vad"
+            and turn["eagerness"] == "high"
+            and turn["create_response"] is True
+            and turn["interrupt_response"] is True
+        )
 
     async def create_opening(self, call_id: str) -> None:
         self.events.append(("opening", call_id))
@@ -205,7 +211,7 @@ class FakeRealtime:
         turn = event.get("session", {}).get("audio", {}).get("input", {}).get("turn_detection", {})
         return (
             turn.get("type") == "semantic_vad"
-            and turn.get("eagerness") == "auto"
+            and turn.get("eagerness") == "high"
             and turn.get("create_response") is False
             and turn.get("interrupt_response") is False
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,7 +137,7 @@ class FakeRealtime:
                     "input": {
                         "turn_detection": {
                             "type": "semantic_vad",
-                            "eagerness": "high",
+                            "eagerness": "auto",
                             "create_response": True,
                             "interrupt_response": True,
                         }
@@ -153,7 +153,7 @@ class FakeRealtime:
                         "transcription": {"model": "gpt-4o-mini-transcribe"},
                         "turn_detection": {
                             "type": "semantic_vad",
-                            "eagerness": "high",
+                            "eagerness": "auto",
                             "create_response": False,
                             "interrupt_response": False,
                         },
@@ -180,7 +180,7 @@ class FakeRealtime:
         turn = event["session"]["audio"]["input"]["turn_detection"]
         return (
             turn["type"] == "semantic_vad"
-            and turn["eagerness"] == "high"
+            and turn["eagerness"] == "auto"
             and turn["create_response"] is True
             and turn["interrupt_response"] is True
         )
@@ -231,7 +231,7 @@ class FakeRealtime:
         turn = event.get("session", {}).get("audio", {}).get("input", {}).get("turn_detection", {})
         return (
             turn.get("type") == "semantic_vad"
-            and turn.get("eagerness") == "high"
+            and turn.get("eagerness") == "auto"
             and turn.get("create_response") is False
             and turn.get("interrupt_response") is False
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,16 @@ def packet() -> ContextPacket:
     )
 
 
+@pytest.fixture
+async def database(settings: Settings):
+    db = Database(settings.database_path)
+    await db.initialize()
+    try:
+        yield db
+    finally:
+        await db.close()
+
+
 class FakeTwilio:
     def __init__(self):
         self.completed: list[str | None] = []
@@ -297,7 +307,10 @@ async def service(settings: Settings):
     svc._test_realtime = realtime
     svc._test_finalizer = finalizer
     yield svc
-    await svc.stop()
+    try:
+        await svc.stop()
+    finally:
+        await db.close()
 
 
 async def wait_background() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,7 @@ class FakeTwilio:
         self.completed: list[str | None] = []
         self.removed: list[tuple[str | None, str | None]] = []
         self.unmuted: list[tuple[str | None, str | None]] = []
+        self.end_on_exit: list[tuple[str | None, str | None]] = []
         self.agent_creates = 0
         self.callee_creates = 0
         self.owner_creates = 0
@@ -112,6 +113,11 @@ class FakeTwilio:
     async def unmute_participant(self, conference_sid_or_name, participant_call_sid) -> None:
         self.unmuted.append((conference_sid_or_name, participant_call_sid))
 
+    async def enable_end_conference_on_exit(
+        self, conference_sid_or_name, participant_call_sid
+    ) -> None:
+        self.end_on_exit.append((conference_sid_or_name, participant_call_sid))
+
 
 class FakeRealtime:
     def __init__(self):
@@ -120,6 +126,7 @@ class FakeRealtime:
         self.hangups: list[str | None] = []
         self.rejects: list[str] = []
         self.closed: list[str] = []
+        self.close_all_calls = 0
         self.tool_results: list[tuple[str, str, dict]] = []
         self.tool_result_continuations: list[bool] = []
         self.accepts: list[tuple[str, str]] = []
@@ -195,6 +202,9 @@ class FakeRealtime:
 
     async def drain_and_close(self, call_id: str) -> None:
         self.closed.append(call_id)
+
+    async def close_all(self) -> None:
+        self.close_all_calls += 1
 
     async def send_tool_result(
         self,

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -540,6 +540,7 @@ async def test_transfer_tool_returns_output_before_removing_ai(service, packet):
             "arguments": '{"reason":"owner needed"}',
         },
     )
+    await wait_background()
     assert order[:2] == ["tool_output", "remove_participant"]
 
 

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -296,6 +296,27 @@ async def test_caller_speech_uses_auto_response_without_manual_create(service, p
 
 
 @pytest.mark.asyncio
+async def test_assistant_transcript_persists_for_aliased_done_event(service, packet):
+    call_id = await seed_call(service.db, packet)
+    await service.db.update_call(call_id, sideband_open=1, callee_joined=1)
+    await service.handle_amd(call_id, "human")
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "response.audio_transcript.done",
+            "event_id": "evt_alias_done",
+            "item_id": "turn_assistant_alias",
+            "transcript": "Hello from the alias event.",
+        },
+    )
+    transcript = await service.db.get_transcript(call_id)
+    assert [(turn.speaker, turn.text) for turn in transcript] == [
+        ("assistant", "Hello from the alias event.")
+    ]
+    assert transcript[0].turn_id == "turn_assistant_alias"
+
+
+@pytest.mark.asyncio
 async def test_tool_output_is_followed_by_observed_continuation(service, packet):
     call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
     await service.handle_realtime_event(

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -566,7 +566,101 @@ async def test_machine_waits_for_message_end_and_all_gates(service, packet):
     await service.db.update_call(call_id, callee_joined=1)
     await service._check_activation_gate(call_id)
     assert service._test_realtime.events == [
-        ("session.update", call_id),
+        ("voicemail", call_id),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_voicemail_activation_never_enables_automatic_responses(service, packet):
+    call_id = await seed_call(service.db, packet)
+    await service.db.update_call(call_id, sideband_open=1, callee_joined=1)
+
+    async def forbidden_update(_call_id: str):
+        raise AssertionError("voicemail must not enable automatic responses")
+
+    service._test_realtime.enable_automatic_responses = forbidden_update
+
+    await service.handle_amd(call_id, "machine_end_beep")
+
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.ACTIVE.value
+    assert service._test_realtime.events == [("voicemail", call_id)]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_amd_wins_before_opening_claim(service, packet):
+    call_id = await seed_call(service.db, packet)
+    await service.db.update_call(call_id, sideband_open=1)
+    claim_reached = asyncio.Event()
+    release_claim = asyncio.Event()
+    original_claim = service.db.claim_opening_if_not_voicemail
+
+    async def delayed_claim(candidate_call_id: str) -> bool:
+        claim_reached.set()
+        await release_claim.wait()
+        return await original_claim(candidate_call_id)
+
+    service.db.claim_opening_if_not_voicemail = delayed_claim
+    answered = asyncio.create_task(
+        service.handle_participant_status(call_id, "callee", {"CallStatus": "in-progress"})
+    )
+    await asyncio.wait_for(claim_reached.wait(), timeout=1)
+
+    amd = asyncio.create_task(service.handle_amd(call_id, "machine_end_beep"))
+    for _ in range(100):
+        if (await service.db.get_call(call_id))["answer_handling"] == "voicemail":
+            break
+        await asyncio.sleep(0.001)
+    else:
+        pytest.fail("AMD classification was not persisted")
+    release_claim.set()
+    await asyncio.gather(answered, amd)
+
+    call = await service.db.get_call(call_id)
+    assert call["answer_handling"] == "voicemail"
+    assert call["opening_sent"] == 0
+    assert service._test_realtime.events == [("voicemail", call_id)]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_opening_claim_wins_before_amd_cancel(service, packet):
+    call_id = await seed_call(service.db, packet)
+    await service.db.update_call(call_id, sideband_open=1)
+    opening_send_reached = asyncio.Event()
+    release_opening_send = asyncio.Event()
+    original_create_opening = service._test_realtime.create_opening
+
+    async def delayed_opening(candidate_call_id: str) -> None:
+        opening_send_reached.set()
+        await release_opening_send.wait()
+        await original_create_opening(candidate_call_id)
+
+    service._test_realtime.create_opening = delayed_opening
+    answered = asyncio.create_task(
+        service.handle_participant_status(call_id, "callee", {"CallStatus": "in-progress"})
+    )
+    await asyncio.wait_for(opening_send_reached.wait(), timeout=1)
+    call = await service.db.get_call(call_id)
+    assert call["opening_sent"] == 1
+
+    amd = asyncio.create_task(service.handle_amd(call_id, "machine_end_beep"))
+    for _ in range(100):
+        if (await service.db.get_call(call_id))["answer_handling"] == "voicemail":
+            break
+        await asyncio.sleep(0.001)
+    else:
+        pytest.fail("AMD classification was not persisted")
+
+    await asyncio.sleep(0)
+    assert not amd.done()
+    assert service._test_realtime.events == []
+
+    release_opening_send.set()
+    await asyncio.gather(answered, amd)
+
+    assert service._test_realtime.events == [
+        ("opening", call_id),
+        ("cancel_response", call_id),
         ("voicemail", call_id),
     ]
 
@@ -583,7 +677,6 @@ async def test_late_voicemail_amd_cancels_opening_before_response_created(servic
 
     assert service._test_realtime.events == [
         ("opening", call_id),
-        ("session.update", call_id),
         ("cancel_response", call_id),
         ("voicemail", call_id),
     ]
@@ -603,7 +696,6 @@ async def test_late_voicemail_amd_cancels_in_flight_opening(service, packet):
 
     assert service._test_realtime.events == [
         ("opening", call_id),
-        ("session.update", call_id),
         ("cancel_response", call_id),
         ("voicemail", call_id),
     ]

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import asyncio
+from datetime import datetime
+
 import pytest
 
+from app.db import LatencyMark
 from app.models import CallState, PreparePhoneCallInput
 from tests.conftest import seed_call, wait_background
 
@@ -37,6 +41,23 @@ async def test_callee_is_not_dialed_until_accept_and_sideband_open(service, pack
     await service.handle_sideband_open(started.call_id)
     assert service._test_twilio.callee_creates == 1
     assert service._test_realtime.initial_updates == [started.call_id]
+    await wait_background()
+    latency = await service.db.get_latency_events(started.call_id)
+    assert [event["stage"] for event in latency] == [
+        "twilio_agent_request",
+        "twilio_agent_created",
+        "openai_accept_request",
+        "openai_accept_completed",
+        "sideband_open",
+        "initial_session_ack",
+        "twilio_callee_request",
+        "twilio_callee_created",
+    ]
+    assert all(datetime.fromisoformat(event["occurred_at"]).tzinfo is not None for event in latency)
+    assert len({event["clock_id"] for event in latency}) == 1
+    assert [event["monotonic_ns"] for event in latency] == sorted(
+        event["monotonic_ns"] for event in latency
+    )
 
 
 @pytest.mark.asyncio
@@ -296,6 +317,120 @@ async def test_tool_output_is_followed_by_observed_continuation(service, packet)
     assert call["tool_call_count"] == 1
     assert call["tool_continuation_observed"] == 1
     assert call["advisory_outcome"]["summary"] == "Done"
+
+
+@pytest.mark.asyncio
+async def test_latency_stages_capture_answer_first_output_and_tool_turnaround(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    await service.handle_participant_status(call_id, "callee", {"CallStatus": "answered"})
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "response.output_audio.delta",
+            "event_id": "evt_audio",
+            "delta": "not-persisted-audio",
+        },
+    )
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "response.output_audio_transcript.delta",
+            "event_id": "evt_transcript",
+            "delta": "Hello",
+        },
+    )
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "response.function_call_arguments.done",
+            "event_id": "evt_tool",
+            "call_id": "tool_latency",
+            "name": "record_call_outcome",
+            "arguments": (
+                '{"status":"completed","summary":"Done","commitments":[],"followUps":[]}'
+            ),
+        },
+    )
+    await service.handle_realtime_send(
+        call_id,
+        {
+            "type": "conversation.item.create",
+            "item": {"type": "function_call_output", "call_id": "tool_latency"},
+        },
+    )
+    await service.handle_realtime_send(call_id, {"type": "response.create"})
+    await wait_background()
+
+    events = await service.db.get_latency_events(call_id)
+    by_stage = {event["stage"]: event for event in events}
+    assert {
+        "callee_answered",
+        "first_openai_audio_delta",
+        "first_assistant_transcript",
+        "tool_call_received",
+        "tool_result_sent",
+        "first_response_create",
+    } <= by_stage.keys()
+    assert by_stage["tool_call_received"]["event_key"] == "tool_latency"
+    assert by_stage["tool_result_sent"]["event_key"] == "tool_latency"
+    assert (
+        by_stage["tool_call_received"]["monotonic_ns"]
+        <= by_stage["tool_result_sent"]["monotonic_ns"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_earlier_answer_callback_mark_wins_when_it_finishes_later(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    marks = iter(
+        [
+            LatencyMark("2026-07-14T12:00:00+00:00", 100),
+            LatencyMark("2026-07-14T12:00:01+00:00", 200),
+        ]
+    )
+    monkeypatch.setattr(LatencyMark, "now", classmethod(lambda cls: next(marks)))
+
+    original_get_call = service.db.get_call
+    first_get_started = asyncio.Event()
+    release_first_get = asyncio.Event()
+    get_count = 0
+
+    async def delay_first_get(call_id: str):
+        nonlocal get_count
+        get_count += 1
+        if get_count == 1:
+            first_get_started.set()
+            await release_first_get.wait()
+        return await original_get_call(call_id)
+
+    monkeypatch.setattr(service.db, "get_call", delay_first_get)
+    earlier_callback = asyncio.create_task(
+        service.handle_conference_event(
+            call_id,
+            {
+                "StatusCallbackEvent": "participant-join",
+                "ParticipantLabel": "callee",
+                "CallSid": "CA" + "b" * 32,
+            },
+        )
+    )
+    await first_get_started.wait()
+
+    # This callback has a later receipt mark but reaches persistence first.
+    await service.handle_participant_status(call_id, "callee", {"CallStatus": "answered"})
+    release_first_get.set()
+    await earlier_callback
+    await wait_background()
+
+    answer_event = next(
+        event
+        for event in await service.db.get_latency_events(call_id)
+        if event["stage"] == "callee_answered"
+    )
+    assert answer_event["monotonic_ns"] == 100
+    assert answer_event["occurred_at"] == "2026-07-14T12:00:00+00:00"
 
 
 @pytest.mark.asyncio

--- a/tests/test_activity_heartbeat.py
+++ b/tests/test_activity_heartbeat.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.db import LatencyMark
+from app.models import CallState
+from tests.conftest import seed_call, wait_background
+
+
+async def _make_call_stale(service, call_id: str) -> None:
+    stale = datetime.now(UTC) - timedelta(minutes=1)
+    await service.db.execute(
+        "UPDATE calls SET last_event_at=? WHERE call_id=?", (stale.isoformat(), call_id)
+    )
+
+
+@pytest.mark.asyncio
+async def test_realtime_deltas_flush_one_latest_arrival_without_per_event_writes(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    original_touch_calls = service.db.touch_calls
+    batches: list[list[tuple[str, str]]] = []
+
+    async def record_batch(activity) -> None:
+        rows = list(activity)
+        batches.append(rows)
+        await original_touch_calls(rows)
+
+    async def forbid_single_touch(*args, **kwargs) -> None:
+        raise AssertionError("Realtime events must not write one heartbeat per frame")
+
+    monkeypatch.setattr(service.db, "touch_calls", record_batch)
+    monkeypatch.setattr(service.db, "touch_call", forbid_single_touch)
+    wall_base = datetime.now(UTC) + timedelta(seconds=1)
+    monotonic_base = LatencyMark.now().monotonic_ns
+
+    latest: LatencyMark | None = None
+    for sequence in range(125):
+        latest = LatencyMark(
+            occurred_at=(wall_base + timedelta(microseconds=sequence)).isoformat(),
+            monotonic_ns=monotonic_base + sequence,
+        )
+        # Production invokes this on the reader before dispatching the delta.
+        service._note_call_activity(call_id, latest)
+        await service.handle_realtime_event(
+            call_id,
+            {"type": "response.audio.delta", "event_id": f"evt_{sequence}"},
+        )
+
+    await service._flush_call_activity()
+
+    assert latest is not None
+    assert batches == [[(call_id, latest.occurred_at)]]
+    assert (await service.db.get_call(call_id))["last_event_at"] == latest.occurred_at
+
+
+@pytest.mark.asyncio
+async def test_batched_arrival_never_overwrites_newer_durable_activity(service, packet):
+    call_id = await seed_call(service.db, packet)
+    newer = datetime.now(UTC) + timedelta(seconds=2)
+    older = newer - timedelta(seconds=1)
+    await service.db.execute(
+        "UPDATE calls SET last_event_at=? WHERE call_id=?", (newer.isoformat(), call_id)
+    )
+
+    await service.db.touch_calls([(call_id, older.isoformat())])
+
+    assert (await service.db.get_call(call_id))["last_event_at"] == newer.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_failed_flush_keeps_fresh_memory_and_prevents_false_stale_timeout(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet)
+    await _make_call_stale(service, call_id)
+    service._note_call_activity(call_id)
+    original_touch_calls = service.db.touch_calls
+    attempts = 0
+
+    async def fail_once(activity) -> None:
+        nonlocal attempts
+        rows = list(activity)
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("simulated heartbeat write failure")
+        await original_touch_calls(rows)
+
+    monkeypatch.setattr(service.db, "touch_calls", fail_once)
+
+    await service._watchdog_once()
+
+    assert (await service.db.get_call(call_id))["state"] == CallState.PREWARMING.value
+    assert call_id in service._latest_call_activity
+    assert call_id in service._dirty_call_activity
+    assert call_id not in service._watchdog_claims
+
+    # A later successful tick retries the retained latest observation.
+    await service._flush_call_activity()
+    assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_flush_never_requeues_over_newer_inflight_activity(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet)
+    base = LatencyMark.now()
+    earlier = LatencyMark(base.occurred_at, base.monotonic_ns)
+    later = LatencyMark(
+        (datetime.fromisoformat(base.occurred_at) + timedelta(seconds=1)).isoformat(),
+        base.monotonic_ns + 1,
+    )
+    service._note_call_activity(call_id, earlier)
+    original_touch_calls = service.db.touch_calls
+    attempts = 0
+
+    async def fail_after_new_activity(activity) -> None:
+        nonlocal attempts
+        rows = list(activity)
+        attempts += 1
+        if attempts == 1:
+            service._note_call_activity(call_id, later)
+            raise RuntimeError("simulated concurrent flush failure")
+        await original_touch_calls(rows)
+
+    monkeypatch.setattr(service.db, "touch_calls", fail_after_new_activity)
+
+    await service._flush_call_activity()
+
+    assert service._latest_call_activity[call_id] == later
+    assert service._dirty_call_activity[call_id] == later
+    await service._flush_call_activity()
+    assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_activity_arriving_during_stale_reread_wins_before_watchdog_claim(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet)
+    await _make_call_stale(service, call_id)
+    original_get_call = service.db.get_call
+    injected = False
+
+    async def get_call_with_racing_activity(requested_call_id: str):
+        nonlocal injected
+        call = await original_get_call(requested_call_id)
+        if requested_call_id == call_id and not injected:
+            injected = True
+            service._note_call_activity(call_id)
+        return call
+
+    monkeypatch.setattr(service.db, "get_call", get_call_with_racing_activity)
+
+    await service._watchdog_once()
+
+    assert injected is True
+    assert (await original_get_call(call_id))["state"] == CallState.PREWARMING.value
+    assert call_id not in service._watchdog_claims
+
+
+@pytest.mark.asyncio
+async def test_activity_after_watchdog_claim_does_not_reverse_real_timeout(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet)
+    await _make_call_stale(service, call_id)
+    original_terminate = service.terminate_call
+    claim_observed = False
+
+    async def terminate_after_late_activity(requested_call_id: str, reason: str, **kwargs):
+        nonlocal claim_observed
+        claim_observed = requested_call_id in service._watchdog_claims
+        service._note_call_activity(requested_call_id)
+        return await original_terminate(requested_call_id, reason, **kwargs)
+
+    monkeypatch.setattr(service, "terminate_call", terminate_after_late_activity)
+
+    await service._watchdog_once()
+    await wait_background()
+
+    assert claim_observed is True
+    assert (await service.db.get_call(call_id))["state"] == CallState.TIMED_OUT.value
+    assert call_id not in service._latest_call_activity
+    assert call_id not in service._dirty_call_activity
+    assert call_id not in service._watchdog_claims
+    assert call_id in service._activity_tombstones
+
+
+@pytest.mark.asyncio
+async def test_terminal_call_clears_all_activity_tracking(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    service._note_call_activity(call_id)
+    service._watchdog_claims.add(call_id)
+
+    assert await service.terminate_call(call_id, "owner_request") is True
+    await wait_background()
+
+    assert call_id not in service._latest_call_activity
+    assert call_id not in service._dirty_call_activity
+    assert call_id not in service._watchdog_claims
+    assert call_id in service._activity_tombstones
+
+
+@pytest.mark.asyncio
+async def test_late_twilio_callbacks_do_not_reinsert_terminal_activity(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.COMPLETED)
+    before = await service.db.get_call(call_id)
+    service._note_call_activity(call_id)
+
+    await service.handle_amd(call_id, "human")
+    await service.handle_conference_event(call_id, {"StatusCallbackEvent": "conference-start"})
+    await service.handle_participant_status(call_id, "callee", {"CallStatus": "ringing"})
+
+    after = await service.db.get_call(call_id)
+    assert after["last_event_at"] == before["last_event_at"]
+    assert after["amd_result"] is None
+    assert call_id not in service._latest_call_activity
+    assert call_id not in service._dirty_call_activity
+    assert call_id not in service._watchdog_claims
+    assert call_id in service._activity_tombstones
+
+
+@pytest.mark.asyncio
+async def test_callback_stale_read_cannot_reinsert_after_termination_claim(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    original_get_call = service.db.get_call
+    inject_termination = True
+
+    async def get_call_with_stale_snapshot(requested_call_id: str):
+        nonlocal inject_termination
+        snapshot = await original_get_call(requested_call_id)
+        if requested_call_id == call_id and inject_termination:
+            inject_termination = False
+            assert await service.terminate_call(call_id, "owner_request") is True
+        return snapshot
+
+    monkeypatch.setattr(service.db, "get_call", get_call_with_stale_snapshot)
+
+    await service.handle_amd(call_id, "human")
+    await wait_background()
+
+    call = await original_get_call(call_id)
+    assert call["state"] == CallState.COMPLETED.value
+    assert call["amd_result"] is None
+    assert call_id in service._activity_tombstones
+    assert call_id not in service._latest_call_activity
+    assert call_id not in service._dirty_call_activity
+
+
+@pytest.mark.asyncio
+async def test_twilio_arrival_blocked_on_read_prevents_watchdog_timeout(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet)
+    await _make_call_stale(service, call_id)
+    original_get_call = service.db.get_call
+    read_started = asyncio.Event()
+    release_read = asyncio.Event()
+
+    async def block_callback_read(requested_call_id: str):
+        if asyncio.current_task().get_name() == "blocked-twilio-callback":
+            read_started.set()
+            await release_read.wait()
+        return await original_get_call(requested_call_id)
+
+    monkeypatch.setattr(service.db, "get_call", block_callback_read)
+    callback = asyncio.create_task(
+        service.handle_amd(call_id, "human"),
+        name="blocked-twilio-callback",
+    )
+    await asyncio.wait_for(read_started.wait(), timeout=1)
+
+    try:
+        await service._watchdog_once()
+        assert (await original_get_call(call_id))["state"] == CallState.PREWARMING.value
+        assert call_id not in service._watchdog_claims
+    finally:
+        release_read.set()
+    await callback
+
+
+@pytest.mark.asyncio
+async def test_activity_tombstones_are_bounded_expire_and_safely_reform(
+    service, packet, monkeypatch
+):
+    monkeypatch.setattr("app.call_state.CALL_ACTIVITY_TOMBSTONE_MAX", 2)
+    monkeypatch.setattr("app.call_state.CALL_ACTIVITY_TOMBSTONE_TTL_SECONDS", 1)
+    clock = [100]
+    monkeypatch.setattr("app.call_state.monotonic_ns", lambda: clock[0])
+    call_ids = [f"call_tombstone_{index}" for index in range(3)]
+
+    for index, call_id in enumerate(call_ids):
+        await seed_call(
+            service.db,
+            packet,
+            call_id=call_id,
+            state=CallState.COMPLETED,
+            openai_call_id=f"rtc_tombstone_{index}",
+        )
+        service._tombstone_call_activity(call_id)
+        clock[0] += 1
+
+    assert list(service._activity_tombstones) == call_ids[-2:]
+    assert len(service._activity_tombstones) == 2
+
+    # The oldest tombstone was evicted, but a late callback still consults the
+    # durable terminal row, reforms the tombstone, and clears transient activity.
+    evicted = call_ids[0]
+    await service.handle_amd(evicted, "human")
+    assert evicted in service._activity_tombstones
+    assert evicted not in service._latest_call_activity
+    assert len(service._activity_tombstones) == 2
+
+    clock[0] += 1_000_000_001
+    assert service._note_call_activity("call_after_expiry") is True
+    assert service._activity_tombstones == {}
+    service._clear_call_activity("call_after_expiry")
+
+
+@pytest.mark.asyncio
+async def test_twilio_callbacks_for_missing_call_leave_no_activity(service):
+    call_id = "call_missing"
+    service._note_call_activity(call_id)
+
+    await service.handle_amd(call_id, "human")
+    await service.handle_conference_event(call_id, {"StatusCallbackEvent": "conference-start"})
+    await service.handle_participant_status(call_id, "callee", {"CallStatus": "ringing"})
+
+    assert call_id not in service._latest_call_activity
+    assert call_id not in service._dirty_call_activity
+    assert call_id not in service._watchdog_claims
+    assert call_id not in service._activity_tombstones

--- a/tests/test_bridge_payloads.py
+++ b/tests/test_bridge_payloads.py
@@ -28,6 +28,11 @@ class FakeWebSocket:
         self.closed = True
 
 
+class FailingSendWebSocket(FakeWebSocket):
+    async def send(self, message: str) -> None:
+        raise RuntimeError("socket send failed")
+
+
 class StreamingFakeWebSocket(FakeWebSocket):
     def __init__(self, echo: dict):
         super().__init__()
@@ -86,6 +91,46 @@ async def test_opening_response_uses_session_context_without_a_script(settings):
             "response": {"output_modalities": ["audio"]},
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_send_hook_runs_after_success_and_cannot_change_send_outcome(settings):
+    observed: list[tuple[str, str, int]] = []
+    websocket = FakeWebSocket()
+
+    async def hook(call_id: str, event: dict) -> None:
+        # The underlying socket write must already have completed before this callback.
+        observed.append((call_id, event["type"], len(websocket.messages)))
+        if event["type"] == "response.cancel":
+            raise RuntimeError("telemetry failed")
+
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+        on_send=hook,
+    )
+    bridge._runtime["call_1"] = RealtimeRuntime(
+        call_id="call_1", openai_call_id="rtc_1", websocket=websocket
+    )
+
+    await bridge.send("call_1", {"type": "response.create"})
+    await bridge.send("call_1", {"type": "response.cancel"})
+
+    assert observed == [
+        ("call_1", "response.create", 1),
+        ("call_1", "response.cancel", 2),
+    ]
+    assert len(websocket.messages) == 2
+
+    bridge._runtime["call_2"] = RealtimeRuntime(
+        call_id="call_2", openai_call_id="rtc_2", websocket=FailingSendWebSocket()
+    )
+    with pytest.raises(RuntimeError, match="socket send failed"):
+        await bridge.send("call_2", {"type": "response.create"})
+    assert all(call_id == "call_1" for call_id, _, _ in observed)
 
 
 @pytest.mark.asyncio

--- a/tests/test_bridge_payloads.py
+++ b/tests/test_bridge_payloads.py
@@ -188,7 +188,7 @@ async def test_sideband_receives_initial_update_echo_while_open_handler_waits(
                     "transcription": {"model": "gpt-4o-mini-transcribe"},
                     "turn_detection": {
                         "type": "semantic_vad",
-                        "eagerness": "auto",
+                        "eagerness": "high",
                         "create_response": False,
                         "interrupt_response": False,
                     },
@@ -251,7 +251,7 @@ async def test_activation_update_is_serialized_and_waits_for_echo(settings):
                 "input": {
                     "turn_detection": {
                         "type": "semantic_vad",
-                        "eagerness": "auto",
+                        "eagerness": "high",
                         "create_response": True,
                         "interrupt_response": True,
                     }
@@ -274,7 +274,7 @@ async def test_activation_update_is_serialized_and_waits_for_echo(settings):
                         "transcription": {"model": "gpt-4o-mini-transcribe"},
                         "turn_detection": {
                             "type": "semantic_vad",
-                            "eagerness": "auto",
+                            "eagerness": "high",
                             "create_response": True,
                             "interrupt_response": True,
                         },
@@ -308,7 +308,7 @@ async def test_initial_session_update_reasserts_safe_audio_gate(settings):
                     "transcription": {"model": "gpt-4o-mini-transcribe"},
                     "turn_detection": {
                         "type": "semantic_vad",
-                        "eagerness": "auto",
+                        "eagerness": "high",
                         "create_response": False,
                         "interrupt_response": False,
                     },
@@ -329,7 +329,7 @@ async def test_initial_session_update_reasserts_safe_audio_gate(settings):
                         "transcription": {"model": "gpt-4o-mini-transcribe"},
                         "turn_detection": {
                             "type": "semantic_vad",
-                            "eagerness": "auto",
+                            "eagerness": "high",
                             "create_response": False,
                             "interrupt_response": False,
                         },
@@ -456,6 +456,7 @@ async def test_twilio_participant_options_match_bridge_contract(settings, packet
     assert agent["wait_url"] == ""
     assert agent["early_media"] is False
     assert agent["muted"] is False
+    assert agent["jitter_buffer_size"] == "small"
     assert agent["to"].startswith("sip:proj_test@sip.api.openai.com;transport=tls?")
     assert "X-Plan-Id=plan_1" in agent["to"]
     assert "X-Bridge-Call-Id=call_1" in agent["to"]
@@ -474,6 +475,7 @@ async def test_twilio_participant_options_match_bridge_contract(settings, packet
     assert callee["end_conference_on_exit"] is True
     assert callee["time_limit"] == settings.max_call_seconds
     assert callee["machine_detection"] == "DetectMessageEnd"
+    assert callee["jitter_buffer_size"] == "small"
     assert callee["amd_status_callback_method"] == "POST"
     assert "plan_id=plan_1" in callee["amd_status_callback"]
 
@@ -486,6 +488,7 @@ async def test_twilio_participant_options_match_bridge_contract(settings, packet
     assert owner["label"] == "owner"
     assert owner["end_conference_on_exit"] is False
     assert owner["timeout"] == 30
+    assert owner["jitter_buffer_size"] == "small"
 
     await bridge.unmute_participant("CF1", "CA" + "a" * 32)
     assert client.conferences("CF1").participants.updates == [

--- a/tests/test_bridge_payloads.py
+++ b/tests/test_bridge_payloads.py
@@ -33,6 +33,26 @@ class FailingSendWebSocket(FakeWebSocket):
         raise RuntimeError("socket send failed")
 
 
+class BlockingFirstSendWebSocket(FakeWebSocket):
+    def __init__(self):
+        super().__init__()
+        self.first_sent = asyncio.Event()
+        self.release_first = asyncio.Event()
+
+    async def send(self, message: str) -> None:
+        await super().send(message)
+        if len(self.messages) == 1:
+            self.first_sent.set()
+            await self.release_first.wait()
+
+
+class SecondSendFailsWebSocket(FakeWebSocket):
+    async def send(self, message: str) -> None:
+        if self.messages:
+            raise RuntimeError("second socket send failed")
+        await super().send(message)
+
+
 class StreamingFakeWebSocket(FakeWebSocket):
     def __init__(self, echo: dict):
         super().__init__()
@@ -365,6 +385,162 @@ async def test_function_output_precedes_manual_continuation(settings):
         },
         {"type": "response.create"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_tool_output_and_continuation_cannot_be_interleaved(settings):
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+    )
+    websocket = BlockingFirstSendWebSocket()
+    bridge._runtime["call_1"] = RealtimeRuntime(
+        call_id="call_1", openai_call_id="rtc_1", websocket=websocket
+    )
+
+    tool_result = asyncio.create_task(
+        bridge.send_tool_result("call_1", "tool_1", {"accepted": True})
+    )
+    await asyncio.wait_for(websocket.first_sent.wait(), timeout=1)
+    competing_send = asyncio.create_task(bridge.send("call_1", {"type": "response.cancel"}))
+    await asyncio.sleep(0)
+
+    assert [message["type"] for message in websocket.messages] == ["conversation.item.create"]
+
+    websocket.release_first.set()
+    await asyncio.gather(tool_result, competing_send)
+    assert [message["type"] for message in websocket.messages] == [
+        "conversation.item.create",
+        "response.create",
+        "response.cancel",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_after_first_frame_finishes_atomic_tool_pair(settings):
+    observed: list[str] = []
+
+    async def on_send(call_id: str, event: dict) -> None:
+        observed.append(event["type"])
+
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+        on_send=on_send,
+    )
+    websocket = BlockingFirstSendWebSocket()
+    bridge._runtime["call_1"] = RealtimeRuntime(
+        call_id="call_1", openai_call_id="rtc_1", websocket=websocket
+    )
+
+    tool_result = asyncio.create_task(
+        bridge.send_tool_result("call_1", "tool_1", {"accepted": True})
+    )
+    await asyncio.wait_for(websocket.first_sent.wait(), timeout=1)
+    competing_send = asyncio.create_task(bridge.send("call_1", {"type": "response.cancel"}))
+    tool_result.cancel()
+    await asyncio.sleep(0)
+
+    assert tool_result.done() is False
+    assert competing_send.done() is False
+    assert [message["type"] for message in websocket.messages] == ["conversation.item.create"]
+
+    websocket.release_first.set()
+    with pytest.raises(asyncio.CancelledError):
+        await tool_result
+    assert observed[:2] == ["conversation.item.create", "response.create"]
+
+    await competing_send
+    assert [message["type"] for message in websocket.messages] == [
+        "conversation.item.create",
+        "response.create",
+        "response.cancel",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_single_frame_waiting_for_lock_is_never_sent(settings):
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+    )
+    websocket = FakeWebSocket()
+    runtime = RealtimeRuntime(call_id="call_1", openai_call_id="rtc_1", websocket=websocket)
+    bridge._runtime["call_1"] = runtime
+    await runtime.send_lock.acquire()
+
+    pending = asyncio.create_task(bridge.send("call_1", {"type": "response.cancel"}))
+    await asyncio.sleep(0)
+    assert pending.done() is False
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+
+    runtime.send_lock.release()
+    await asyncio.sleep(0)
+    assert websocket.messages == []
+
+
+@pytest.mark.asyncio
+async def test_cancelled_tool_pair_waiting_for_lock_is_never_sent(settings):
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+    )
+    websocket = FakeWebSocket()
+    runtime = RealtimeRuntime(call_id="call_1", openai_call_id="rtc_1", websocket=websocket)
+    bridge._runtime["call_1"] = runtime
+    await runtime.send_lock.acquire()
+
+    pending = asyncio.create_task(bridge.send_tool_result("call_1", "tool_1", {"accepted": True}))
+    await asyncio.sleep(0)
+    assert pending.done() is False
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(pending, timeout=0.1)
+
+    runtime.send_lock.release()
+    await asyncio.sleep(0)
+    assert websocket.messages == []
+
+
+@pytest.mark.asyncio
+async def test_partial_tool_result_send_notifies_only_successful_frames(settings):
+    observed: list[str] = []
+
+    async def on_send(call_id: str, event: dict) -> None:
+        observed.append(event["type"])
+
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+        on_send=on_send,
+    )
+    websocket = SecondSendFailsWebSocket()
+    bridge._runtime["call_1"] = RealtimeRuntime(
+        call_id="call_1", openai_call_id="rtc_1", websocket=websocket
+    )
+
+    with pytest.raises(RuntimeError, match="second socket send failed"):
+        await bridge.send_tool_result("call_1", "tool_1", {"accepted": True})
+
+    assert [message["type"] for message in websocket.messages] == ["conversation.item.create"]
+    assert observed == ["conversation.item.create"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_bridge_payloads.py
+++ b/tests/test_bridge_payloads.py
@@ -209,7 +209,7 @@ async def test_sideband_receives_initial_update_echo_while_open_handler_waits(
                     "transcription": {"model": "gpt-4o-mini-transcribe"},
                     "turn_detection": {
                         "type": "semantic_vad",
-                        "eagerness": "high",
+                        "eagerness": "auto",
                         "create_response": False,
                         "interrupt_response": False,
                     },
@@ -272,7 +272,7 @@ async def test_activation_update_is_serialized_and_waits_for_echo(settings):
                 "input": {
                     "turn_detection": {
                         "type": "semantic_vad",
-                        "eagerness": "high",
+                        "eagerness": "auto",
                         "create_response": True,
                         "interrupt_response": True,
                     }
@@ -295,7 +295,7 @@ async def test_activation_update_is_serialized_and_waits_for_echo(settings):
                         "transcription": {"model": "gpt-4o-mini-transcribe"},
                         "turn_detection": {
                             "type": "semantic_vad",
-                            "eagerness": "high",
+                            "eagerness": "auto",
                             "create_response": True,
                             "interrupt_response": True,
                         },
@@ -329,7 +329,7 @@ async def test_initial_session_update_reasserts_safe_audio_gate(settings):
                     "transcription": {"model": "gpt-4o-mini-transcribe"},
                     "turn_detection": {
                         "type": "semantic_vad",
-                        "eagerness": "high",
+                        "eagerness": "auto",
                         "create_response": False,
                         "interrupt_response": False,
                     },
@@ -350,7 +350,7 @@ async def test_initial_session_update_reasserts_safe_audio_gate(settings):
                         "transcription": {"model": "gpt-4o-mini-transcribe"},
                         "turn_detection": {
                             "type": "semantic_vad",
-                            "eagerness": "high",
+                            "eagerness": "auto",
                             "create_response": False,
                             "interrupt_response": False,
                         },

--- a/tests/test_bridge_payloads.py
+++ b/tests/test_bridge_payloads.py
@@ -5,6 +5,7 @@ import json
 from types import SimpleNamespace
 
 import pytest
+from twilio.base.exceptions import TwilioRestException
 
 from app.openai_realtime import RealtimeBridge, RealtimeRuntime
 from app.twilio_bridge import TwilioBridge
@@ -667,6 +668,23 @@ async def test_twilio_participant_options_match_bridge_contract(settings, packet
     assert owner["jitter_buffer_size"] == "small"
 
     await bridge.unmute_participant("CF1", "CA" + "a" * 32)
+    await bridge.enable_end_conference_on_exit("CF1", "CA" + "c" * 32)
     assert client.conferences("CF1").participants.updates == [
-        {"call_sid": "CA" + "a" * 32, "muted": False}
+        {"call_sid": "CA" + "a" * 32, "muted": False},
+        {"call_sid": "CA" + "c" * 32, "end_conference_on_exit": True},
     ]
+
+
+@pytest.mark.asyncio
+async def test_complete_conference_treats_missing_resource_as_already_closed(settings):
+    class MissingConference:
+        participants = FakeParticipants()
+
+        def update(self, **kwargs):
+            del kwargs
+            raise TwilioRestException(404, "/Conferences/CF-missing", "not found")
+
+    client = SimpleNamespace(conferences=lambda _name: MissingConference())
+    bridge = TwilioBridge(settings, client=client)
+
+    await bridge.complete_conference("CF-missing")

--- a/tests/test_finalizer.py
+++ b/tests/test_finalizer.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import httpx
 import pytest
 import respx
-from openai import APITimeoutError
+from openai import APIStatusError, APITimeoutError
 from pydantic import SecretStr
 
 from app.finalizer import Finalizer
@@ -19,12 +19,24 @@ class FakeResponses:
         self.parsed = parsed
         self.error = error
         self.calls = 0
+        self.timeouts: list[float] = []
 
     async def parse(self, **kwargs):
         self.calls += 1
+        self.timeouts.append(kwargs["timeout"])
         if self.error:
             raise self.error
         return SimpleNamespace(output_parsed=self.parsed)
+
+
+def status_error(status_code: int) -> APIStatusError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/responses")
+    response = httpx.Response(status_code, request=request)
+    return APIStatusError(
+        f"OpenAI returned {status_code}",
+        response=response,
+        body=None,
+    )
 
 
 @pytest.mark.asyncio
@@ -59,6 +71,29 @@ async def test_terminal_state_and_raw_transcript_saved_before_extraction(setting
     result = await finalizer.finalize(call_id)
     assert result.finalization_status == "succeeded"
     assert result.result_source == "post_call_extractor"
+    assert responses.timeouts == [30.0]
+
+
+@pytest.mark.asyncio
+async def test_extractor_timeout_can_exceed_live_control_timeout(settings, service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.COMPLETED)
+    parsed = ExtractedCallResult(
+        outcome="completed",
+        summary="Appointment confirmed.",
+        commitments=[],
+        confirmation_numbers=[],
+        follow_ups=[],
+        confidence=0.95,
+    )
+    settings.openai_extraction_timeout_seconds = 45
+    responses = FakeResponses(parsed=parsed)
+
+    result = await Finalizer(settings, service.db, SimpleNamespace(responses=responses)).finalize(
+        call_id
+    )
+
+    assert result.finalization_status == "succeeded"
+    assert responses.timeouts == [45]
 
 
 @pytest.mark.asyncio
@@ -167,3 +202,44 @@ async def test_extractor_retries_one_transient_failure_only(settings, service, p
 
     assert responses.calls == 2
     assert result.finalization_status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_extractor_retries_one_server_error(settings, service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.COMPLETED)
+    parsed = ExtractedCallResult(
+        outcome="completed",
+        summary="Completed after a server retry.",
+        commitments=[],
+        confirmation_numbers=[],
+        follow_ups=[],
+        confidence=0.8,
+    )
+
+    class ServerErrorThenSuccess(FakeResponses):
+        async def parse(inner_self, **kwargs):
+            inner_self.calls += 1
+            if inner_self.calls == 1:
+                raise status_error(500)
+            return SimpleNamespace(output_parsed=parsed)
+
+    responses = ServerErrorThenSuccess()
+    result = await Finalizer(settings, service.db, SimpleNamespace(responses=responses)).finalize(
+        call_id
+    )
+
+    assert responses.calls == 2
+    assert result.finalization_status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_extractor_does_not_retry_nontransient_client_error(settings, service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.COMPLETED)
+    responses = FakeResponses(error=status_error(400))
+
+    result = await Finalizer(settings, service.db, SimpleNamespace(responses=responses)).finalize(
+        call_id
+    )
+
+    assert responses.calls == 1
+    assert result.finalization_status == "failed"

--- a/tests/test_http_clients.py
+++ b/tests/test_http_clients.py
@@ -14,6 +14,12 @@ from app.settings import Settings
 from app.twilio_bridge import TwilioBridge
 
 
+def _leaf_exceptions(error: BaseException) -> list[BaseException]:
+    if isinstance(error, BaseExceptionGroup):
+        return [leaf for child in error.exceptions for leaf in _leaf_exceptions(child)]
+    return [error]
+
+
 def test_default_twilio_client_uses_bounded_pooled_transport(settings, monkeypatch):
     observed: dict[str, object] = {}
     transport = object()
@@ -56,22 +62,30 @@ def test_twilio_http_timeout_is_configurable(settings, monkeypatch):
 
 def test_openai_client_has_bounded_timeouts_and_no_sdk_retries(settings, monkeypatch):
     observed: dict[str, object] = {}
+    transport = object()
+
+    def fake_http_client(**kwargs):
+        observed["transport_options"] = kwargs
+        return transport
 
     def fake_openai(**kwargs):
-        observed.update(kwargs)
+        observed["client_options"] = kwargs
         return SimpleNamespace()
 
+    monkeypatch.setattr("app.openai_client.httpx.AsyncClient", fake_http_client)
     monkeypatch.setattr("app.openai_client.AsyncOpenAI", fake_openai)
 
     create_openai_client(settings)
 
-    timeout = observed["timeout"]
+    client_options = observed["client_options"]
+    timeout = client_options["timeout"]
     assert timeout.connect == 3.0
     assert timeout.read == 10.0
     assert timeout.write == 10.0
     assert timeout.pool == 10.0
-    assert observed["max_retries"] == 0
-    assert "http_client" not in observed
+    assert client_options["max_retries"] == 0
+    assert client_options["http_client"] is transport
+    assert observed["transport_options"]["limits"].keepalive_expiry == 60
 
 
 def test_openai_control_timeouts_are_configurable(settings, monkeypatch):
@@ -80,6 +94,10 @@ def test_openai_control_timeouts_are_configurable(settings, monkeypatch):
     values["openai_http_timeout_seconds"] = 20
     configured = Settings(**values)
     observed: dict[str, object] = {}
+    monkeypatch.setattr(
+        "app.openai_client.httpx.AsyncClient",
+        lambda **kwargs: observed.update(transport_options=kwargs) or object(),
+    )
     monkeypatch.setattr(
         "app.openai_client.AsyncOpenAI",
         lambda **kwargs: observed.update(kwargs) or SimpleNamespace(),
@@ -92,9 +110,9 @@ def test_openai_control_timeouts_are_configurable(settings, monkeypatch):
     assert timeout.read == 20
 
 
-def test_openai_keepalive_override_is_opt_in(settings, monkeypatch):
+def test_openai_keepalive_expiry_is_configurable(settings, monkeypatch):
     values = settings.model_dump()
-    values["openai_keepalive_expiry_seconds"] = 60
+    values["openai_keepalive_expiry_seconds"] = 90
     configured = Settings(**values)
     observed: dict[str, object] = {}
     transport = object()
@@ -113,7 +131,7 @@ def test_openai_keepalive_override_is_opt_in(settings, monkeypatch):
     create_openai_client(configured)
 
     transport_options = observed["transport_options"]
-    assert transport_options["limits"].keepalive_expiry == 60
+    assert transport_options["limits"].keepalive_expiry == 90
     assert transport_options["limits"].max_connections == 1000
     assert transport_options["limits"].max_keepalive_connections == 100
     assert transport_options["follow_redirects"] is True
@@ -204,6 +222,7 @@ async def test_call_service_closes_only_an_internally_created_openai_client(sett
 @pytest.mark.asyncio
 async def test_app_lifespan_closes_openai_when_service_shutdown_fails(settings, monkeypatch):
     client = SimpleNamespace(closed=False)
+    captured = {}
 
     async def close() -> None:
         client.closed = True
@@ -212,7 +231,7 @@ async def test_app_lifespan_closes_openai_when_service_shutdown_fails(settings, 
 
     class FailingStopService:
         def __init__(self, *args, **kwargs):
-            pass
+            captured["db"] = args[1]
 
         async def recover_startup(self) -> None:
             pass
@@ -232,3 +251,168 @@ async def test_app_lifespan_closes_openai_when_service_shutdown_fails(settings, 
             pass
 
     assert client.closed is True
+    assert captured["db"]._writer is None
+    assert captured["db"]._reader is None
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_closes_database_when_openai_shutdown_fails(settings, monkeypatch):
+    captured = {}
+
+    class FailingCloseClient:
+        async def close(self) -> None:
+            raise RuntimeError("openai close failed")
+
+    class Service:
+        def __init__(self, *args, **kwargs):
+            captured["db"] = args[1]
+
+        async def recover_startup(self) -> None:
+            pass
+
+        async def start_watchdog(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            pass
+
+    monkeypatch.setattr("app.main.create_openai_client", lambda _: FailingCloseClient())
+    monkeypatch.setattr("app.main.CallService", Service)
+    application = create_app(settings)
+
+    with pytest.raises(RuntimeError, match="openai close failed"):
+        async with application.router.lifespan_context(application):
+            pass
+
+    assert captured["db"]._writer is None
+    assert captured["db"]._reader is None
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_closes_database_when_openai_client_creation_fails(
+    settings, monkeypatch
+):
+    captured = {}
+
+    def create_database(path):
+        db = Database(path)
+        captured["db"] = db
+        return db
+
+    def fail_client_creation(_):
+        raise RuntimeError("openai client creation failed")
+
+    monkeypatch.setattr("app.main.Database", create_database)
+    monkeypatch.setattr("app.main.create_openai_client", fail_client_creation)
+    application = create_app(settings)
+
+    with pytest.raises(RuntimeError, match="openai client creation failed"):
+        async with application.router.lifespan_context(application):
+            pass
+
+    assert captured["db"]._writer is None
+    assert captured["db"]._reader is None
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_aggregates_all_cleanup_failures(settings, monkeypatch):
+    attempts: list[str] = []
+    captured = {}
+    service_getters = []
+
+    class FailingCloseDatabase(Database):
+        async def close(self) -> None:
+            attempts.append("database")
+            await super().close()
+            raise RuntimeError("database close failed")
+
+    class FailingCloseClient:
+        async def close(self) -> None:
+            attempts.append("openai")
+            raise RuntimeError("openai close failed")
+
+    class FailingStopService:
+        def __init__(self, *args, **kwargs):
+            captured["db"] = args[1]
+
+        async def recover_startup(self) -> None:
+            pass
+
+        async def start_watchdog(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            attempts.append("service")
+            raise RuntimeError("service stop failed")
+
+    monkeypatch.setattr("app.main.Database", FailingCloseDatabase)
+    monkeypatch.setattr("app.main.create_openai_client", lambda _: FailingCloseClient())
+    monkeypatch.setattr("app.main.CallService", FailingStopService)
+    monkeypatch.setattr(
+        "app.main.register_tools", lambda _mcp, get_service: service_getters.append(get_service)
+    )
+    application = create_app(settings)
+
+    with pytest.raises(ExceptionGroup) as raised:
+        async with application.router.lifespan_context(application):
+            pass
+
+    assert [str(error) for error in raised.value.exceptions] == [
+        "service stop failed",
+        "openai close failed",
+        "database close failed",
+    ]
+    assert attempts == ["service", "openai", "database"]
+    assert captured["db"]._writer is None
+    assert captured["db"]._reader is None
+    with pytest.raises(RuntimeError, match="service is not started"):
+        service_getters[0]()
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_preserves_body_error_with_cleanup_failures(settings, monkeypatch):
+    attempts: list[str] = []
+
+    class FailingCloseDatabase(Database):
+        async def close(self) -> None:
+            attempts.append("database")
+            await super().close()
+            raise RuntimeError("database close failed")
+
+    class FailingCloseClient:
+        async def close(self) -> None:
+            attempts.append("openai")
+            raise RuntimeError("openai close failed")
+
+    class FailingStopService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def recover_startup(self) -> None:
+            pass
+
+        async def start_watchdog(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            attempts.append("service")
+            raise RuntimeError("service stop failed")
+
+    monkeypatch.setattr("app.main.Database", FailingCloseDatabase)
+    monkeypatch.setattr("app.main.create_openai_client", lambda _: FailingCloseClient())
+    monkeypatch.setattr("app.main.CallService", FailingStopService)
+    application = create_app(settings)
+
+    with pytest.raises(ExceptionGroup) as raised:
+        async with application.router.lifespan_context(application):
+            raise ValueError("lifespan body failed")
+
+    leaves = _leaf_exceptions(raised.value)
+    assert [str(error) for error in leaves] == [
+        "lifespan body failed",
+        "service stop failed",
+        "openai close failed",
+        "database close failed",
+    ]
+    assert isinstance(leaves[0], ValueError)
+    assert attempts == ["service", "openai", "database"]

--- a/tests/test_http_clients.py
+++ b/tests/test_http_clients.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from app.call_state import CallService
+from app.db import Database
+from app.main import create_app
+from app.openai_client import create_openai_client
+from app.openai_realtime import RealtimeBridge
+from app.settings import Settings
+from app.twilio_bridge import TwilioBridge
+
+
+def test_default_twilio_client_uses_bounded_pooled_transport(settings, monkeypatch):
+    observed: dict[str, object] = {}
+    transport = object()
+
+    def fake_http_client(**kwargs):
+        observed["transport_options"] = kwargs
+        return transport
+
+    def fake_client(account_sid, auth_token, **kwargs):
+        observed["credentials"] = (account_sid, auth_token)
+        observed["client_options"] = kwargs
+        return SimpleNamespace()
+
+    monkeypatch.setattr("app.twilio_bridge.TwilioHttpClient", fake_http_client)
+    monkeypatch.setattr("app.twilio_bridge.Client", fake_client)
+
+    TwilioBridge(settings)
+
+    assert observed["transport_options"] == {
+        "pool_connections": True,
+        "timeout": 10.0,
+        "max_retries": 0,
+    }
+    assert observed["client_options"] == {"http_client": transport}
+
+
+def test_twilio_http_timeout_is_configurable(settings, monkeypatch):
+    settings.twilio_http_timeout_seconds = 12
+    observed: dict[str, object] = {}
+    monkeypatch.setattr(
+        "app.twilio_bridge.TwilioHttpClient",
+        lambda **kwargs: observed.update(kwargs) or object(),
+    )
+    monkeypatch.setattr("app.twilio_bridge.Client", lambda *args, **kwargs: SimpleNamespace())
+
+    TwilioBridge(settings)
+
+    assert observed["timeout"] == 12
+
+
+def test_openai_client_has_bounded_timeouts_and_no_sdk_retries(settings, monkeypatch):
+    observed: dict[str, object] = {}
+
+    def fake_openai(**kwargs):
+        observed.update(kwargs)
+        return SimpleNamespace()
+
+    monkeypatch.setattr("app.openai_client.AsyncOpenAI", fake_openai)
+
+    create_openai_client(settings)
+
+    timeout = observed["timeout"]
+    assert timeout.connect == 3.0
+    assert timeout.read == 10.0
+    assert timeout.write == 10.0
+    assert timeout.pool == 10.0
+    assert observed["max_retries"] == 0
+    assert "http_client" not in observed
+
+
+def test_openai_control_timeouts_are_configurable(settings, monkeypatch):
+    values = settings.model_dump()
+    values["openai_connect_timeout_seconds"] = 4
+    values["openai_http_timeout_seconds"] = 20
+    configured = Settings(**values)
+    observed: dict[str, object] = {}
+    monkeypatch.setattr(
+        "app.openai_client.AsyncOpenAI",
+        lambda **kwargs: observed.update(kwargs) or SimpleNamespace(),
+    )
+
+    create_openai_client(configured)
+
+    timeout = observed["timeout"]
+    assert timeout.connect == 4
+    assert timeout.read == 20
+
+
+def test_openai_keepalive_override_is_opt_in(settings, monkeypatch):
+    values = settings.model_dump()
+    values["openai_keepalive_expiry_seconds"] = 60
+    configured = Settings(**values)
+    observed: dict[str, object] = {}
+    transport = object()
+
+    def fake_http_client(**kwargs):
+        observed["transport_options"] = kwargs
+        return transport
+
+    def fake_openai(**kwargs):
+        observed["client_options"] = kwargs
+        return SimpleNamespace()
+
+    monkeypatch.setattr("app.openai_client.httpx.AsyncClient", fake_http_client)
+    monkeypatch.setattr("app.openai_client.AsyncOpenAI", fake_openai)
+
+    create_openai_client(configured)
+
+    transport_options = observed["transport_options"]
+    assert transport_options["limits"].keepalive_expiry == 60
+    assert transport_options["limits"].max_connections == 1000
+    assert transport_options["limits"].max_keepalive_connections == 100
+    assert transport_options["follow_redirects"] is True
+    assert observed["client_options"]["http_client"] is transport
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("openai_connect_timeout_seconds", 0),
+        ("openai_http_timeout_seconds", 61),
+        ("openai_keepalive_expiry_seconds", 4),
+        ("openai_extraction_timeout_seconds", 121),
+    ],
+)
+def test_openai_transport_settings_are_bounded(settings, field, value):
+    values = settings.model_dump()
+    values[field] = value
+    with pytest.raises(ValueError):
+        Settings(**values)
+
+
+def test_openai_connect_timeout_cannot_exceed_request_timeout(settings):
+    values = settings.model_dump()
+    values["openai_connect_timeout_seconds"] = 11
+    values["openai_http_timeout_seconds"] = 10
+    with pytest.raises(ValueError, match="cannot exceed"):
+        Settings(**values)
+
+
+@pytest.mark.asyncio
+async def test_realtime_accept_has_a_total_wall_clock_deadline(settings, packet):
+    settings.openai_connect_timeout_seconds = 0.005
+    settings.openai_http_timeout_seconds = 0.01
+
+    async def hanging_accept(*args, **kwargs):
+        await asyncio.Event().wait()
+
+    client = SimpleNamespace(
+        realtime=SimpleNamespace(
+            calls=SimpleNamespace(
+                with_raw_response=SimpleNamespace(accept=hanging_accept),
+            )
+        )
+    )
+    bridge = RealtimeBridge(
+        settings,
+        client,
+        on_event=lambda *args: None,
+        on_open=lambda *args: None,
+        on_fatal=lambda *args: None,
+    )
+
+    with pytest.raises(TimeoutError):
+        await bridge.accept_and_connect(
+            call_id="call_1",
+            openai_call_id="rtc_1",
+            packet=packet,
+        )
+
+
+@pytest.mark.asyncio
+async def test_call_service_closes_only_an_internally_created_openai_client(settings, monkeypatch):
+    owned = SimpleNamespace(closed=False)
+
+    async def close() -> None:
+        owned.closed = True
+
+    owned.close = close
+    monkeypatch.setattr("app.call_state.create_openai_client", lambda _: owned)
+    db = Database(settings.database_path)
+
+    service = CallService(settings, db, twilio=SimpleNamespace())
+    await service.stop()
+    assert owned.closed is True
+
+    injected = SimpleNamespace(closed=False)
+
+    async def close_injected() -> None:
+        injected.closed = True
+
+    injected.close = close_injected
+    service = CallService(settings, db, twilio=SimpleNamespace(), openai=injected)
+    await service.stop()
+    assert injected.closed is False
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_closes_openai_when_service_shutdown_fails(settings, monkeypatch):
+    client = SimpleNamespace(closed=False)
+
+    async def close() -> None:
+        client.closed = True
+
+    client.close = close
+
+    class FailingStopService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def recover_startup(self) -> None:
+            pass
+
+        async def start_watchdog(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            raise RuntimeError("stop failed")
+
+    monkeypatch.setattr("app.main.create_openai_client", lambda _: client)
+    monkeypatch.setattr("app.main.CallService", FailingStopService)
+    application = create_app(settings)
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        async with application.router.lifespan_context(application):
+            pass
+
+    assert client.closed is True

--- a/tests/test_lifespan_cleanup.py
+++ b/tests/test_lifespan_cleanup.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.main import create_app
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_cleanup_step_failure_propagates_as_single_error(settings, monkeypatch):
+    attempts: list[str] = []
+
+    class FailingStopService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def recover_startup(self) -> None:
+            pass
+
+        async def start_watchdog(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            attempts.append("service")
+            raise RuntimeError("stop failed")
+
+    monkeypatch.setattr("app.main.CallService", FailingStopService)
+    application = create_app(settings)
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        async with application.router.lifespan_context(application):
+            pass
+
+    assert attempts == ["service"]
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_bounds_a_hung_cleanup_step(settings, monkeypatch):
+    monkeypatch.setattr("app.main.LIFESPAN_CLEANUP_STEP_TIMEOUT_SECONDS", 0.05)
+    attempts: list[str] = []
+
+    class HangingStopService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def recover_startup(self) -> None:
+            pass
+
+        async def start_watchdog(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            attempts.append("service")
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr("app.main.CallService", HangingStopService)
+    application = create_app(settings)
+
+    async def run_lifespan():
+        async with application.router.lifespan_context(application):
+            pass
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(run_lifespan(), timeout=5)
+
+    assert attempts == ["service"]
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_cancellation_from_cleanup_step_propagates_and_runs_remaining_steps(
+    settings, monkeypatch
+):
+    attempts: list[str] = []
+
+    class CancelledStopService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def recover_startup(self) -> None:
+            pass
+
+        async def start_watchdog(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            attempts.append("service")
+            raise asyncio.CancelledError
+
+    class ClosingClient:
+        async def close(self) -> None:
+            attempts.append("openai")
+
+    monkeypatch.setattr("app.main.create_openai_client", lambda _: ClosingClient())
+    monkeypatch.setattr("app.main.CallService", CancelledStopService)
+    application = create_app(settings)
+
+    with pytest.raises(asyncio.CancelledError):
+        async with application.router.lifespan_context(application):
+            pass
+
+    # Cancellation propagates as CancelledError alone (never wrapped in a
+    # BaseExceptionGroup) but the remaining, now individually bounded, cleanup
+    # steps still ran.
+    assert attempts == ["service", "openai"]
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_cancellation_during_body_propagates_and_runs_cleanup(
+    settings, monkeypatch
+):
+    attempts: list[str] = []
+
+    class Service:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def recover_startup(self) -> None:
+            raise asyncio.CancelledError
+
+        async def start_watchdog(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            attempts.append("service")
+
+    class ClosingClient:
+        async def close(self) -> None:
+            attempts.append("openai")
+
+    monkeypatch.setattr("app.main.create_openai_client", lambda _: ClosingClient())
+    monkeypatch.setattr("app.main.CallService", Service)
+    application = create_app(settings)
+
+    with pytest.raises(asyncio.CancelledError):
+        async with application.router.lifespan_context(application):
+            pass
+
+    assert attempts == ["service", "openai"]

--- a/tests/test_openai_payload.py
+++ b/tests/test_openai_payload.py
@@ -30,7 +30,7 @@ def test_initial_accept_payload_is_typed_and_matches_release_contract(settings, 
         "transcription": {"model": "gpt-4o-mini-transcribe"},
         "turn_detection": {
             "type": "semantic_vad",
-            "eagerness": "auto",
+            "eagerness": "high",
             "create_response": False,
             "interrupt_response": False,
         },
@@ -67,7 +67,7 @@ def test_session_created_echo_requires_transcription_and_full_initial_vad(settin
                     "transcription": {"model": "gpt-4o-mini-transcribe"},
                     "turn_detection": {
                         "type": "semantic_vad",
-                        "eagerness": "auto",
+                        "eagerness": "high",
                         "create_response": False,
                         "interrupt_response": False,
                     },
@@ -77,5 +77,55 @@ def test_session_created_echo_requires_transcription_and_full_initial_vad(settin
     }
     assert bridge.expected_transcription_echoed(event)
     assert bridge.expected_initial_vad_echoed(event)
-    event["session"]["audio"]["input"]["turn_detection"]["eagerness"] = "high"
+    event["session"]["audio"]["input"]["turn_detection"]["eagerness"] = "auto"
     assert not bridge.expected_initial_vad_echoed(event)
+
+
+def test_semantic_vad_auto_setting_is_available_for_rollback(settings, packet):
+    from app.settings import Settings
+
+    values = settings.model_dump()
+    values["semantic_vad_eagerness"] = "auto"
+    rollback_settings = Settings(**values)
+    bridge = RealtimeBridge(
+        rollback_settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+    )
+
+    payload = bridge.build_accept_payload(packet).model_dump(exclude_none=True)
+    turn = payload["audio"]["input"]["turn_detection"]
+    assert turn["eagerness"] == "auto"
+    assert bridge.expected_initial_vad_echoed(
+        {"session": {"audio": {"input": {"turn_detection": turn}}}}
+    )
+
+
+def test_activation_echo_must_preserve_configured_semantic_vad(settings):
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+    )
+    event = {
+        "session": {
+            "audio": {
+                "input": {
+                    "turn_detection": {
+                        "type": "semantic_vad",
+                        "eagerness": "high",
+                        "create_response": True,
+                        "interrupt_response": True,
+                    }
+                }
+            }
+        }
+    }
+
+    assert bridge.activation_update_confirmed(event)
+    event["session"]["audio"]["input"]["turn_detection"]["eagerness"] = "auto"
+    assert not bridge.activation_update_confirmed(event)

--- a/tests/test_openai_payload.py
+++ b/tests/test_openai_payload.py
@@ -36,7 +36,7 @@ def test_initial_accept_payload_is_typed_and_matches_release_contract(settings, 
         },
     }
     assert payload["audio"]["output"] == {
-        "voice": "marin",
+        "voice": "echo",
         "speed": 1.0,
     }
     assert "format" not in payload["audio"]["input"]

--- a/tests/test_openai_payload.py
+++ b/tests/test_openai_payload.py
@@ -30,7 +30,7 @@ def test_initial_accept_payload_is_typed_and_matches_release_contract(settings, 
         "transcription": {"model": "gpt-4o-mini-transcribe"},
         "turn_detection": {
             "type": "semantic_vad",
-            "eagerness": "high",
+            "eagerness": "auto",
             "create_response": False,
             "interrupt_response": False,
         },
@@ -67,7 +67,7 @@ def test_session_created_echo_requires_transcription_and_full_initial_vad(settin
                     "transcription": {"model": "gpt-4o-mini-transcribe"},
                     "turn_detection": {
                         "type": "semantic_vad",
-                        "eagerness": "high",
+                        "eagerness": "auto",
                         "create_response": False,
                         "interrupt_response": False,
                     },
@@ -77,18 +77,18 @@ def test_session_created_echo_requires_transcription_and_full_initial_vad(settin
     }
     assert bridge.expected_transcription_echoed(event)
     assert bridge.expected_initial_vad_echoed(event)
-    event["session"]["audio"]["input"]["turn_detection"]["eagerness"] = "auto"
+    event["session"]["audio"]["input"]["turn_detection"]["eagerness"] = "high"
     assert not bridge.expected_initial_vad_echoed(event)
 
 
-def test_semantic_vad_auto_setting_is_available_for_rollback(settings, packet):
+def test_semantic_vad_high_setting_is_available_for_tuning(settings, packet):
     from app.settings import Settings
 
     values = settings.model_dump()
-    values["semantic_vad_eagerness"] = "auto"
-    rollback_settings = Settings(**values)
+    values["semantic_vad_eagerness"] = "high"
+    tuned_settings = Settings(**values)
     bridge = RealtimeBridge(
-        rollback_settings,
+        tuned_settings,
         SimpleNamespace(),
         on_event=_noop,
         on_open=_noop,
@@ -97,7 +97,7 @@ def test_semantic_vad_auto_setting_is_available_for_rollback(settings, packet):
 
     payload = bridge.build_accept_payload(packet).model_dump(exclude_none=True)
     turn = payload["audio"]["input"]["turn_detection"]
-    assert turn["eagerness"] == "auto"
+    assert turn["eagerness"] == "high"
     assert bridge.expected_initial_vad_echoed(
         {"session": {"audio": {"input": {"turn_detection": turn}}}}
     )
@@ -117,7 +117,7 @@ def test_activation_echo_must_preserve_configured_semantic_vad(settings):
                 "input": {
                     "turn_detection": {
                         "type": "semantic_vad",
-                        "eagerness": "high",
+                        "eagerness": "auto",
                         "create_response": True,
                         "interrupt_response": True,
                     }
@@ -127,5 +127,5 @@ def test_activation_echo_must_preserve_configured_semantic_vad(settings):
     }
 
     assert bridge.activation_update_confirmed(event)
-    event["session"]["audio"]["input"]["turn_detection"]["eagerness"] = "auto"
+    event["session"]["audio"]["input"]["turn_detection"]["eagerness"] = "high"
     assert not bridge.activation_update_confirmed(event)

--- a/tests/test_policy_and_db.py
+++ b/tests/test_policy_and_db.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import asyncio
+import threading
 from datetime import UTC, datetime, timedelta
 
+import aiosqlite
 import pytest
 from pydantic import ValidationError
 
@@ -11,10 +14,137 @@ from app.policy import validate_context, validate_destination
 from app.settings import Settings
 
 
+async def _pragma_value(connection: aiosqlite.Connection, name: str):
+    cursor = await connection.execute(f"PRAGMA {name}")
+    row = await cursor.fetchone()
+    return row[0]
+
+
 @pytest.mark.asyncio
-async def test_initialize_migrates_legacy_opening_column_and_state(settings, packet):
+async def test_database_reuses_reader_and_writer_with_durable_pragmas(database):
+    writer = database._writer
+    reader = database._reader
+    assert writer is not None
+    assert reader is not None
+    assert writer is not reader
+
+    for connection in (writer, reader):
+        assert await _pragma_value(connection, "journal_mode") == "wal"
+        assert await _pragma_value(connection, "synchronous") == 2
+        assert await _pragma_value(connection, "foreign_keys") == 1
+        assert await _pragma_value(connection, "busy_timeout") == 5000
+    assert await _pragma_value(writer, "query_only") == 0
+    assert await _pragma_value(reader, "query_only") == 1
+
+    await database.execute("CREATE TABLE connection_reuse (value TEXT NOT NULL)")
+    await database.execute("INSERT INTO connection_reuse(value) VALUES (?)", ("visible",))
+    assert await database.fetch_one("SELECT value FROM connection_reuse") == {"value": "visible"}
+    assert database._writer is writer
+    assert database._reader is reader
+
+    # Re-running migrations is idempotent and does not churn live connections.
+    await database.initialize()
+    assert database._writer is writer
+    assert database._reader is reader
+
+
+@pytest.mark.asyncio
+async def test_database_close_is_idempotent_and_initialize_reopens(settings):
     db = Database(settings.database_path)
     await db.initialize()
+    first_writer = db._writer
+    first_reader = db._reader
+
+    await db.close()
+    await db.close()
+    assert db._writer is None
+    assert db._reader is None
+    with pytest.raises(RuntimeError, match="not initialized"):
+        await db.fetch_one("SELECT 1")
+
+    await db.initialize()
+    try:
+        assert db._writer is not first_writer
+        assert db._reader is not first_reader
+        assert await db.fetch_one("SELECT 1 AS value") == {"value": 1}
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_persistent_writer_rolls_back_failed_operation(database):
+    await database.execute("CREATE TABLE unique_values (value TEXT PRIMARY KEY)")
+    await database.execute("INSERT INTO unique_values(value) VALUES (?)", ("first",))
+
+    with pytest.raises(aiosqlite.IntegrityError):
+        await database.execute("INSERT INTO unique_values(value) VALUES (?)", ("first",))
+
+    # The failed transaction cannot poison the next user of the shared writer.
+    await database.execute("INSERT INTO unique_values(value) VALUES (?)", ("second",))
+    rows = await database.fetch_all("SELECT value FROM unique_values ORDER BY value")
+    assert rows == [{"value": "first"}, {"value": "second"}]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_queued_write_rolls_back_before_releasing_writer(database):
+    await database.execute("CREATE TABLE cancelled_writes (value TEXT NOT NULL)")
+    writer = database._writer
+    assert writer is not None
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def block_worker() -> int:
+        worker_started.set()
+        if not release_worker.wait(timeout=5):
+            raise TimeoutError("test worker was not released")
+        return 1
+
+    await writer.create_function("block_worker", 0, block_worker)
+
+    async def occupy_worker() -> None:
+        async with writer.execute("SELECT block_worker()") as cursor:
+            await cursor.fetchone()
+
+    blocker = asyncio.create_task(occupy_worker())
+    write: asyncio.Task[int] | None = None
+    try:
+        assert await asyncio.to_thread(worker_started.wait, 1)
+        write = asyncio.create_task(
+            database.execute("INSERT INTO cancelled_writes(value) VALUES (?)", ("abandoned",))
+        )
+        for _ in range(100):
+            if writer._tx.qsize() >= 1:
+                break
+            await asyncio.sleep(0)
+        else:
+            pytest.fail("write was not queued behind the blocked SQLite worker")
+
+        write.cancel()
+        for _ in range(100):
+            if writer._tx.qsize() >= 2:
+                break
+            await asyncio.sleep(0)
+
+        # The cancelled caller stays inside the write lock until its rollback is queued behind
+        # the abandoned INSERT and has actually completed.
+        assert not write.done()
+    finally:
+        release_worker.set()
+        await asyncio.gather(blocker, return_exceptions=True)
+
+    assert write is not None
+    with pytest.raises(asyncio.CancelledError):
+        await write
+    assert await database.fetch_all("SELECT value FROM cancelled_writes") == []
+
+    await database.execute("INSERT INTO cancelled_writes(value) VALUES (?)", ("healthy",))
+    assert await database.fetch_all("SELECT value FROM cancelled_writes") == [{"value": "healthy"}]
+
+
+@pytest.mark.asyncio
+async def test_initialize_migrates_legacy_opening_column_and_state(database, packet):
+    db = database
     expires_at = datetime.now(UTC) + timedelta(minutes=10)
     await db.create_plan(
         "plan_legacy",
@@ -46,9 +176,8 @@ async def test_initialize_migrates_legacy_opening_column_and_state(settings, pac
 
 
 @pytest.mark.asyncio
-async def test_latency_events_are_migration_safe_idempotent_and_correlated(settings, packet):
-    db = Database(settings.database_path)
-    await db.initialize()
+async def test_latency_events_are_migration_safe_idempotent_and_correlated(database, packet):
+    db = database
     expires_at = datetime.now(UTC) + timedelta(minutes=10)
     await db.create_plan(
         "plan_latency",
@@ -237,9 +366,8 @@ def test_confirmation_number_requires_evidence():
 
 
 @pytest.mark.asyncio
-async def test_transcript_order_and_source_id_are_idempotent(settings):
-    db = Database(settings.database_path)
-    await db.initialize()
+async def test_transcript_order_and_source_id_are_idempotent(database):
+    db = database
     # Minimal rows for the transcript FK.
     await db.create_plan(
         "plan_db",
@@ -283,9 +411,8 @@ async def test_transcript_order_and_source_id_are_idempotent(settings):
 
 
 @pytest.mark.asyncio
-async def test_deployment_lock_atomically_blocks_new_calls(settings):
-    db = Database(settings.database_path)
-    await db.initialize()
+async def test_deployment_lock_atomically_blocks_new_calls(database):
+    db = database
     await db.create_plan(
         "plan_deploy",
         {},

--- a/tests/test_policy_and_db.py
+++ b/tests/test_policy_and_db.py
@@ -230,6 +230,36 @@ async def test_latency_events_are_migration_safe_idempotent_and_correlated(datab
     assert "call_latency_events" in tables
 
 
+@pytest.mark.asyncio
+async def test_conference_cleanup_pending_column_and_round_trip(database, packet):
+    db = database
+    columns = {row["name"] for row in await db.fetch_all("PRAGMA table_info(calls)")}
+    assert "conference_cleanup_pending" in columns
+
+    await db.create_plan(
+        "plan_cleanup",
+        packet.model_dump(mode="json"),
+        "Owner explicitly requested the call",
+        datetime.now(UTC) + timedelta(minutes=10),
+    )
+    assert await db.claim_plan_and_create_call(
+        plan_id="plan_cleanup",
+        call_id="call_cleanup",
+        conference_name="conference_cleanup",
+        confirmation_text="Confirmed",
+    )
+    assert (await db.get_call("call_cleanup"))["conference_cleanup_pending"] == 0
+    assert await db.list_conference_cleanup_pending() == []
+
+    await db.set_conference_cleanup_pending("call_cleanup", True)
+    pending = await db.list_conference_cleanup_pending()
+    assert [row["call_id"] for row in pending] == ["call_cleanup"]
+    assert (await db.get_call("call_cleanup"))["conference_cleanup_pending"] == 1
+
+    await db.set_conference_cleanup_pending("call_cleanup", False)
+    assert await db.list_conference_cleanup_pending() == []
+
+
 @pytest.mark.parametrize(
     "phone",
     ["+1911", "+1933", "+1988", "+1211", "+19005550123", "14155550100"],

--- a/tests/test_policy_and_db.py
+++ b/tests/test_policy_and_db.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from pydantic import ValidationError
 
-from app.db import Database, DeploymentLockedError
+from app.db import Database, DeploymentLockedError, LatencyMark, LatencyStage
 from app.models import CallState, EvidenceValue, PreparePhoneCallInput
 from app.policy import validate_context, validate_destination
 from app.settings import Settings
@@ -43,6 +43,62 @@ async def test_initialize_migrates_legacy_opening_column_and_state(settings, pac
     assert "greeting_sent" not in columns
     assert call["opening_sent"] == 1
     assert call["state"] == CallState.ACTIVE.value
+
+
+@pytest.mark.asyncio
+async def test_latency_events_are_migration_safe_idempotent_and_correlated(settings, packet):
+    db = Database(settings.database_path)
+    await db.initialize()
+    expires_at = datetime.now(UTC) + timedelta(minutes=10)
+    await db.create_plan(
+        "plan_latency",
+        packet.model_dump(mode="json"),
+        "Owner explicitly requested the call",
+        expires_at,
+    )
+    assert await db.claim_plan_and_create_call(
+        plan_id="plan_latency",
+        call_id="call_latency",
+        conference_name="conference_latency",
+        confirmation_text="Confirmed",
+    )
+
+    first = LatencyMark("2026-07-14T12:00:00+00:00", 100)
+    later = LatencyMark("2026-07-14T12:00:01+00:00", 200)
+    earliest = LatencyMark("2026-07-14T11:59:59+00:00", 50)
+    await db.record_latency_events(
+        "call_latency",
+        [
+            (LatencyStage.SIDEBAND_OPEN, first, ""),
+            (LatencyStage.TOOL_CALL_RECEIVED, first, "tool_1"),
+            (LatencyStage.TOOL_CALL_RECEIVED, later, "tool_2"),
+        ],
+    )
+    await db.record_latency_event(
+        "call_latency",
+        LatencyStage.SIDEBAND_OPEN,
+        later,
+    )
+    await db.record_latency_event(
+        "call_latency",
+        LatencyStage.SIDEBAND_OPEN,
+        earliest,
+    )
+
+    events = await db.get_latency_events("call_latency")
+    assert [(event["stage"], event["event_key"]) for event in events] == [
+        ("sideband_open", ""),
+        ("tool_call_received", "tool_1"),
+        ("tool_call_received", "tool_2"),
+    ]
+    assert events[0]["occurred_at"] == earliest.occurred_at
+    assert events[0]["monotonic_ns"] == earliest.monotonic_ns
+    assert len({event["clock_id"] for event in events}) == 1
+
+    # Existing databases receive this table through CREATE TABLE IF NOT EXISTS.
+    await db.initialize()
+    tables = {row["name"] for row in await db.fetch_all("SELECT name FROM sqlite_master")}
+    assert "call_latency_events" in tables
 
 
 @pytest.mark.parametrize(

--- a/tests/test_policy_and_db.py
+++ b/tests/test_policy_and_db.py
@@ -441,6 +441,74 @@ async def test_transcript_order_and_source_id_are_idempotent(database):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    ["prewarming", "ready_to_activate", "activating", "active"],
+)
+async def test_claim_transfer_joining_accepts_each_eligible_state(database, state):
+    db = database
+    call_id = f"call_eligible_{state}"
+    await db.create_plan(
+        f"plan_{call_id}", {}, "authority", datetime.now(UTC) + timedelta(minutes=10)
+    )
+    assert await db.claim_plan_and_create_call(
+        plan_id=f"plan_{call_id}",
+        call_id=call_id,
+        conference_name=f"conference_{call_id}",
+        confirmation_text="confirmed",
+    )
+    await db.update_call(call_id, state=state, callee_joined=1)
+
+    assert await db.claim_transfer_joining(call_id, "owner needed") is True
+    call = await db.get_call(call_id)
+    assert call["transfer_outcome"] == "joining:owner needed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    ["completed", "failed", "timed_out", "transferred", "terminating"],
+)
+async def test_claim_transfer_joining_rejects_terminal_and_terminating_states(database, state):
+    db = database
+    call_id = f"call_ineligible_{state}"
+    await db.create_plan(
+        f"plan_{call_id}", {}, "authority", datetime.now(UTC) + timedelta(minutes=10)
+    )
+    assert await db.claim_plan_and_create_call(
+        plan_id=f"plan_{call_id}",
+        call_id=call_id,
+        conference_name=f"conference_{call_id}",
+        confirmation_text="confirmed",
+    )
+    await db.update_call(call_id, state=state, callee_joined=1)
+
+    assert await db.claim_transfer_joining(call_id, "owner needed") is False
+    call = await db.get_call(call_id)
+    assert call["transfer_outcome"] is None
+
+
+@pytest.mark.asyncio
+async def test_claim_transfer_joining_rejects_before_callee_joined(database):
+    db = database
+    call_id = "call_not_joined"
+    await db.create_plan(
+        f"plan_{call_id}", {}, "authority", datetime.now(UTC) + timedelta(minutes=10)
+    )
+    assert await db.claim_plan_and_create_call(
+        plan_id=f"plan_{call_id}",
+        call_id=call_id,
+        conference_name=f"conference_{call_id}",
+        confirmation_text="confirmed",
+    )
+    # PREWARMING is the default state after claim_plan_and_create_call and callee_joined
+    # defaults to 0 until the callee actually answers.
+    assert await db.claim_transfer_joining(call_id, "owner needed") is False
+    call = await db.get_call(call_id)
+    assert call["transfer_outcome"] is None
+
+
+@pytest.mark.asyncio
 async def test_deployment_lock_atomically_blocks_new_calls(database):
     db = database
     await db.create_plan(

--- a/tests/test_prompt_limits.py
+++ b/tests/test_prompt_limits.py
@@ -72,10 +72,10 @@ def test_semantic_vad_accepts_supported_eagerness(eagerness: str):
     assert vad.eagerness == eagerness
 
 
-def test_semantic_vad_defaults_to_high_and_rejects_unknown_value():
+def test_semantic_vad_defaults_to_auto_and_rejects_unknown_value():
     vad = SemanticVad(create_response=True, interrupt_response=True)
 
-    assert vad.eagerness == "high"
+    assert vad.eagerness == "auto"
     with pytest.raises(ValidationError):
         SemanticVad(
             eagerness="fast",

--- a/tests/test_prompt_limits.py
+++ b/tests/test_prompt_limits.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from app import prompts
+from app.models import (
+    CONTEXT_PACKET_MAX_BYTES,
+    ContextPacket,
+    PreparePhoneCallInput,
+    SemanticVad,
+)
+from app.prompts import REALTIME_INSTRUCTIONS_MAX_BYTES, realtime_instructions
+
+
+def _oversized_packet_data(packet: ContextPacket, value: str) -> dict:
+    data = packet.model_dump(mode="json")
+    data["relevant_facts"] = [value]
+    return data
+
+
+def test_context_packet_rejects_oversized_ascii(packet: ContextPacket):
+    data = _oversized_packet_data(packet, "x" * CONTEXT_PACKET_MAX_BYTES)
+
+    with pytest.raises(ValidationError, match=r"exceeds 16384 UTF-8 bytes"):
+        ContextPacket.model_validate(data)
+
+
+def test_context_packet_counts_multibyte_utf8_bytes(packet: ContextPacket):
+    # Fewer than 16,384 characters, but three UTF-8 bytes per character plus JSON overhead.
+    value = "界" * (CONTEXT_PACKET_MAX_BYTES // 3)
+    assert len(value) < CONTEXT_PACKET_MAX_BYTES
+
+    with pytest.raises(ValidationError, match=r"exceeds 16384 UTF-8 bytes"):
+        ContextPacket.model_validate(_oversized_packet_data(packet, value))
+
+
+def test_normal_context_uses_compact_approved_json(packet: ContextPacket):
+    expected = json.dumps(
+        packet.model_dump(mode="json"),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+    instructions = realtime_instructions(packet)
+
+    assert packet.approved_context_json() == expected
+    assert f"# Approved context\n{expected}\n" in instructions
+    assert len(instructions.encode("utf-8")) <= REALTIME_INSTRUCTIONS_MAX_BYTES
+
+
+def test_realtime_instructions_enforce_final_byte_limit(
+    packet: ContextPacket, monkeypatch: pytest.MonkeyPatch
+):
+    size_bytes = len(realtime_instructions(packet).encode("utf-8"))
+    monkeypatch.setattr(prompts, "REALTIME_INSTRUCTIONS_MAX_BYTES", size_bytes - 1)
+
+    with pytest.raises(ValueError, match=r"Realtime instructions exceed"):
+        realtime_instructions(packet)
+
+
+@pytest.mark.parametrize("eagerness", ["low", "medium", "high", "auto"])
+def test_semantic_vad_accepts_supported_eagerness(eagerness: str):
+    vad = SemanticVad(
+        eagerness=eagerness,
+        create_response=True,
+        interrupt_response=True,
+    )
+
+    assert vad.eagerness == eagerness
+
+
+def test_semantic_vad_defaults_to_high_and_rejects_unknown_value():
+    vad = SemanticVad(create_response=True, interrupt_response=True)
+
+    assert vad.eagerness == "high"
+    with pytest.raises(ValidationError):
+        SemanticVad(
+            eagerness="fast",
+            create_response=True,
+            interrupt_response=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_oversized_context_is_rejected_before_plan_persistence(service, packet):
+    raw_request = {
+        "context": _oversized_packet_data(packet, "x" * CONTEXT_PACKET_MAX_BYTES),
+        "authority_basis": "Owner asked Poke to place this call",
+        "requested_by_owner": True,
+    }
+
+    async def validate_and_prepare():
+        request = PreparePhoneCallInput.model_validate(raw_request)
+        return await service.prepare(request)
+
+    with pytest.raises(ValidationError, match=r"exceeds 16384 UTF-8 bytes"):
+        await validate_and_prepare()
+
+    row = await service.db.fetch_one("SELECT COUNT(*) AS count FROM plans")
+    assert row == {"count": 0}

--- a/tests/test_realtime_dispatch.py
+++ b/tests/test_realtime_dispatch.py
@@ -381,6 +381,24 @@ async def test_external_drain_waits_for_queued_events_before_cancel_fallback(set
 
 
 @pytest.mark.asyncio
+async def test_close_all_stops_every_registered_runtime(settings, monkeypatch):
+    monkeypatch.setattr("app.openai_realtime.REALTIME_MEDIA_DRAIN_SECONDS", 0)
+    websocket = QueueWebSocket()
+    bridge, runtime, task, fatals, _ = await _start_bridge(
+        settings,
+        monkeypatch,
+        call_id="call_shutdown_all",
+        websocket=websocket,
+        on_event=_noop,
+    )
+    await asyncio.wait_for(bridge.close_all(), timeout=1)
+
+    assert task.done()
+    assert runtime.call_id not in bridge._runtime
+    assert fatals == []
+
+
+@pytest.mark.asyncio
 async def test_dispatcher_preserves_fifo_order(settings, monkeypatch):
     websocket = QueueWebSocket()
     handled: list[int] = []

--- a/tests/test_realtime_dispatch.py
+++ b/tests/test_realtime_dispatch.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.openai_realtime import (
+    REALTIME_EVENT_QUEUE_MAXSIZE,
+    RealtimeBridge,
+    RealtimeRuntime,
+)
+
+
+class QueueWebSocket:
+    def __init__(self) -> None:
+        self.incoming: asyncio.Queue[str | None] = asyncio.Queue()
+        self.messages: list[dict[str, Any]] = []
+        self.connected = asyncio.Event()
+        self.sent = asyncio.Event()
+        self.received: list[dict[str, Any]] = []
+        self.closed = False
+
+    def __aiter__(self) -> QueueWebSocket:
+        return self
+
+    async def __anext__(self) -> str:
+        message = await self.incoming.get()
+        if message is None:
+            raise StopAsyncIteration
+        event = json.loads(message)
+        self.received.append(event)
+        return message
+
+    async def feed(self, event: dict[str, Any]) -> None:
+        await self.incoming.put(json.dumps(event))
+
+    async def send(self, message: str) -> None:
+        self.messages.append(json.loads(message))
+        self.sent.set()
+
+    async def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        await self.incoming.put(None)
+
+
+class FirstCloseFailsWebSocket(QueueWebSocket):
+    def __init__(self, mode: str) -> None:
+        super().__init__()
+        self.mode = mode
+        self.close_attempts = 0
+
+    async def close(self) -> None:
+        self.close_attempts += 1
+        if self.close_attempts == 1:
+            if self.mode == "raises":
+                raise RuntimeError("close failed")
+            await asyncio.Event().wait()
+        await super().close()
+
+
+class FakeConnection:
+    def __init__(self, websocket: QueueWebSocket) -> None:
+        self.websocket = websocket
+
+    async def __aenter__(self) -> QueueWebSocket:
+        self.websocket.connected.set()
+        return self.websocket
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.websocket.close()
+
+
+async def _noop(*args: object, **kwargs: object) -> None:
+    return None
+
+
+async def _start_bridge(
+    settings: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    call_id: str,
+    websocket: QueueWebSocket,
+    on_event: Callable[[str, dict[str, Any]], Awaitable[None]],
+    on_open: Callable[[str], Awaitable[None]] = _noop,
+) -> tuple[
+    RealtimeBridge,
+    RealtimeRuntime,
+    asyncio.Task[None],
+    list[tuple[str, str]],
+    asyncio.Event,
+]:
+    fatals: list[tuple[str, str]] = []
+    fatal_called = asyncio.Event()
+
+    async def on_fatal(failed_call_id: str, reason: str) -> None:
+        fatals.append((failed_call_id, reason))
+        fatal_called.set()
+
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=on_event,
+        on_open=on_open,
+        on_fatal=on_fatal,
+    )
+    runtime = RealtimeRuntime(call_id=call_id, openai_call_id=f"rtc_{call_id}")
+    bridge._runtime[call_id] = runtime
+    monkeypatch.setattr(
+        "app.openai_realtime.websockets.connect",
+        lambda *args, **kwargs: FakeConnection(websocket),
+    )
+    task = asyncio.create_task(bridge._run(runtime), name=f"test-sideband:{call_id}")
+    runtime.task = task
+    await asyncio.wait_for(websocket.connected.wait(), timeout=1)
+    await asyncio.sleep(0)
+    return bridge, runtime, task, fatals, fatal_called
+
+
+@pytest.mark.asyncio
+async def test_reader_continues_while_first_application_event_is_blocked(settings, monkeypatch):
+    websocket = QueueWebSocket()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    handled: list[int] = []
+
+    async def on_event(call_id: str, event: dict[str, Any]) -> None:
+        handled.append(event["sequence"])
+        if event["sequence"] == 1:
+            first_started.set()
+            await release_first.wait()
+
+    _, runtime, task, fatals, _ = await _start_bridge(
+        settings,
+        monkeypatch,
+        call_id="call_read_ahead",
+        websocket=websocket,
+        on_event=on_event,
+    )
+
+    await websocket.feed({"type": "test.event", "sequence": 1})
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+    await websocket.feed({"type": "test.event", "sequence": 2})
+    for _ in range(10):
+        if runtime.event_queue.qsize() == 1:
+            break
+        await asyncio.sleep(0)
+
+    assert [event["sequence"] for event in websocket.received] == [1, 2]
+    assert runtime.event_queue.qsize() == 1
+
+    release_first.set()
+    await websocket.close()
+    await asyncio.wait_for(task, timeout=1)
+    assert handled == [1, 2]
+    assert fatals == []
+
+
+@pytest.mark.asyncio
+async def test_session_updated_readiness_bypasses_blocked_dispatcher(settings, monkeypatch):
+    websocket = QueueWebSocket()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    handled_types: list[str] = []
+
+    async def on_event(call_id: str, event: dict[str, Any]) -> None:
+        handled_types.append(event["type"])
+        if event["type"] == "test.block":
+            first_started.set()
+            await release_first.wait()
+
+    bridge, _, task, fatals, _ = await _start_bridge(
+        settings,
+        monkeypatch,
+        call_id="call_readiness",
+        websocket=websocket,
+        on_event=on_event,
+    )
+    await websocket.feed({"type": "test.block"})
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+
+    update = asyncio.create_task(bridge.verify_initial_session("call_readiness"))
+    await asyncio.wait_for(websocket.sent.wait(), timeout=1)
+    echoed = {"type": "session.updated", "session": {"audio": {"input": {}}}}
+    await websocket.feed(echoed)
+
+    assert await asyncio.wait_for(update, timeout=1) == echoed
+    assert handled_types == ["test.block"]
+
+    release_first.set()
+    await websocket.close()
+    await asyncio.wait_for(task, timeout=1)
+    assert handled_types == ["test.block", "session.updated"]
+    assert fatals == []
+
+
+@pytest.mark.asyncio
+async def test_on_open_can_drain_production_runtime_without_parent_child_cycle(
+    settings, monkeypatch
+):
+    monkeypatch.setattr("app.openai_realtime.REALTIME_MEDIA_DRAIN_SECONDS", 0)
+    monkeypatch.setattr("app.openai_realtime.REALTIME_CLOSE_TIMEOUT_SECONDS", 0.1)
+    websocket = QueueWebSocket()
+    fatals: list[tuple[str, str]] = []
+    drain_returned = asyncio.Event()
+    bridge_holder: dict[str, RealtimeBridge] = {}
+
+    async def on_open(call_id: str) -> None:
+        await bridge_holder["bridge"].drain_and_close(call_id)
+        drain_returned.set()
+
+    async def on_fatal(call_id: str, reason: str) -> None:
+        fatals.append((call_id, reason))
+
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=on_open,
+        on_fatal=on_fatal,
+    )
+    bridge_holder["bridge"] = bridge
+    runtime = RealtimeRuntime(call_id="call_open_drain", openai_call_id="rtc_open_drain")
+    bridge._runtime[runtime.call_id] = runtime
+    monkeypatch.setattr(
+        "app.openai_realtime.websockets.connect",
+        lambda *args, **kwargs: FakeConnection(websocket),
+    )
+    runtime.task = asyncio.create_task(bridge._run(runtime), name="sideband:call_open_drain")
+
+    await asyncio.wait_for(runtime.task, timeout=1)
+
+    assert drain_returned.is_set()
+    assert runtime.open_task is not None and runtime.open_task.done()
+    assert runtime.receiver_task is not None and runtime.receiver_task.done()
+    assert runtime.dispatcher_task is not None and runtime.dispatcher_task.done()
+    assert runtime.call_id not in bridge._runtime
+    assert fatals == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("close_mode", ["raises", "times_out"])
+async def test_child_close_failure_wakes_supervisor_and_clears_runtime(
+    settings, monkeypatch, close_mode
+):
+    monkeypatch.setattr("app.openai_realtime.REALTIME_MEDIA_DRAIN_SECONDS", 0)
+    monkeypatch.setattr("app.openai_realtime.REALTIME_CLOSE_TIMEOUT_SECONDS", 0.01)
+    websocket = FirstCloseFailsWebSocket(close_mode)
+    fatals: list[tuple[str, str]] = []
+    bridge_holder: dict[str, RealtimeBridge] = {}
+    after_drain = asyncio.Event()
+
+    async def on_open(call_id: str) -> None:
+        await bridge_holder["bridge"].drain_and_close(call_id)
+        # Production termination persists terminal state and schedules finalization here.
+        after_drain.set()
+
+    async def on_fatal(call_id: str, reason: str) -> None:
+        fatals.append((call_id, reason))
+
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=on_open,
+        on_fatal=on_fatal,
+    )
+    bridge_holder["bridge"] = bridge
+    runtime = RealtimeRuntime(call_id=f"call_close_{close_mode}", openai_call_id="rtc_close")
+    bridge._runtime[runtime.call_id] = runtime
+    monkeypatch.setattr(
+        "app.openai_realtime.websockets.connect",
+        lambda *args, **kwargs: FakeConnection(websocket),
+    )
+    runtime.task = asyncio.create_task(bridge._run(runtime), name=f"sideband:{runtime.call_id}")
+
+    await asyncio.wait_for(runtime.task, timeout=0.5)
+
+    assert websocket.close_attempts == 2
+    assert after_drain.is_set()
+    assert runtime.open_task is not None and runtime.open_task.done()
+    assert runtime.open_task.exception() is None
+    assert runtime.receiver_task is not None and runtime.receiver_task.done()
+    assert runtime.dispatcher_task is not None and runtime.dispatcher_task.done()
+    assert runtime.call_id not in bridge._runtime
+    assert fatals == []
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_close_failure_finishes_current_handler_before_cleanup(
+    settings, monkeypatch
+):
+    monkeypatch.setattr("app.openai_realtime.REALTIME_MEDIA_DRAIN_SECONDS", 0)
+    monkeypatch.setattr("app.openai_realtime.REALTIME_CLOSE_TIMEOUT_SECONDS", 0.01)
+    websocket = FirstCloseFailsWebSocket("raises")
+    handler_steps: list[str] = []
+    bridge: RealtimeBridge
+
+    async def on_event(call_id: str, event: dict[str, Any]) -> None:
+        handler_steps.append("before_drain")
+        await bridge.drain_and_close(call_id)
+        # This models terminal state persistence/finalizer scheduling in terminate_call.
+        handler_steps.append("after_drain")
+
+    bridge, runtime, task, fatals, _ = await _start_bridge(
+        settings,
+        monkeypatch,
+        call_id="call_dispatcher_close_failure",
+        websocket=websocket,
+        on_event=on_event,
+    )
+    await websocket.feed({"type": "test.terminate"})
+
+    await asyncio.wait_for(task, timeout=0.5)
+
+    assert handler_steps == ["before_drain", "after_drain"]
+    assert websocket.close_attempts == 2
+    assert runtime.dispatcher_task is not None and runtime.dispatcher_task.done()
+    assert runtime.receiver_task is not None and runtime.receiver_task.done()
+    assert runtime.call_id not in bridge._runtime
+    assert fatals == []
+
+
+@pytest.mark.asyncio
+async def test_external_drain_waits_for_queued_events_before_cancel_fallback(settings, monkeypatch):
+    monkeypatch.setattr("app.openai_realtime.REALTIME_MEDIA_DRAIN_SECONDS", 0.01)
+    monkeypatch.setattr("app.openai_realtime.REALTIME_CLOSE_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr("app.openai_realtime.REALTIME_TASK_DRAIN_TIMEOUT_SECONDS", 0.25)
+    monkeypatch.setattr("app.openai_realtime.REALTIME_TASK_CANCEL_TIMEOUT_SECONDS", 0.1)
+    websocket = QueueWebSocket()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    handled: list[int] = []
+
+    async def on_event(call_id: str, event: dict[str, Any]) -> None:
+        handled.append(event["sequence"])
+        if event["sequence"] == 1:
+            first_started.set()
+            await release_first.wait()
+
+    bridge, runtime, _, fatals, _ = await _start_bridge(
+        settings,
+        monkeypatch,
+        call_id="call_external_drain",
+        websocket=websocket,
+        on_event=on_event,
+    )
+    await websocket.feed({"type": "test.event", "sequence": 1})
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+    await websocket.feed({"type": "test.event", "sequence": 2})
+    for _ in range(10):
+        if runtime.event_queue.qsize() == 1:
+            break
+        await asyncio.sleep(0)
+    assert runtime.event_queue.qsize() == 1
+
+    async def release_during_supervised_drain() -> None:
+        # Release after the websocket has closed. The old immediate-cancel behavior dropped the
+        # second event here; the supervised grace window lets both FIFO entries complete.
+        await asyncio.sleep(0.03)
+        release_first.set()
+
+    release_task = asyncio.create_task(release_during_supervised_drain())
+    await asyncio.wait_for(bridge.drain_and_close(runtime.call_id), timeout=1)
+    await release_task
+
+    assert handled == [1, 2]
+    assert runtime.task is not None and runtime.task.done()
+    assert runtime.call_id not in bridge._runtime
+    assert fatals == []
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_preserves_fifo_order(settings, monkeypatch):
+    websocket = QueueWebSocket()
+    handled: list[int] = []
+
+    async def on_event(call_id: str, event: dict[str, Any]) -> None:
+        handled.append(event["sequence"])
+        await asyncio.sleep(0)
+
+    _, runtime, task, fatals, _ = await _start_bridge(
+        settings,
+        monkeypatch,
+        call_id="call_fifo",
+        websocket=websocket,
+        on_event=on_event,
+    )
+    for sequence in range(25):
+        await websocket.feed({"type": "test.event", "sequence": sequence})
+    await websocket.close()
+
+    await asyncio.wait_for(task, timeout=1)
+    assert handled == list(range(25))
+    assert runtime.receiver_task is not None and runtime.receiver_task.done()
+    assert runtime.dispatcher_task is not None and runtime.dispatcher_task.done()
+    assert fatals == []
+
+
+@pytest.mark.asyncio
+async def test_queue_overflow_is_fatal_instead_of_dropping_events(settings, monkeypatch):
+    websocket = QueueWebSocket()
+    first_started = asyncio.Event()
+    never_release = asyncio.Event()
+
+    async def on_event(call_id: str, event: dict[str, Any]) -> None:
+        first_started.set()
+        await never_release.wait()
+
+    _, runtime, task, fatals, fatal_called = await _start_bridge(
+        settings,
+        monkeypatch,
+        call_id="call_overflow",
+        websocket=websocket,
+        on_event=on_event,
+    )
+    await websocket.feed({"type": "test.block", "sequence": 0})
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+    for sequence in range(1, REALTIME_EVENT_QUEUE_MAXSIZE + 2):
+        await websocket.feed({"type": "test.event", "sequence": sequence})
+
+    await asyncio.wait_for(fatal_called.wait(), timeout=1)
+    await asyncio.wait_for(task, timeout=1)
+    assert fatals == [("call_overflow", "sideband_error:RealtimeEventQueueOverflow")]
+    assert runtime.dispatcher_task is not None and runtime.dispatcher_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_handler_failure_is_fatal_and_cancels_reader(settings, monkeypatch):
+    class HandlerFailure(RuntimeError):
+        pass
+
+    websocket = QueueWebSocket()
+
+    async def on_event(call_id: str, event: dict[str, Any]) -> None:
+        raise HandlerFailure("handler failed")
+
+    _, runtime, task, fatals, fatal_called = await _start_bridge(
+        settings,
+        monkeypatch,
+        call_id="call_handler_failure",
+        websocket=websocket,
+        on_event=on_event,
+    )
+    await websocket.feed({"type": "test.event"})
+
+    await asyncio.wait_for(fatal_called.wait(), timeout=1)
+    await asyncio.wait_for(task, timeout=1)
+    assert fatals == [("call_handler_failure", "sideband_error:HandlerFailure")]
+    assert runtime.receiver_task is not None and runtime.receiver_task.cancelled()
+    assert runtime.dispatcher_task is not None and runtime.dispatcher_task.done()

--- a/tests/test_realtime_dispatch.py
+++ b/tests/test_realtime_dispatch.py
@@ -88,6 +88,7 @@ async def _start_bridge(
     websocket: QueueWebSocket,
     on_event: Callable[[str, dict[str, Any]], Awaitable[None]],
     on_open: Callable[[str], Awaitable[None]] = _noop,
+    on_activity: Callable[[str], None] | None = None,
 ) -> tuple[
     RealtimeBridge,
     RealtimeRuntime,
@@ -108,6 +109,7 @@ async def _start_bridge(
         on_event=on_event,
         on_open=on_open,
         on_fatal=on_fatal,
+        on_activity=on_activity,
     )
     runtime = RealtimeRuntime(call_id=call_id, openai_call_id=f"rtc_{call_id}")
     bridge._runtime[call_id] = runtime
@@ -128,6 +130,7 @@ async def test_reader_continues_while_first_application_event_is_blocked(setting
     first_started = asyncio.Event()
     release_first = asyncio.Event()
     handled: list[int] = []
+    activity: list[str] = []
 
     async def on_event(call_id: str, event: dict[str, Any]) -> None:
         handled.append(event["sequence"])
@@ -141,6 +144,7 @@ async def test_reader_continues_while_first_application_event_is_blocked(setting
         call_id="call_read_ahead",
         websocket=websocket,
         on_event=on_event,
+        on_activity=activity.append,
     )
 
     await websocket.feed({"type": "test.event", "sequence": 1})
@@ -153,6 +157,7 @@ async def test_reader_continues_while_first_application_event_is_blocked(setting
 
     assert [event["sequence"] for event in websocket.received] == [1, 2]
     assert runtime.event_queue.qsize() == 1
+    assert activity == ["call_read_ahead", "call_read_ahead"]
 
     release_first.set()
     await websocket.close()

--- a/tests/test_realtime_dispatch.py
+++ b/tests/test_realtime_dispatch.py
@@ -399,6 +399,74 @@ async def test_close_all_stops_every_registered_runtime(settings, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_close_all_gives_up_on_cancellation_resistant_task_and_logs(
+    settings, monkeypatch, caplog
+):
+    # Keep drain_and_close's own bounded retries fast so the test exercises close_all's
+    # final bounded pass rather than timing out inside drain_and_close first.
+    monkeypatch.setattr("app.openai_realtime.REALTIME_MEDIA_DRAIN_SECONDS", 0)
+    monkeypatch.setattr("app.openai_realtime.REALTIME_TASK_DRAIN_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr("app.openai_realtime.REALTIME_TASK_CANCEL_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr("app.openai_realtime.REALTIME_SHUTDOWN_FINAL_TIMEOUT_SECONDS", 0.05)
+    release = asyncio.Event()
+
+    async def stubborn() -> None:
+        # Swallows cancellation like a stalled send shielded by _send_batch would, so
+        # close_all's final wait must give up rather than hang forever.
+        while True:
+            try:
+                await release.wait()
+                return
+            except asyncio.CancelledError:
+                continue
+
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+    )
+    task = asyncio.create_task(stubborn(), name="sideband:call_stuck")
+    runtime = RealtimeRuntime(call_id="call_stuck", openai_call_id="rtc_stuck")
+    runtime.task = task
+    bridge._runtime[runtime.call_id] = runtime
+
+    try:
+        with caplog.at_level("ERROR", logger="app.openai_realtime"):
+            await asyncio.wait_for(bridge.close_all(), timeout=2)
+
+        assert any("sideband:call_stuck" in record.getMessage() for record in caplog.records)
+    finally:
+        release.set()
+        await asyncio.wait_for(task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_stalled_websocket_send_raises_timeout(settings, monkeypatch):
+    monkeypatch.setattr("app.openai_realtime.REALTIME_SEND_TIMEOUT_SECONDS", 0.05)
+
+    class HangingWebSocket:
+        async def send(self, message: str) -> None:
+            # Never returns, modeling a dead TCP connection mid-send.
+            await asyncio.Event().wait()
+
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+    )
+    runtime = RealtimeRuntime(call_id="call_stalled_send", openai_call_id="rtc_stalled_send")
+    runtime.websocket = HangingWebSocket()
+    bridge._runtime[runtime.call_id] = runtime
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(bridge.send(runtime.call_id, {"type": "test.event"}), timeout=1)
+
+
+@pytest.mark.asyncio
 async def test_dispatcher_preserves_fifo_order(settings, monkeypatch):
     websocket = QueueWebSocket()
     handled: list[int] = []

--- a/tests/test_teardown_recovery.py
+++ b/tests/test_teardown_recovery.py
@@ -165,3 +165,36 @@ async def test_get_result_never_in_progress_after_terminal(service, packet):
     response = await service.get_result(call_id)
     assert response["state"] == CallState.COMPLETED
     assert response["result"] is not None
+
+
+@pytest.mark.asyncio
+async def test_failed_compensation_durably_marks_conference_cleanup_pending(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    call = await service.db.get_call(call_id)
+
+    async def failed_complete(_conference):
+        raise RuntimeError("Twilio unavailable")
+
+    monkeypatch.setattr(service._test_twilio, "complete_conference", failed_complete)
+
+    result = await service._complete_conference_or_schedule(call)
+
+    assert result is False
+    stored = await service.db.get_call(call_id)
+    assert stored["conference_cleanup_pending"] == 1
+
+
+@pytest.mark.asyncio
+async def test_recover_startup_completes_pending_conference_cleanup(service, packet):
+    # The call row is already terminal, so it is invisible to list_nonterminal_calls;
+    # only the durable flag lets startup recovery find and finish the orphaned conference.
+    call_id = await seed_call(service.db, packet, state=CallState.COMPLETED)
+    await service.db.set_conference_cleanup_pending(call_id, True)
+
+    await service.recover_startup()
+
+    assert service._test_twilio.completed == ["CF" + "a" * 32]
+    stored = await service.db.get_call(call_id)
+    assert stored["conference_cleanup_pending"] == 0

--- a/tests/test_tool_transfer_safety.py
+++ b/tests/test_tool_transfer_safety.py
@@ -1,0 +1,1065 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import app.call_state as call_state_module
+from app.models import CallState
+from app.twilio_bridge import ParticipantInfo
+from tests.conftest import seed_call
+
+
+def _tool_event(
+    tool_call_id: str,
+    name: str,
+    arguments: str,
+) -> dict[str, str]:
+    return {
+        "type": "response.function_call_arguments.done",
+        "event_id": f"evt_{tool_call_id}",
+        "call_id": tool_call_id,
+        "name": name,
+        "arguments": arguments,
+    }
+
+
+@pytest.mark.asyncio
+async def test_invalid_tool_result_is_sent_before_single_fused_write_finishes(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    original = service.db.record_tool_call
+    write_started = asyncio.Event()
+    release_write = asyncio.Event()
+    writes = 0
+
+    async def blocked_write(*args, **kwargs):
+        nonlocal writes
+        writes += 1
+        write_started.set()
+        await release_write.wait()
+        await original(*args, **kwargs)
+
+    monkeypatch.setattr(service.db, "record_tool_call", blocked_write)
+    handling = asyncio.create_task(
+        service.handle_realtime_event(
+            call_id,
+            _tool_event(
+                "tool_fast",
+                "future_tool",
+                "{}",
+            ),
+        )
+    )
+
+    await asyncio.wait_for(write_started.wait(), timeout=2)
+    await asyncio.sleep(0)
+    assert service._test_realtime.tool_results[-1][1] == "tool_fast"
+    assert not handling.done()
+
+    release_write.set()
+    await asyncio.wait_for(handling, timeout=2)
+    assert writes == 1
+    call = await service.db.get_call(call_id)
+    assert call["tool_call_count"] == 1
+    assert call.get("advisory_outcome") is None
+
+
+@pytest.mark.asyncio
+async def test_valid_advisory_is_durable_before_accepted_output(service, packet, monkeypatch):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    original = service.db.record_tool_call
+    write_started = asyncio.Event()
+    release_write = asyncio.Event()
+
+    async def blocked_write(*args, **kwargs):
+        write_started.set()
+        await release_write.wait()
+        await original(*args, **kwargs)
+
+    monkeypatch.setattr(service.db, "record_tool_call", blocked_write)
+    handling = asyncio.create_task(
+        service.handle_realtime_event(
+            call_id,
+            _tool_event(
+                "tool_durable",
+                "record_call_outcome",
+                '{"status":"completed","summary":"Done","commitments":[],"followUps":[]}',
+            ),
+        )
+    )
+
+    await asyncio.wait_for(write_started.wait(), timeout=2)
+    await asyncio.sleep(0)
+    assert service._test_realtime.tool_results == []
+
+    release_write.set()
+    await asyncio.wait_for(handling, timeout=2)
+    call = await service.db.get_call(call_id)
+    assert call["advisory_outcome"]["summary"] == "Done"
+    assert service._test_realtime.tool_results[-1][2] == {"accepted": True}
+
+
+@pytest.mark.asyncio
+async def test_invalid_and_unknown_tools_count_without_overwriting_valid_advisory(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    events = [
+        _tool_event(
+            "tool_valid",
+            "record_call_outcome",
+            '{"status":"completed","summary":"Keep me","commitments":[],"followUps":[]}',
+        ),
+        _tool_event("tool_invalid", "record_call_outcome", "{}"),
+        _tool_event("tool_unknown", "future_tool", "{}"),
+    ]
+    for event in events:
+        await service.handle_realtime_event(call_id, event)
+
+    call = await service.db.get_call(call_id)
+    assert call["tool_call_count"] == 3
+    assert call["advisory_outcome"]["summary"] == "Keep me"
+    latency_keys = {
+        event["event_key"]
+        for event in await service.db.get_latency_events(call_id)
+        if event["stage"] == "tool_call_received"
+    }
+    assert latency_keys == {"tool_valid", "tool_invalid", "tool_unknown"}
+
+
+@pytest.mark.asyncio
+async def test_response_created_marks_continuation_without_reading_call(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    await service.handle_realtime_event(
+        call_id,
+        _tool_event("tool_1", "future_tool", "{}"),
+    )
+
+    async def forbidden_read(_call_id: str):
+        raise AssertionError("response.created must use one conditional UPDATE")
+
+    monkeypatch.setattr(service.db, "get_call", forbidden_read)
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "response.created", "response": {"id": "resp_after_tool"}},
+    )
+    row = await service.db.fetch_one(
+        "SELECT tool_continuation_observed FROM calls WHERE call_id=?", (call_id,)
+    )
+    assert row["tool_continuation_observed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_ordinary_response_created_performs_no_tool_continuation_write(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    writes = 0
+
+    async def forbidden_write(_call_id: str):
+        nonlocal writes
+        writes += 1
+        raise AssertionError("ordinary responses must not write tool continuation state")
+
+    monkeypatch.setattr(service.db, "mark_tool_continuation_observed", forbidden_write)
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "response.created", "response": {"id": "resp_ordinary"}},
+    )
+
+    assert writes == 0
+    assert service._active_response_ids[call_id] == "resp_ordinary"
+
+
+@pytest.mark.asyncio
+async def test_valid_end_call_arms_fallback_before_persistence_failure(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    fallback_started = asyncio.Event()
+    release_fallback = asyncio.Event()
+
+    async def blocked_fallback(_call_id: str, _tool_call_id: str):
+        fallback_started.set()
+        await release_fallback.wait()
+
+    async def failed_write(*args, **kwargs):
+        del args, kwargs
+        await fallback_started.wait()
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(service, "_voice_end_fallback", blocked_fallback)
+    monkeypatch.setattr(service.db, "record_tool_call", failed_write)
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await service.handle_realtime_event(
+            call_id,
+            _tool_event("tool_end", "end_call", '{"reason":"objective_completed"}'),
+        )
+
+    assert service._voice_end_pending[call_id][0] == "tool_end"
+    assert fallback_started.is_set()
+    release_fallback.set()
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_transfer_runs_in_background_and_duplicate_creates_one_owner(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    create_started = asyncio.Event()
+    release_create = asyncio.Event()
+
+    async def blocked_create(**kwargs):
+        del kwargs
+        service._test_twilio.owner_creates += 1
+        create_started.set()
+        await release_create.wait()
+        return ParticipantInfo("CA" + "c" * 32, "CF" + "a" * 32)
+
+    monkeypatch.setattr(service._test_twilio, "create_owner_participant", blocked_create)
+    await service._handle_tool_call(
+        call_id,
+        _tool_event("tool_transfer_1", "transfer_to_owner", '{"reason":"owner needed"}'),
+    )
+    await asyncio.wait_for(create_started.wait(), timeout=2)
+    transfer_task = service._owner_transfer_tasks[call_id]
+    assert not transfer_task.done()
+
+    await service._handle_tool_call(
+        call_id,
+        _tool_event("tool_transfer_2", "transfer_to_owner", '{"reason":"again"}'),
+    )
+    assert service._test_twilio.owner_creates == 1
+    assert service._test_realtime.tool_results[-1][2]["accepted"] is False
+
+    service._owner_join_events[call_id].set()
+    release_create.set()
+    assert (await asyncio.wait_for(asyncio.shield(transfer_task), timeout=2))["accepted"] is True
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.TRANSFERRED.value
+    assert call["tool_call_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_joining_claim_still_registers_transfer_worker(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    original_claim = service.db.claim_transfer_joining
+    claim_committed = asyncio.Event()
+    release_claim = asyncio.Event()
+
+    async def committed_then_blocked(*args, **kwargs):
+        claimed = await original_claim(*args, **kwargs)
+        claim_committed.set()
+        await release_claim.wait()
+        return claimed
+
+    monkeypatch.setattr(service.db, "claim_transfer_joining", committed_then_blocked)
+    starting = asyncio.create_task(
+        service._start_owner_transfer(call_id, "owner needed", tool_call_id=None)
+    )
+    await asyncio.wait_for(claim_committed.wait(), timeout=2)
+    starting.cancel()
+    await asyncio.sleep(0)
+    assert not starting.done()
+
+    release_claim.set()
+    transfer_task, error = await asyncio.wait_for(starting, timeout=2)
+    assert error is None
+    assert transfer_task is service._owner_transfer_tasks[call_id]
+    service._owner_join_events[call_id].set()
+    assert (await asyncio.wait_for(transfer_task, timeout=2))["accepted"] is True
+
+
+@pytest.mark.asyncio
+async def test_cancel_after_termination_claim_still_finishes_media_and_terminal_state(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    hangup_started = asyncio.Event()
+    release_hangup = asyncio.Event()
+
+    async def blocked_hangup(openai_call_id):
+        service._test_realtime.hangups.append(openai_call_id)
+        hangup_started.set()
+        await release_hangup.wait()
+
+    monkeypatch.setattr(service._test_realtime, "hangup", blocked_hangup)
+    terminating = asyncio.create_task(service.terminate_call(call_id, "owner_request"))
+    await asyncio.wait_for(hangup_started.wait(), timeout=2)
+    claimed = await service.db.get_call(call_id)
+    assert claimed["state"] == CallState.TERMINATING.value
+    assert claimed["termination_claimed"] == 1
+
+    terminating.cancel()
+    await asyncio.sleep(0)
+    assert not terminating.done()
+    release_hangup.set()
+    assert await asyncio.wait_for(terminating, timeout=2) is True
+
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.COMPLETED.value
+    assert service._test_twilio.completed == ["CF" + "a" * 32]
+    assert service._test_realtime.closed == [call_id]
+
+
+@pytest.mark.asyncio
+async def test_termination_claim_commit_then_raise_is_reconciled(service, packet, monkeypatch):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    original_claim = service.db.claim_termination
+
+    async def commit_then_raise(*args, **kwargs):
+        assert await original_claim(*args, **kwargs) is not None
+        raise RuntimeError("connection lost after commit")
+
+    monkeypatch.setattr(service.db, "claim_termination", commit_then_raise)
+
+    assert await service.terminate_call(call_id, "owner_request") is True
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.COMPLETED.value
+    assert call["termination_reason"] == "owner_request"
+    assert service._test_twilio.completed == ["CF" + "a" * 32]
+
+
+@pytest.mark.asyncio
+async def test_joining_claim_commit_then_raise_spawns_one_transfer_worker(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    service._owner_join_events.setdefault(call_id, asyncio.Event()).set()
+    original_claim = service.db.claim_transfer_joining
+
+    async def commit_then_raise(*args, **kwargs):
+        assert await original_claim(*args, **kwargs) is True
+        raise RuntimeError("connection lost after commit")
+
+    monkeypatch.setattr(service.db, "claim_transfer_joining", commit_then_raise)
+    result = await service.transfer_to_owner(call_id, "owner needed")
+
+    assert result["accepted"] is True
+    assert service._test_twilio.owner_creates == 1
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.TRANSFERRED.value
+    assert call["twilio_owner_call_sid"] == "CA" + "c" * 32
+
+
+@pytest.mark.asyncio
+async def test_termination_waits_for_late_owner_create_and_cleans_sid_once(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    create_started = asyncio.Event()
+    release_create = asyncio.Event()
+
+    async def late_create(**kwargs):
+        del kwargs
+        service._test_twilio.owner_creates += 1
+        create_started.set()
+        await release_create.wait()
+        return ParticipantInfo("CA" + "c" * 32, "CF" + "a" * 32)
+
+    monkeypatch.setattr(service._test_twilio, "create_owner_participant", late_create)
+    await service._handle_tool_call(
+        call_id,
+        _tool_event("tool_transfer", "transfer_to_owner", '{"reason":"owner needed"}'),
+    )
+    await asyncio.wait_for(create_started.wait(), timeout=2)
+
+    terminating = asyncio.create_task(service.terminate_call(call_id, "owner_request"))
+    await asyncio.sleep(0)
+    assert not terminating.done()
+    release_create.set()
+    assert await asyncio.wait_for(terminating, timeout=2) is True
+
+    owner_sid = "CA" + "c" * 32
+    conference = "CF" + "a" * 32
+    assert service._test_twilio.removed.count((conference, owner_sid)) == 1
+    assert service._test_twilio.completed == [conference]
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.COMPLETED.value
+    assert call["transfer_outcome"] == "failed:termination_won"
+    assert call_id not in service._owner_transfer_tasks
+
+
+@pytest.mark.asyncio
+async def test_owner_join_timeout_cleanup_failure_completes_conference(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    attempts: list[str | None] = []
+
+    async def failed_remove(conference, participant_call_sid):
+        del conference
+        attempts.append(participant_call_sid)
+        raise RuntimeError("Twilio cleanup failed")
+
+    monkeypatch.setattr(call_state_module, "OWNER_JOIN_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(service._test_twilio, "remove_participant", failed_remove)
+    result = await service.transfer_to_owner(call_id, "owner needed")
+
+    assert result["accepted"] is False
+    assert attempts == ["CA" + "c" * 32]
+    assert service._test_twilio.completed == ["CF" + "a" * 32]
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.FAILED.value
+    assert call["termination_reason"] == "transfer_cleanup_failed"
+
+
+@pytest.mark.asyncio
+async def test_required_conference_completion_failure_stays_recoverable(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    attempts = 0
+    original_complete = service._test_twilio.complete_conference
+
+    async def failed_complete(_conference):
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("Twilio unavailable")
+
+    monkeypatch.setattr(call_state_module, "TERMINATION_MEDIA_RETRY_DELAY_SECONDS", 0)
+    monkeypatch.setattr(service._test_twilio, "complete_conference", failed_complete)
+    assert await service.terminate_call(call_id, "owner_request") is False
+
+    stranded = await service.db.get_call(call_id)
+    assert attempts == 2
+    assert stranded["state"] == CallState.TERMINATING.value
+    assert stranded["termination_claimed"] == 1
+    assert service._test_finalizer.states_seen == []
+
+    monkeypatch.setattr(service._test_twilio, "complete_conference", original_complete)
+    await service.recover_startup()
+    recovered = await service.db.get_call(call_id)
+    assert recovered["state"] == CallState.FAILED.value
+    assert recovered["termination_reason"] == "startup_recovery"
+    assert service._test_twilio.completed == ["CF" + "a" * 32]
+
+
+@pytest.mark.asyncio
+async def test_required_conference_completion_succeeds_via_live_background_retry(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    attempts = 0
+    recovered = asyncio.Event()
+    original_complete = service._test_twilio.complete_conference
+
+    async def transient_complete(conference):
+        nonlocal attempts
+        attempts += 1
+        if attempts <= 2:
+            raise RuntimeError("temporary Twilio outage")
+        await original_complete(conference)
+        recovered.set()
+
+    monkeypatch.setattr(call_state_module, "TERMINATION_MEDIA_RETRY_DELAY_SECONDS", 0)
+    monkeypatch.setattr(call_state_module, "TERMINATION_MEDIA_BACKGROUND_RETRY_BASE_SECONDS", 0)
+    monkeypatch.setattr(service._test_twilio, "complete_conference", transient_complete)
+
+    assert await service.terminate_call(call_id, "owner_request") is False
+    await asyncio.wait_for(recovered.wait(), timeout=2)
+    for _ in range(50):
+        if (await service.db.get_call(call_id))["state"] == CallState.COMPLETED.value:
+            break
+        await asyncio.sleep(0.01)
+
+    assert attempts == 3
+    assert (await service.db.get_call(call_id))["state"] == CallState.COMPLETED.value
+    assert service._test_twilio.completed == ["CF" + "a" * 32]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_failed_background_retry_after_current_attempt(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    attempts = 0
+    background_attempt_started = asyncio.Event()
+    release_background_attempt = asyncio.Event()
+
+    async def fail_with_blocked_background(_conference):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 3:
+            background_attempt_started.set()
+            await release_background_attempt.wait()
+        raise RuntimeError("Twilio unavailable")
+
+    monkeypatch.setattr(call_state_module, "TERMINATION_MEDIA_RETRY_DELAY_SECONDS", 0)
+    monkeypatch.setattr(call_state_module, "TERMINATION_MEDIA_BACKGROUND_RETRY_BASE_SECONDS", 0)
+    monkeypatch.setattr(service._test_twilio, "complete_conference", fail_with_blocked_background)
+
+    assert await service.terminate_call(call_id, "owner_request") is False
+    await asyncio.wait_for(background_attempt_started.wait(), timeout=2)
+    stopping = asyncio.create_task(service.stop())
+    await asyncio.sleep(0)
+    assert not stopping.done()
+    release_background_attempt.set()
+    await asyncio.wait_for(stopping, timeout=2)
+
+    # Shutdown may make one final idempotent teardown attempt, but cancellation
+    # must stop the unbounded retry loop promptly.
+    assert 3 <= attempts < 10
+    assert service._conference_retry_tasks == {}
+    assert (await service.db.get_call(call_id))["state"] == CallState.TERMINATING.value
+
+
+@pytest.mark.asyncio
+async def test_startup_recovery_continues_other_rows_during_sustained_twilio_failure(
+    service, packet, monkeypatch
+):
+    failing_call = await seed_call(
+        service.db,
+        packet,
+        call_id="call_recovery_failing",
+        state=CallState.ACTIVE,
+        openai_call_id="rtc_recovery_failing",
+    )
+    healthy_call = await seed_call(
+        service.db,
+        packet,
+        call_id="call_recovery_healthy",
+        state=CallState.ACTIVE,
+        openai_call_id="rtc_recovery_healthy",
+    )
+    failing_conference = "CF" + "f" * 32
+    healthy_conference = "CF" + "h" * 32
+    await service.db.update_call(failing_call, conference_sid=failing_conference)
+    await service.db.update_call(healthy_call, conference_sid=healthy_conference)
+    original_complete = service._test_twilio.complete_conference
+
+    async def selectively_fail(conference):
+        if conference == failing_conference:
+            raise RuntimeError("sustained Twilio outage")
+        await original_complete(conference)
+
+    service.settings.max_call_seconds = 0.05
+    monkeypatch.setattr(call_state_module, "TERMINATION_MEDIA_RETRY_DELAY_SECONDS", 0)
+    monkeypatch.setattr(call_state_module, "TERMINATION_MEDIA_BACKGROUND_RETRY_BASE_SECONDS", 0.01)
+    monkeypatch.setattr(call_state_module, "TERMINATION_MEDIA_BACKGROUND_RETRY_MAX_SECONDS", 0.01)
+    monkeypatch.setattr(service._test_twilio, "complete_conference", selectively_fail)
+
+    await asyncio.wait_for(service.recover_startup(), timeout=2)
+
+    assert (await service.db.get_call(failing_call))["state"] == CallState.TERMINATING.value
+    assert (await service.db.get_call(healthy_call))["state"] == CallState.FAILED.value
+    assert healthy_conference in service._test_twilio.completed
+
+
+@pytest.mark.asyncio
+async def test_db_outage_after_owner_create_cleans_owner_before_conference(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    service._owner_join_events.setdefault(call_id, asyncio.Event()).set()
+    order: list[str] = []
+    original_remove = service._test_twilio.remove_participant
+    original_complete = service._test_twilio.complete_conference
+
+    async def tracked_remove(conference, participant_call_sid):
+        order.append("remove_owner")
+        await original_remove(conference, participant_call_sid)
+
+    async def tracked_complete(conference):
+        order.append("complete_conference")
+        await original_complete(conference)
+
+    async def db_unavailable(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(service._test_twilio, "remove_participant", tracked_remove)
+    monkeypatch.setattr(service._test_twilio, "complete_conference", tracked_complete)
+    monkeypatch.setattr(service.db, "promote_transfer", db_unavailable)
+    monkeypatch.setattr(service.db, "fail_joining_transfer", db_unavailable)
+
+    result = await service.transfer_to_owner(call_id, "owner needed")
+
+    assert result["accepted"] is False
+    assert order == ["remove_owner", "complete_conference"]
+    assert service._test_twilio.removed == [("CF" + "a" * 32, "CA" + "c" * 32)]
+    assert service._test_twilio.completed == ["CF" + "a" * 32]
+
+
+@pytest.mark.asyncio
+async def test_failed_direct_compensation_is_owned_by_background_retry(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    service._owner_join_events.setdefault(call_id, asyncio.Event()).set()
+    attempts = 0
+    compensated = asyncio.Event()
+    original_complete = service._test_twilio.complete_conference
+
+    async def db_unavailable(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("database unavailable")
+
+    async def transient_complete(conference):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("Twilio temporarily unavailable")
+        await original_complete(conference)
+        compensated.set()
+
+    monkeypatch.setattr(call_state_module, "TERMINATION_MEDIA_BACKGROUND_RETRY_BASE_SECONDS", 0)
+    monkeypatch.setattr(service.db, "promote_transfer", db_unavailable)
+    monkeypatch.setattr(service.db, "fail_joining_transfer", db_unavailable)
+    monkeypatch.setattr(service.db, "fail_promoted_transfer", db_unavailable)
+    monkeypatch.setattr(service._test_twilio, "complete_conference", transient_complete)
+
+    result = await service.transfer_to_owner(call_id, "owner needed")
+    await asyncio.wait_for(compensated.wait(), timeout=2)
+
+    assert result["accepted"] is False
+    assert attempts == 2
+    assert service._test_twilio.completed == ["CF" + "a" * 32]
+
+
+@pytest.mark.asyncio
+async def test_promotion_commit_then_exception_is_adopted_and_torn_down(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    service._owner_join_events.setdefault(call_id, asyncio.Event()).set()
+    original_promote = service.db.promote_transfer
+
+    async def commit_then_raise(*args, **kwargs):
+        assert await original_promote(*args, **kwargs) is not None
+        raise RuntimeError("connection lost after commit")
+
+    monkeypatch.setattr(service.db, "promote_transfer", commit_then_raise)
+    result = await service.transfer_to_owner(call_id, "owner needed")
+
+    assert result["accepted"] is False
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.FAILED.value
+    assert call["transfer_outcome"] == "failed:RuntimeError"
+    assert service._test_twilio.removed == [("CF" + "a" * 32, "CA" + "c" * 32)]
+    assert service._test_twilio.completed == ["CF" + "a" * 32]
+
+
+@pytest.mark.asyncio
+async def test_completion_commit_then_exception_cannot_recover_as_transferred(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    service._owner_join_events.setdefault(call_id, asyncio.Event()).set()
+    original_complete = service.db.complete_promoted_transfer
+
+    async def commit_then_raise(*args, **kwargs):
+        assert await original_complete(*args, **kwargs) is True
+        raise RuntimeError("connection lost after commit")
+
+    monkeypatch.setattr(service.db, "complete_promoted_transfer", commit_then_raise)
+    result = await service.transfer_to_owner(call_id, "owner needed")
+
+    assert result["accepted"] is False
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.FAILED.value
+    assert call["transfer_outcome"] == "failed:RuntimeError"
+    assert call["termination_reason"] == "transfer_failed:RuntimeError"
+    assert service._test_twilio.completed == ["CF" + "a" * 32]
+
+
+@pytest.mark.asyncio
+async def test_terminal_cas_failure_never_returns_success_and_ends_conference(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    service._owner_join_events.setdefault(call_id, asyncio.Event()).set()
+
+    async def lost_terminal_cas(*args, **kwargs):
+        del args, kwargs
+        return False
+
+    monkeypatch.setattr(service.db, "finish_claimed_termination", lost_terminal_cas)
+    result = await service.transfer_to_owner(call_id, "owner needed")
+
+    assert result["accepted"] is False
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.TERMINATING.value
+    assert call["transfer_outcome"] == "failed:terminal_cas"
+    assert call["termination_reason"] == "transfer_failed:terminal_cas"
+    assert service._test_twilio.removed == [
+        ("CF" + "a" * 32, "CA" + "a" * 32),
+        ("CF" + "a" * 32, "CA" + "c" * 32),
+    ]
+    assert service._test_twilio.completed
+    assert service._test_finalizer.states_seen == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ambiguous_result", ["raise", "false"])
+async def test_transferred_terminal_commit_ambiguity_preserves_handoff(
+    service, packet, monkeypatch, ambiguous_result
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    service._owner_join_events.setdefault(call_id, asyncio.Event()).set()
+    original_finish = service.db.finish_claimed_termination
+
+    async def commit_then_ambiguous(*args, **kwargs):
+        assert await original_finish(*args, **kwargs) is True
+        if ambiguous_result == "raise":
+            raise RuntimeError("connection lost after commit")
+        return False
+
+    monkeypatch.setattr(service.db, "finish_claimed_termination", commit_then_ambiguous)
+    result = await service.transfer_to_owner(call_id, "owner needed")
+
+    assert result["accepted"] is True
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.TRANSFERRED.value
+    assert call["termination_reason"] == "transfer_completed"
+    assert call["transfer_outcome"] == "completed:owner needed"
+    assert service._test_twilio.completed == []
+    assert service._test_twilio.end_on_exit == [("CF" + "a" * 32, "CA" + "c" * 32)]
+
+
+@pytest.mark.asyncio
+async def test_terminal_transcript_failure_cannot_undo_transferred_call(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    service._owner_join_events.setdefault(call_id, asyncio.Event()).set()
+
+    async def failed_transcript(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("transcript database unavailable")
+
+    monkeypatch.setattr(service.db, "add_transcript_turn", failed_transcript)
+    result = await service.transfer_to_owner(call_id, "owner needed")
+
+    assert result["accepted"] is True
+    assert (await service.db.get_call(call_id))["state"] == CallState.TRANSFERRED.value
+    assert service._test_twilio.completed == []
+    assert service._test_twilio.end_on_exit == [("CF" + "a" * 32, "CA" + "c" * 32)]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cannot_cancel_transfer_after_terminal_commit(service, packet, monkeypatch):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    service._owner_join_events.setdefault(call_id, asyncio.Event()).set()
+    bookkeeping_started = asyncio.Event()
+    release_bookkeeping = asyncio.Event()
+
+    async def blocked_terminal_bookkeeping(*args, **kwargs):
+        del args, kwargs
+        bookkeeping_started.set()
+        await release_bookkeeping.wait()
+
+    monkeypatch.setattr(service.db, "add_transcript_turn", blocked_terminal_bookkeeping)
+    transferring = asyncio.create_task(service.transfer_to_owner(call_id, "owner needed"))
+    await asyncio.wait_for(bookkeeping_started.wait(), timeout=2)
+    assert (await service.db.get_call(call_id))["state"] == CallState.TRANSFERRED.value
+
+    stopping = asyncio.create_task(service.stop())
+    await asyncio.sleep(0)
+    assert not stopping.done()
+    release_bookkeeping.set()
+    await asyncio.wait_for(stopping, timeout=2)
+
+    assert (await asyncio.wait_for(transferring, timeout=2))["accepted"] is True
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.TRANSFERRED.value
+    assert call["transfer_outcome"] == "completed:owner needed"
+    assert service._test_twilio.completed == []
+    assert ("CF" + "a" * 32, "CA" + "c" * 32) not in service._test_twilio.removed
+
+
+@pytest.mark.asyncio
+async def test_owner_leave_after_join_aborts_before_ai_handoff(service, packet, monkeypatch):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    original_promote = service.db.promote_transfer
+    promotion_committed = asyncio.Event()
+    release_promotion = asyncio.Event()
+
+    async def committed_then_blocked(*args, **kwargs):
+        promoted = await original_promote(*args, **kwargs)
+        promotion_committed.set()
+        await release_promotion.wait()
+        return promoted
+
+    monkeypatch.setattr(service.db, "promote_transfer", committed_then_blocked)
+    transferring = asyncio.create_task(service.transfer_to_owner(call_id, "owner needed"))
+    for _ in range(50):
+        if call_id in service._owner_expected_sids:
+            break
+        await asyncio.sleep(0.01)
+    owner_sid = "CA" + "c" * 32
+    await service.handle_conference_event(
+        call_id,
+        {
+            "StatusCallbackEvent": "participant-join",
+            "ParticipantLabel": "owner",
+            "CallSid": owner_sid,
+        },
+    )
+    await asyncio.wait_for(promotion_committed.wait(), timeout=2)
+    await service.handle_conference_event(
+        call_id,
+        {
+            "StatusCallbackEvent": "participant-leave",
+            "ParticipantLabel": "owner",
+            "CallSid": owner_sid,
+        },
+    )
+    release_promotion.set()
+
+    result = await asyncio.wait_for(transferring, timeout=2)
+    assert result["accepted"] is False
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.FAILED.value
+    assert call["transfer_outcome"] == "failed:OwnerTransferDeparted"
+    assert ("CF" + "a" * 32, "CA" + "a" * 32) not in service._test_twilio.removed
+    assert service._test_twilio.completed == ["CF" + "a" * 32]
+
+
+@pytest.mark.asyncio
+async def test_ai_removal_failure_rolls_back_owner_and_fails_call(service, packet, monkeypatch):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    service._owner_join_events.setdefault(call_id, asyncio.Event()).set()
+    original_remove = service._test_twilio.remove_participant
+    ai_sid = "CA" + "a" * 32
+
+    async def fail_ai_only(conference, participant_call_sid):
+        if participant_call_sid == ai_sid:
+            raise RuntimeError("AI removal failed")
+        await original_remove(conference, participant_call_sid)
+
+    monkeypatch.setattr(service._test_twilio, "remove_participant", fail_ai_only)
+    result = await service.transfer_to_owner(call_id, "owner needed")
+
+    assert result["accepted"] is False
+    conference = "CF" + "a" * 32
+    assert service._test_twilio.removed == [(conference, "CA" + "c" * 32)]
+    assert service._test_twilio.completed == [conference]
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.FAILED.value
+    assert call["transfer_outcome"] == "failed:RuntimeError"
+    assert call["termination_reason"] == "transfer_failed:RuntimeError"
+
+    retry = await service.transfer_to_owner(call_id, "retry")
+    assert retry["accepted"] is False
+    assert service._test_twilio.owner_creates == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("transfer_outcome", "expected_state", "conference_completed"),
+    [
+        ("joining:owner needed", CallState.FAILED, True),
+        ("in_progress:owner needed", CallState.FAILED, True),
+        ("completed:owner needed", CallState.TRANSFERRED, False),
+    ],
+)
+async def test_startup_recovery_is_conservative_until_transfer_completed(
+    service,
+    packet,
+    transfer_outcome,
+    expected_state,
+    conference_completed,
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    promoted = transfer_outcome.startswith(("in_progress:", "completed:"))
+    await service.db.update_call(
+        call_id,
+        state=CallState.TERMINATING.value if promoted else CallState.ACTIVE.value,
+        transfer_outcome=transfer_outcome,
+        twilio_owner_call_sid=("CA" + "c" * 32)
+        if transfer_outcome.startswith("completed:")
+        else None,
+        termination_claimed=int(promoted),
+        termination_reason="transfer_completed" if promoted else None,
+    )
+
+    await service.recover_startup()
+
+    call = await service.db.get_call(call_id)
+    assert call["state"] == expected_state.value
+    assert bool(service._test_twilio.completed) is conference_completed
+    if expected_state == CallState.FAILED:
+        assert call["transfer_outcome"] == "failed:startup_recovery"
+    else:
+        assert call["transfer_outcome"] == transfer_outcome
+        assert service._test_twilio.end_on_exit == [("CF" + "a" * 32, "CA" + "c" * 32)]
+
+
+@pytest.mark.asyncio
+async def test_completed_transfer_without_persisted_owner_sid_fails_closed_on_restart(
+    service, packet
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    await service.db.update_call(
+        call_id,
+        state=CallState.TERMINATING.value,
+        transfer_outcome="completed:owner needed",
+        termination_claimed=1,
+        termination_reason="transfer_completed",
+        twilio_owner_call_sid=None,
+    )
+
+    await service.recover_startup()
+
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.FAILED.value
+    assert call["transfer_outcome"] == "failed:owner_exit_unarmed"
+    assert call["termination_reason"] == "transfer_failed:owner_exit_unarmed"
+    assert service._test_twilio.completed == ["CF" + "a" * 32]
+
+
+@pytest.mark.asyncio
+async def test_transferred_owner_is_armed_to_end_conference_after_process_state_clears(
+    service, packet
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    service._owner_join_events.setdefault(call_id, asyncio.Event()).set()
+    result = await service.transfer_to_owner(call_id, "owner needed")
+
+    assert result["accepted"] is True
+    assert service._test_twilio.end_on_exit == [("CF" + "a" * 32, "CA" + "c" * 32)]
+    assert call_id not in service._owner_join_events
+    await service.handle_participant_status(
+        call_id,
+        "owner",
+        {"CallStatus": "completed", "CallSid": "CA" + "c" * 32},
+    )
+    assert (await service.db.get_call(call_id))["state"] == CallState.TRANSFERRED.value
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancellation_cannot_interrupt_transfer_compensation(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    failure_write_started = asyncio.Event()
+    release_failure_write = asyncio.Event()
+    original_fail = service.db.fail_joining_transfer
+
+    async def failed_owner_remove(_conference, _participant_call_sid):
+        raise RuntimeError("owner delete failed")
+
+    async def blocked_failure_write(*args, **kwargs):
+        failure_write_started.set()
+        await release_failure_write.wait()
+        return await original_fail(*args, **kwargs)
+
+    monkeypatch.setattr(call_state_module, "OWNER_JOIN_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(service._test_twilio, "remove_participant", failed_owner_remove)
+    monkeypatch.setattr(service.db, "fail_joining_transfer", blocked_failure_write)
+
+    transferring = asyncio.create_task(service.transfer_to_owner(call_id, "owner needed"))
+    await asyncio.wait_for(failure_write_started.wait(), timeout=2)
+    stopping = asyncio.create_task(service.stop())
+    await asyncio.sleep(0)
+    assert not stopping.done()
+    release_failure_write.set()
+    await asyncio.wait_for(stopping, timeout=2)
+
+    assert (await asyncio.wait_for(transferring, timeout=2))["accepted"] is False
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.FAILED.value
+    assert call["termination_reason"] == "service_shutdown"
+    assert service._test_twilio.completed
+    assert set(service._test_twilio.completed) == {"CF" + "a" * 32}
+
+
+@pytest.mark.asyncio
+async def test_stop_drains_joining_claim_committed_after_shutdown_snapshot(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    claim_committed = asyncio.Event()
+    release_claim = asyncio.Event()
+    original_claim = service.db.claim_transfer_joining
+
+    async def committed_then_blocked(*args, **kwargs):
+        claimed = await original_claim(*args, **kwargs)
+        claim_committed.set()
+        await release_claim.wait()
+        return claimed
+
+    monkeypatch.setattr(service.db, "claim_transfer_joining", committed_then_blocked)
+    starting = asyncio.create_task(
+        service._start_owner_transfer(call_id, "owner needed", tool_call_id=None)
+    )
+    await asyncio.wait_for(claim_committed.wait(), timeout=2)
+    stopping = asyncio.create_task(service.stop())
+    await asyncio.sleep(0)
+    release_claim.set()
+
+    await asyncio.wait_for(stopping, timeout=2)
+    transfer_task, error = await asyncio.wait_for(starting, timeout=2)
+    assert transfer_task is None
+    assert error == "service is stopping"
+    assert service._test_twilio.owner_creates == 0
+    call = await service.db.get_call(call_id)
+    assert call["transfer_outcome"] == "failed:service_stopping"
+    assert service._background == set()
+
+
+@pytest.mark.asyncio
+async def test_stop_fails_closed_for_an_unexpected_active_call(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+
+    await asyncio.wait_for(service.stop(), timeout=2)
+
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.FAILED.value
+    assert call["termination_reason"] == "service_shutdown"
+    assert service._test_realtime.hangups == ["rtc_test"]
+    assert service._test_twilio.completed == ["CF" + "a" * 32]
+    assert service._test_realtime.close_all_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cleans_owner_created_after_transfer_task_cancellation(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    create_started = asyncio.Event()
+    release_create = asyncio.Event()
+
+    async def late_create(**kwargs):
+        del kwargs
+        create_started.set()
+        await release_create.wait()
+        return ParticipantInfo("CA" + "c" * 32, "CF" + "a" * 32)
+
+    monkeypatch.setattr(service._test_twilio, "create_owner_participant", late_create)
+    await service._handle_tool_call(
+        call_id,
+        _tool_event("tool_transfer", "transfer_to_owner", '{"reason":"owner needed"}'),
+    )
+    await asyncio.wait_for(create_started.wait(), timeout=2)
+
+    stopping = asyncio.create_task(service.stop())
+    await asyncio.sleep(0)
+    assert not stopping.done()
+    release_create.set()
+    await asyncio.wait_for(stopping, timeout=2)
+
+    assert service._test_twilio.removed == [("CF" + "a" * 32, "CA" + "c" * 32)]
+    assert call_id not in service._owner_transfer_tasks
+
+
+@pytest.mark.asyncio
+async def test_ordinary_termination_atomically_aborts_joining_before_promotion(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    assert await service.db.claim_transfer_joining(call_id, "owner needed")
+
+    claimed = await service.db.claim_termination(call_id, "owner_request")
+
+    assert claimed is not None
+    assert claimed["state"] == CallState.TERMINATING.value
+    assert claimed["termination_claimed"] == 1
+    assert claimed["termination_reason"] == "owner_request"
+    assert claimed["transfer_outcome"] == "failed:termination_won"
+    assert await service.db.promote_transfer(call_id, "owner needed") is None

--- a/tests/test_tool_transfer_safety.py
+++ b/tests/test_tool_transfer_safety.py
@@ -128,6 +128,57 @@ async def test_invalid_and_unknown_tools_count_without_overwriting_valid_advisor
 
 
 @pytest.mark.asyncio
+async def test_nontransfer_tool_result_send_race_does_not_propagate(service, packet, monkeypatch):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+
+    async def teardown_race(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("sideband is not open")
+
+    monkeypatch.setattr(service.realtime, "send_tool_result", teardown_race)
+
+    # Must not raise: a benign teardown race sending the tool result cannot escalate
+    # into a fatal error, but the durable write still has to land.
+    await service.handle_realtime_event(
+        call_id,
+        _tool_event("tool_race", "future_tool", "{}"),
+    )
+
+    call = await service.db.get_call(call_id)
+    assert call["tool_call_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_advisory_persistence_failure_sends_rejection_and_propagates(
+    service, packet, monkeypatch
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+
+    async def failing_write(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(service.db, "record_tool_call", failing_write)
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await service.handle_realtime_event(
+            call_id,
+            _tool_event(
+                "tool_advisory_fail",
+                "record_call_outcome",
+                '{"status":"completed","summary":"Done","commitments":[],"followUps":[]}',
+            ),
+        )
+
+    # The model must still receive a tool result even though its outcome was lost.
+    assert service._test_realtime.tool_results[-1] == (
+        call_id,
+        "tool_advisory_fail",
+        {"accepted": False, "error": "outcome could not be persisted"},
+    )
+
+
+@pytest.mark.asyncio
 async def test_response_created_marks_continuation_without_reading_call(
     service, packet, monkeypatch
 ):
@@ -1063,3 +1114,19 @@ async def test_ordinary_termination_atomically_aborts_joining_before_promotion(s
     assert claimed["termination_reason"] == "owner_request"
     assert claimed["transfer_outcome"] == "failed:termination_won"
     assert await service.db.promote_transfer(call_id, "owner needed") is None
+
+
+@pytest.mark.asyncio
+async def test_spawned_task_failure_is_logged(service, caplog):
+    async def boom() -> None:
+        raise RuntimeError("background task exploded")
+
+    with caplog.at_level("ERROR", logger="app.call_state"):
+        task = service._spawn(boom(), name="test-boom-task")
+        with pytest.raises(RuntimeError, match="background task exploded"):
+            await task
+
+    assert any(
+        record.levelname == "ERROR" and "test-boom-task" in record.getMessage()
+        for record in caplog.records
+    )

--- a/tests/test_tool_transfer_safety.py
+++ b/tests/test_tool_transfer_safety.py
@@ -1117,6 +1117,36 @@ async def test_ordinary_termination_atomically_aborts_joining_before_promotion(s
 
 
 @pytest.mark.asyncio
+async def test_transfer_claim_during_prewarming_with_callee_joined_completes(service, packet):
+    # The opening turn starts as soon as the callee answers, while the durable state is
+    # still prewarming (AMD/activation converge asynchronously). A transfer requested in
+    # that window must still be able to claim and complete.
+    call_id = await seed_call(service.db, packet, state=CallState.PREWARMING)
+    await service.db.update_call(call_id, callee_joined=1)
+    service._owner_join_events.setdefault(call_id, asyncio.Event()).set()
+
+    result = await service.transfer_to_owner(call_id, "owner needed")
+
+    assert result["accepted"] is True
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.TRANSFERRED.value
+    assert call["transfer_outcome"] == "completed:owner needed"
+
+
+@pytest.mark.asyncio
+async def test_transfer_claim_before_callee_joined_is_rejected(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.PREWARMING)
+
+    result = await service.transfer_to_owner(call_id, "owner needed")
+
+    assert result["accepted"] is False
+    assert result["error"] == "owner transfer already attempted or call is ending"
+    call = await service.db.get_call(call_id)
+    assert call["transfer_outcome"] is None
+    assert service._test_twilio.owner_creates == 0
+
+
+@pytest.mark.asyncio
 async def test_spawned_task_failure_is_logged(service, caplog):
     async def boom() -> None:
         raise RuntimeError("background task exploded")


### PR DESCRIPTION
## Summary
- Cut live-call setup and turn latency with stage telemetry, leaner realtime connection/dispatch, and coalesced heartbeat writes.
- Make tool and transfer handling nonblocking so call audio/control paths are not stalled by side work.
- Switch the realtime voice from `marin` to `echo`.

## Test plan
- [ ] `uv run ruff format --check app tests scripts`
- [ ] `uv run ruff check app tests scripts`
- [ ] `uv run pytest -q`
- [ ] Spot-check a live call for faster setup/first turn and no regressions in tool use or transfer
- [ ] Confirm heartbeat/activity persistence still updates under load


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xiyaowang0519/poke-call/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->