### PR TITLE
Enable Realtime session traces on accept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ htmlcov/
 *.db
 *.db-shm
 *.db-wal
+.playwright-mcp/
 

--- a/app/models.py
+++ b/app/models.py
@@ -244,6 +244,8 @@ class AcceptPayload(BaseModel):
     max_output_tokens: int = Field(default=300, ge=1, le=4096)
     parallel_tool_calls: Literal[False] = False
     tool_choice: Literal["auto"] = "auto"
+    # Writes Realtime session activity to the OpenAI Traces dashboard.
+    tracing: Literal["auto"] = "auto"
     instructions: str
     audio: RealtimeAudio
     tools: list[RealtimeFunctionTool]

--- a/tests/test_openai_payload.py
+++ b/tests/test_openai_payload.py
@@ -26,6 +26,7 @@ def test_initial_accept_payload_is_typed_and_matches_release_contract(settings, 
     assert payload["max_output_tokens"] == 300
     assert payload["parallel_tool_calls"] is False
     assert payload["tool_choice"] == "auto"
+    assert payload["tracing"] == "auto"
     assert payload["audio"]["input"] == {
         "transcription": {"model": "gpt-4o-mini-transcribe"},
         "turn_detection": {


### PR DESCRIPTION
## Summary
- Set `tracing: "auto"` on Realtime call accept so sessions appear in the OpenAI Traces dashboard.
- Ignore `.playwright-mcp/` in git.

## Test plan
- [x] `pytest tests/test_openai_payload.py tests/test_bridge_payloads.py`
- [ ] After merge/deploy, place a call and confirm a trace at https://platform.openai.com/logs?api=traces


Made with [Cursor](https://cursor.com)