### PR TITLE
Fix goodbye cutoff: drain SIP audio before hangup, gate end_call on callee engagement

### DIFF
--- a/app/call_state.py
+++ b/app/call_state.py
@@ -41,6 +41,13 @@ logger = logging.getLogger(__name__)
 CALL_ACTIVITY_TOMBSTONE_TTL_SECONDS = 15 * 60
 CALL_ACTIVITY_TOMBSTONE_MAX = 4096
 OWNER_JOIN_TIMEOUT_SECONDS = 30
+# Over SIP, response.done marks the end of audio *generation*; playback to the phone lags
+# behind because OpenAI drains a server-side output buffer in real time. Termination after a
+# final spoken turn (voice-initiated end_call goodbye, voicemail) must wait for
+# output_audio_buffer.stopped or the callee hears the closing words cut off. The fallback
+# below bounds that wait in case the event is never delivered; it stays under the 15s
+# watchdog staleness window so a completed call is not misreported as timed out.
+TERMINATION_AUDIO_DRAIN_TIMEOUT_SECONDS = 12.0
 TERMINATION_MEDIA_RETRY_DELAY_SECONDS = 0.1
 TERMINATION_MEDIA_BACKGROUND_RETRY_BASE_SECONDS = 0.5
 TERMINATION_MEDIA_BACKGROUND_RETRY_MAX_SECONDS = 15.0
@@ -91,6 +98,7 @@ class CallService:
         self._owner_transfer_locks: dict[str, asyncio.Lock] = {}
         self._opening_transition_locks: dict[str, asyncio.Lock] = {}
         self._voice_end_pending: dict[str, tuple[str, str | None]] = {}
+        self._audio_drain_terminations: dict[str, tuple[str | None, str]] = {}
         self._active_response_ids: dict[str, str | None] = {}
         self._tool_seen_calls: set[str] = set()
         self._queued_latency_events: dict[tuple[str, LatencyStage, str], LatencyMark] = {}
@@ -859,10 +867,13 @@ class CallService:
             # A cancelled response.done here is the opening turn we cancelled when AMD
             # reported voicemail; the voicemail response itself is still in flight.
             if call and call.get("voicemail_sent") and status not in {"cancelled", "canceled"}:
-                self._spawn(
-                    self.terminate_call(call_id, "voicemail_left"),
-                    name=f"terminate:{call_id}:voicemail",
+                self._terminate_after_audio_drain(
+                    call_id,
+                    response.get("id") or event.get("response_id"),
+                    "voicemail_left",
                 )
+        elif event_type in {"output_audio_buffer.stopped", "output_audio_buffer.cleared"}:
+            self._handle_output_audio_drained(call_id, event)
         elif event_type in {"session.ended", "call.ended"}:
             self._spawn(
                 self.terminate_call(call_id, "openai_terminal_event"),
@@ -1093,10 +1104,7 @@ class CallService:
         if status != "completed":
             return
         self._voice_end_pending.pop(call_id, None)
-        self._spawn(
-            self.terminate_call(call_id, "voice_model_end_call"),
-            name=f"terminate:{call_id}:voice-end",
-        )
+        self._terminate_after_audio_drain(call_id, response_id, "voice_model_end_call")
 
     async def _voice_end_fallback(self, call_id: str, tool_call_id: str) -> None:
         await asyncio.sleep(15)
@@ -1105,6 +1113,47 @@ class CallService:
             return
         self._voice_end_pending.pop(call_id, None)
         await self.terminate_call(call_id, "voice_model_end_call")
+
+    def _terminate_after_audio_drain(
+        self, call_id: str, response_id: str | None, reason: str
+    ) -> None:
+        """Delay a post-final-response termination until SIP playback finishes.
+
+        response.done only means generation finished; hanging up right away truncates the
+        closing words still buffered on OpenAI's side. output_audio_buffer.stopped (or
+        .cleared, when the callee interrupts) marks actual end of playback. A bounded
+        fallback still terminates if neither event is ever delivered.
+        """
+
+        self._audio_drain_terminations[call_id] = (response_id, reason)
+        self._spawn(
+            self._audio_drain_fallback(call_id, response_id, reason),
+            name=f"audio-drain-fallback:{call_id}",
+        )
+
+    def _handle_output_audio_drained(self, call_id: str, event: dict[str, Any]) -> None:
+        pending = self._audio_drain_terminations.get(call_id)
+        if pending is None:
+            return
+        expected_response_id, reason = pending
+        response_id = event.get("response_id")
+        if expected_response_id and response_id and expected_response_id != response_id:
+            return
+        self._audio_drain_terminations.pop(call_id, None)
+        self._spawn(
+            self.terminate_call(call_id, reason),
+            name=f"terminate:{call_id}:audio-drained",
+        )
+
+    async def _audio_drain_fallback(
+        self, call_id: str, response_id: str | None, reason: str
+    ) -> None:
+        await asyncio.sleep(TERMINATION_AUDIO_DRAIN_TIMEOUT_SECONDS)
+        pending = self._audio_drain_terminations.get(call_id)
+        if pending is None or pending != (response_id, reason):
+            return
+        self._audio_drain_terminations.pop(call_id, None)
+        await self.terminate_call(call_id, reason)
 
     async def transfer_to_owner(
         self, call_id: str, reason: str, *, terminate_after: bool = True
@@ -1904,6 +1953,7 @@ class CallService:
         call_id = call["call_id"]
         self._tombstone_call_activity(call_id)
         self._voice_end_pending.pop(call_id, None)
+        self._audio_drain_terminations.pop(call_id, None)
         self._active_response_ids.pop(call_id, None)
         media_tasks = [self.realtime.hangup(call.get("openai_call_id"))]
         if not preserve_conference:

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -122,9 +122,12 @@ class RealtimeBridge:
                     "type": "function",
                     "name": "end_call",
                     "description": (
-                        "Request the end of the phone call when the conversation is finished. Call "
-                        "this immediately instead of waiting for the callee or outer client to hang "
-                        "up. After it succeeds, you will be prompted to say the final goodbye."
+                        "Request the end of the phone call once the conversation is truly "
+                        "finished: the objective is resolved and the callee has nothing further. "
+                        "If the callee just asked a question or made a request, answer it fully "
+                        "as a normal turn before calling this. Once finished, call this promptly "
+                        "instead of waiting for the callee or outer client to hang up. After it "
+                        "succeeds, you will be prompted to say the final goodbye."
                     ),
                     "parameters": {
                         "type": "object",

--- a/app/prompts.py
+++ b/app/prompts.py
@@ -26,8 +26,11 @@ otherwise explain briefly and use end_call.
 
 # Ending the call
 You are the only component that knows when the conversation is finished.
-When the approved objective is complete, the callee declines, the number is wrong, or the objective
-cannot be completed, immediately use end_call. Do not wait for the callee or the outer Poke client to
+The conversation is finished when the approved objective is complete and the callee has nothing
+further, or when the callee declines, the number is wrong, or the objective cannot be completed.
+A pending question or request from the callee means the conversation is not finished: answer it
+fully as a normal turn first, and never fold new content into the goodbye. Once the conversation
+is finished, end promptly with end_call. Do not wait for the callee or the outer Poke client to
 hang up. After the function succeeds, the application will prompt you to deliver one brief natural
 goodbye before it disconnects. If the callee interrupts that closing, address them and use end_call
 again only when the conversation is actually finished.

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -494,11 +494,129 @@ async def test_voice_model_ends_call_only_after_its_completed_response(service, 
     )
     await wait_background()
 
+    # Generation finishing must not hang up while the goodbye is still playing over SIP.
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.ACTIVE.value
+    assert service._test_realtime.hangups == []
+
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "output_audio_buffer.stopped", "response_id": "resp_closing"},
+    )
+    await wait_background()
+
     call = await service.db.get_call(call_id)
     assert call["state"] == CallState.COMPLETED.value
     assert call["termination_reason"] == "voice_model_end_call"
     assert service._test_realtime.hangups == ["rtc_test"]
     assert service._test_twilio.completed == ["CF" + "a" * 32]
+
+
+@pytest.mark.asyncio
+async def test_voice_end_ignores_stale_audio_buffer_stopped_events(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    await service._handle_tool_call(
+        call_id,
+        {
+            "call_id": "tool_end",
+            "name": "end_call",
+            "arguments": '{"reason":"objective_completed"}',
+        },
+    )
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "response.created", "response": {"id": "resp_closing"}},
+    )
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "response.done",
+            "response": {"id": "resp_closing", "status": "completed"},
+        },
+    )
+
+    # A drain event for an earlier response must not end the call early.
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "output_audio_buffer.stopped", "response_id": "resp_earlier"},
+    )
+    await wait_background()
+    assert (await service.db.get_call(call_id))["state"] == CallState.ACTIVE.value
+    assert service._test_realtime.hangups == []
+
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "output_audio_buffer.stopped", "response_id": "resp_closing"},
+    )
+    await wait_background()
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.COMPLETED.value
+    assert call["termination_reason"] == "voice_model_end_call"
+
+
+@pytest.mark.asyncio
+async def test_voice_end_interrupted_playback_still_terminates(service, packet):
+    """output_audio_buffer.cleared (callee interrupt) also marks the end of playback."""
+
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    await service._handle_tool_call(
+        call_id,
+        {
+            "call_id": "tool_end",
+            "name": "end_call",
+            "arguments": '{"reason":"objective_completed"}',
+        },
+    )
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "response.created", "response": {"id": "resp_closing"}},
+    )
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "response.done",
+            "response": {"id": "resp_closing", "status": "completed"},
+        },
+    )
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "output_audio_buffer.cleared", "response_id": "resp_closing"},
+    )
+    await wait_background()
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.COMPLETED.value
+    assert call["termination_reason"] == "voice_model_end_call"
+
+
+@pytest.mark.asyncio
+async def test_voice_end_terminates_after_drain_timeout_without_buffer_event(
+    service, packet, monkeypatch
+):
+    monkeypatch.setattr("app.call_state.TERMINATION_AUDIO_DRAIN_TIMEOUT_SECONDS", 0.05)
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    await service._handle_tool_call(
+        call_id,
+        {
+            "call_id": "tool_end",
+            "name": "end_call",
+            "arguments": '{"reason":"objective_completed"}',
+        },
+    )
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "response.created", "response": {"id": "resp_closing"}},
+    )
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "response.done",
+            "response": {"id": "resp_closing", "status": "completed"},
+        },
+    )
+    await wait_background()
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.COMPLETED.value
+    assert call["termination_reason"] == "voice_model_end_call"
 
 
 @pytest.mark.asyncio
@@ -734,6 +852,15 @@ async def test_late_voicemail_amd_cancels_in_flight_opening(service, packet):
     await service.handle_realtime_event(
         call_id,
         {"type": "response.done", "response": {"id": "resp_vm", "status": "completed"}},
+    )
+    await wait_background()
+    # The voicemail hangup waits for playback to drain so the message is not cut off.
+    call = await service.db.get_call(call_id)
+    assert call["state"] == CallState.ACTIVE.value
+
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "output_audio_buffer.stopped", "response_id": "resp_vm"},
     )
     await wait_background()
     call = await service.db.get_call(call_id)

--- a/tests/test_openai_payload.py
+++ b/tests/test_openai_payload.py
@@ -50,6 +50,11 @@ def test_initial_accept_payload_is_typed_and_matches_release_contract(settings, 
     assert end_call["parameters"]["required"] == ["reason"]
     assert "objective_completed" in end_call["parameters"]["properties"]["reason"]["enum"]
     assert "final goodbye" in end_call["description"].lower()
+    # Ending must be gated on the callee having nothing further, not just objective status;
+    # a pending callee request must be answered as a normal turn before end_call.
+    description = end_call["description"].lower()
+    assert "callee has nothing further" in description
+    assert "answer it fully" in description
 
 
 def test_session_created_echo_requires_transcription_and_full_initial_vad(settings, packet):

--- a/tests/test_prompt_limits.py
+++ b/tests/test_prompt_limits.py
@@ -51,6 +51,21 @@ def test_normal_context_uses_compact_approved_json(packet: ContextPacket):
     assert len(instructions.encode("utf-8")) <= REALTIME_INSTRUCTIONS_MAX_BYTES
 
 
+def test_ending_instructions_gate_on_callee_engagement(packet: ContextPacket):
+    """Regression: the model once armed end_call while the callee's request (a joke) was
+    still pending, folding the answer into the goodbye. Ending must require both a complete
+    objective and a callee with nothing further."""
+
+    flattened = realtime_instructions(packet).replace("\n", " ")
+
+    assert "the callee has nothing further" in flattened
+    assert (
+        "A pending question or request from the callee means the conversation is not finished"
+        in flattened
+    )
+    assert "answer it fully as a normal turn first" in flattened
+
+
 def test_realtime_instructions_enforce_final_byte_limit(
     packet: ContextPacket, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Behavioral change

Live-call debugging of `call_H-0M5sL-w5u0q3JdMiGd3Q4x` (2026-07-15 03:26 UTC, Fly logs + volume DB) surfaced two issues:

**1. Hangup truncated the goodbye audio.** After the model called `end_call` and its goodbye response reached `response.done` at 03:27:19, `terminate_call("voice_model_end_call")` immediately hung up the OpenAI SIP leg and completed the Twilio conference — while the ~7s goodbye was still buffered on OpenAI's side. Over SIP, `response.done` marks the end of audio *generation*; playback lags behind the server-side output buffer.

Fix: terminations that follow a final spoken turn (`voice_model_end_call` goodbye and `voicemail_left`) now wait for `output_audio_buffer.stopped` (or `.cleared` on callee interrupt) for the matching `response_id` before tearing down media. A 12s fallback timer still terminates if neither event arrives, chosen to stay under the 15s watchdog staleness window so the call is not misreported as `timed_out`. Any other termination path (callee hangup, watchdog, shutdown) clears the pending drain state via `_finish_claimed_termination`.

**2. The model ended the call too eagerly.** The same call shows `end_call` armed in the same response as "Alright, let me think of a quick one to share" — before the callee's pending request (a joke) was answered; the answer was then folded into the forced goodbye turn. The prompt and tool description said "immediately use end_call ... do not wait" with objective completion as the only test and no definition of *not finished*.

Fix: the "# Ending the call" prompt section and the `end_call` tool description now define finished as "objective complete **and the callee has nothing further**", and state that a pending question or request means the conversation is not finished and must be answered fully as a normal turn (never folded into the goodbye). The once-finished-end-promptly guardrail is retained.

## Risks to live-call teardown / billing

- The billable window for a voice-ended call now extends by the true goodbye playback time (a few seconds) or at most 12s if the buffer event is never delivered.
- Stale `output_audio_buffer.stopped` events from earlier responses are ignored via `response_id` matching, so they cannot trigger an early hangup.
- The softer ending prompt could marginally lengthen calls where the callee keeps engaging; the time-limit watchdog remains the hard stop.

## Configuration changes

None. New module constant `TERMINATION_AUDIO_DRAIN_TIMEOUT_SECONDS = 12.0`.

## Validation

- `uv run ruff format --check app tests scripts` and `uv run ruff check app tests scripts` pass.
- `uv run pytest -q`: 229 passed, including new regression tests for drain-gated hangup (stale-event rejection, `.cleared` interrupt path, fallback-timeout path), updated `end_call`/voicemail flow tests asserting no hangup between `response.done` and `output_audio_buffer.stopped`, and new payload/prompt contract tests pinning the callee-engagement gating language.
- App boots cleanly with dummy `.env.local` and `/healthz` returns ok.
- Not validated with a live SIP canary (places a real billable call and needs a human on the phone); recommend a canary call after deploy to confirm the goodbye plays to completion and mid-call requests get answered before wrap-up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5398658d-fb02-40bf-a605-903447f51a49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5398658d-fb02-40bf-a605-903447f51a49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

