### PR TITLE
Fix Grok opening response race

### DIFF
--- a/app/call_state.py
+++ b/app/call_state.py
@@ -51,7 +51,7 @@ TERMINATION_AUDIO_DRAIN_TIMEOUT_SECONDS = 12.0
 TERMINATION_MEDIA_RETRY_DELAY_SECONDS = 0.1
 TERMINATION_MEDIA_BACKGROUND_RETRY_BASE_SECONDS = 0.5
 TERMINATION_MEDIA_BACKGROUND_RETRY_MAX_SECONDS = 15.0
-OPENING_AUTO_RESPONSE_GRACE_SECONDS = 0.1
+OPENING_INPUT_SETTLE_SECONDS = 0.1
 
 
 class OwnerTransferDeparted(RuntimeError):
@@ -98,7 +98,7 @@ class CallService:
         self._owner_transfer_locks: dict[str, asyncio.Lock] = {}
         self._opening_transition_locks: dict[str, asyncio.Lock] = {}
         self._input_speech_active: set[str] = set()
-        self._opening_waiting_for_input_commit: set[str] = set()
+        self._opening_waiting_for_input_end: set[str] = set()
         self._voice_end_pending: dict[str, tuple[str, str | None]] = {}
         self._audio_drain_terminations: dict[str, tuple[str | None, str]] = {}
         self._active_response_ids: dict[str, str | None] = {}
@@ -721,10 +721,10 @@ class CallService:
             if call.get("answer_handling") == "voicemail":
                 return
             if call_id in self._input_speech_active:
-                self._opening_waiting_for_input_commit.add(call_id)
-                logger.info("deferring opening until caller input commits call_id=%s", call_id)
+                self._opening_waiting_for_input_end.add(call_id)
+                logger.info("deferring opening until caller speech ends call_id=%s", call_id)
                 return
-            self._opening_waiting_for_input_commit.discard(call_id)
+            self._opening_waiting_for_input_end.discard(call_id)
             if not await self.db.claim_opening_if_not_voicemail(call_id):
                 return
 
@@ -737,19 +737,31 @@ class CallService:
         # Twilio round-trip can never delay the model's response.create.
         await self._unmute_agent(call_id, conference, call.get("twilio_ai_call_sid"))
 
-    async def _resume_opening_after_input_commit(self, call_id: str) -> None:
-        # Grok may automatically create a response for a server-VAD commit. Give that
-        # response.created event a brief chance to arrive before issuing the manual fallback.
-        await asyncio.sleep(OPENING_AUTO_RESPONSE_GRACE_SECONDS)
-        if call_id in self._opening_waiting_for_input_commit:
+    async def _resume_opening_after_input_end(self, call_id: str, source: str) -> None:
+        # speech_stopped precedes Grok's internal audio commit. Let that settle before issuing
+        # response.create, while transcription completion remains a fallback for SIP sessions
+        # that omit input_audio_buffer.committed.
+        await asyncio.sleep(OPENING_INPUT_SETTLE_SECONDS)
+        if call_id in self._opening_waiting_for_input_end:
+            logger.info("resuming deferred opening call_id=%s source=%s", call_id, source)
             await self._start_opening_on_answer(call_id)
+
+    async def _release_deferred_opening_after_input(self, call_id: str, source: str) -> None:
+        async with self._opening_transition_lock(call_id):
+            self._input_speech_active.discard(call_id)
+            resume_opening = call_id in self._opening_waiting_for_input_end
+        if resume_opening:
+            self._spawn(
+                self._resume_opening_after_input_end(call_id, source),
+                name=f"resume-opening:{call_id}:{source}",
+            )
 
     async def _adopt_automatic_opening(self, call_id: str) -> None:
         call: dict[str, Any] | None = None
         async with self._opening_transition_lock(call_id):
-            if call_id not in self._opening_waiting_for_input_commit:
+            if call_id not in self._opening_waiting_for_input_end:
                 return
-            self._opening_waiting_for_input_commit.discard(call_id)
+            self._opening_waiting_for_input_end.discard(call_id)
             call = await self.db.get_call(call_id)
             if call is None or CallState(call["state"]) in TERMINAL_STATES:
                 return
@@ -834,16 +846,13 @@ class CallService:
         elif event_type == "input_audio_buffer.speech_started":
             async with self._opening_transition_lock(call_id):
                 self._input_speech_active.add(call_id)
-        elif event_type == "input_audio_buffer.committed":
-            async with self._opening_transition_lock(call_id):
-                self._input_speech_active.discard(call_id)
-                resume_opening = call_id in self._opening_waiting_for_input_commit
-            if resume_opening:
-                self._spawn(
-                    self._resume_opening_after_input_commit(call_id),
-                    name=f"resume-opening:{call_id}",
-                )
+        elif event_type in {
+            "input_audio_buffer.speech_stopped",
+            "input_audio_buffer.committed",
+        }:
+            await self._release_deferred_opening_after_input(call_id, event_type)
         elif event_type == "conversation.item.input_audio_transcription.completed":
+            await self._release_deferred_opening_after_input(call_id, event_type)
             text = event.get("transcript", "").strip()
             if text:
                 await self.db.add_transcript_turn(
@@ -2118,7 +2127,7 @@ class CallService:
         self._owner_transfer_tasks.pop(call_id, None)
         self._owner_transfer_locks.pop(call_id, None)
         self._input_speech_active.discard(call_id)
-        self._opening_waiting_for_input_commit.discard(call_id)
+        self._opening_waiting_for_input_end.discard(call_id)
         self._opening_transition_locks.pop(call_id, None)
         self._tool_seen_calls.discard(call_id)
         try:

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -51,6 +51,7 @@ TERMINATION_AUDIO_DRAIN_TIMEOUT_SECONDS = 12.0
 TERMINATION_MEDIA_RETRY_DELAY_SECONDS = 0.1
 TERMINATION_MEDIA_BACKGROUND_RETRY_BASE_SECONDS = 0.5
 TERMINATION_MEDIA_BACKGROUND_RETRY_MAX_SECONDS = 15.0
+OPENING_AUTO_RESPONSE_GRACE_SECONDS = 0.1
 
 
 class OwnerTransferDeparted(RuntimeError):
@@ -96,6 +97,8 @@ class CallService:
         self._owner_transfer_tasks: dict[str, asyncio.Task[dict[str, Any]]] = {}
         self._owner_transfer_locks: dict[str, asyncio.Lock] = {}
         self._opening_transition_locks: dict[str, asyncio.Lock] = {}
+        self._input_speech_active: set[str] = set()
+        self._opening_waiting_for_input_commit: set[str] = set()
         self._voice_end_pending: dict[str, tuple[str, str | None]] = {}
         self._audio_drain_terminations: dict[str, tuple[str | None, str]] = {}
         self._active_response_ids: dict[str, str | None] = {}
@@ -717,6 +720,11 @@ class CallService:
                 return
             if call.get("answer_handling") == "voicemail":
                 return
+            if call_id in self._input_speech_active:
+                self._opening_waiting_for_input_commit.add(call_id)
+                logger.info("deferring opening until caller input commits call_id=%s", call_id)
+                return
+            self._opening_waiting_for_input_commit.discard(call_id)
             if not await self.db.claim_opening_if_not_voicemail(call_id):
                 return
 
@@ -727,6 +735,28 @@ class CallService:
         conference = call.get("conference_sid") or call.get("conference_name")
         # The explicit unmute is a race-safety net. Sending the opening first ensures its
         # Twilio round-trip can never delay the model's response.create.
+        await self._unmute_agent(call_id, conference, call.get("twilio_ai_call_sid"))
+
+    async def _resume_opening_after_input_commit(self, call_id: str) -> None:
+        # Grok may automatically create a response for a server-VAD commit. Give that
+        # response.created event a brief chance to arrive before issuing the manual fallback.
+        await asyncio.sleep(OPENING_AUTO_RESPONSE_GRACE_SECONDS)
+        if call_id in self._opening_waiting_for_input_commit:
+            await self._start_opening_on_answer(call_id)
+
+    async def _adopt_automatic_opening(self, call_id: str) -> None:
+        call: dict[str, Any] | None = None
+        async with self._opening_transition_lock(call_id):
+            if call_id not in self._opening_waiting_for_input_commit:
+                return
+            self._opening_waiting_for_input_commit.discard(call_id)
+            call = await self.db.get_call(call_id)
+            if call is None or CallState(call["state"]) in TERMINAL_STATES:
+                return
+            if not await self.db.claim_opening_if_not_voicemail(call_id):
+                return
+
+        conference = call.get("conference_sid") or call.get("conference_name")
         await self._unmute_agent(call_id, conference, call.get("twilio_ai_call_sid"))
 
     async def _unmute_agent(
@@ -801,6 +831,18 @@ class CallService:
             # miss this startup event, so readiness is established by the explicit
             # session.update/session.updated handshake in handle_sideband_open.
             logger.debug("observed session.created call_id=%s", call_id)
+        elif event_type == "input_audio_buffer.speech_started":
+            async with self._opening_transition_lock(call_id):
+                self._input_speech_active.add(call_id)
+        elif event_type == "input_audio_buffer.committed":
+            async with self._opening_transition_lock(call_id):
+                self._input_speech_active.discard(call_id)
+                resume_opening = call_id in self._opening_waiting_for_input_commit
+            if resume_opening:
+                self._spawn(
+                    self._resume_opening_after_input_commit(call_id),
+                    name=f"resume-opening:{call_id}",
+                )
         elif event_type == "conversation.item.input_audio_transcription.completed":
             text = event.get("transcript", "").strip()
             if text:
@@ -835,6 +877,7 @@ class CallService:
                 event_key=str(event.get("call_id") or event_id),
             )
         elif event_type == "response.created":
+            await self._adopt_automatic_opening(call_id)
             if call_id in self._tool_seen_calls:
                 self._tool_seen_calls.discard(call_id)
                 await self.db.mark_tool_continuation_observed(call_id)
@@ -2074,6 +2117,8 @@ class CallService:
         self._owner_failures.pop(call_id, None)
         self._owner_transfer_tasks.pop(call_id, None)
         self._owner_transfer_locks.pop(call_id, None)
+        self._input_speech_active.discard(call_id)
+        self._opening_waiting_for_input_commit.discard(call_id)
         self._opening_transition_locks.pop(call_id, None)
         self._tool_seen_calls.discard(call_id)
         try:

--- a/app/xai_realtime.py
+++ b/app/xai_realtime.py
@@ -34,6 +34,18 @@ REALTIME_TASK_CANCEL_TIMEOUT_SECONDS = 1.0
 REALTIME_SEND_TIMEOUT_SECONDS = 10.0
 REALTIME_SHUTDOWN_FINAL_TIMEOUT_SECONDS = 10.0
 _EVENT_QUEUE_CLOSED = object()
+_LOGGED_REALTIME_EVENT_TYPES = {
+    "session.updated",
+    "input_audio_buffer.speech_started",
+    "input_audio_buffer.speech_stopped",
+    "input_audio_buffer.committed",
+    "conversation.item.input_audio_transcription.completed",
+    "response.created",
+    "response.output_audio.done",
+    "response.output_audio_transcript.done",
+    "response.done",
+    "error",
+}
 
 
 class RealtimeEventQueueOverflow(RuntimeError):
@@ -266,6 +278,16 @@ class RealtimeBridge:
     async def _receive_events(self, runtime: RealtimeRuntime, websocket: Any) -> None:
         async for message in websocket:
             event = json.loads(message)
+            event_type = event.get("type")
+            if event_type in _LOGGED_REALTIME_EVENT_TYPES:
+                response = event.get("response") or {}
+                logger.info(
+                    "Realtime event received call_id=%s type=%s event_id=%s response_id=%s",
+                    runtime.call_id,
+                    event_type,
+                    event.get("event_id"),
+                    response.get("id") or event.get("response_id"),
+                )
             # Record liveness on the reader fast path. Application dispatch may be
             # intentionally backlogged, but a frame already read from the socket is
             # authoritative evidence that the call is still alive.
@@ -416,9 +438,14 @@ class RealtimeBridge:
             raise failure
 
     async def _notify_sent(self, call_id: str, events: list[dict[str, Any]]) -> None:
-        if self.on_send is None:
-            return
         for event in events:
+            logger.info(
+                "Realtime control sent call_id=%s type=%s",
+                call_id,
+                event.get("type"),
+            )
+            if self.on_send is None:
+                continue
             try:
                 await self.on_send(call_id, event)
             except Exception:

--- a/app/xai_realtime.py
+++ b/app/xai_realtime.py
@@ -474,13 +474,7 @@ class RealtimeBridge:
         )
 
     async def create_opening(self, call_id: str) -> None:
-        await self.send(
-            call_id,
-            {
-                "type": "response.create",
-                "response": {"output_modalities": ["audio"]},
-            },
-        )
+        await self.send(call_id, {"type": "response.create"})
 
     async def cancel_response(self, call_id: str, response_id: str | None = None) -> None:
         event: dict[str, Any] = {"type": "response.cancel"}
@@ -494,7 +488,6 @@ class RealtimeBridge:
             {
                 "type": "response.create",
                 "response": {
-                    "output_modalities": ["audio"],
                     "instructions": (
                         "Leave one concise voicemail that advances the approved objective using only "
                         "the approved context. Do not ask questions."
@@ -526,7 +519,6 @@ class RealtimeBridge:
             continuation: dict[str, Any] = {"type": "response.create"}
             if continuation_instructions:
                 continuation["response"] = {
-                    "output_modalities": ["audio"],
                     "instructions": continuation_instructions,
                 }
             events.append(continuation)

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -189,8 +189,8 @@ async def test_callee_answered_status_starts_opening_before_conference_join(serv
 
 
 @pytest.mark.asyncio
-async def test_caller_speech_defers_opening_until_input_commits(service, packet, monkeypatch):
-    monkeypatch.setattr("app.call_state.OPENING_AUTO_RESPONSE_GRACE_SECONDS", 0)
+async def test_caller_speech_defers_opening_until_speech_stops(service, packet, monkeypatch):
+    monkeypatch.setattr("app.call_state.OPENING_INPUT_SETTLE_SECONDS", 0)
     call_id = await seed_call(service.db, packet)
     await service.handle_sideband_open(call_id)
 
@@ -209,19 +209,6 @@ async def test_caller_speech_defers_opening_until_input_commits(service, packet,
             "event_id": "evt_speech_stopped",
         },
     )
-
-    call = await service.db.get_call(call_id)
-    assert call["opening_sent"] == 0
-    assert service._test_realtime.events == []
-    assert service._test_twilio.unmuted == []
-
-    await service.handle_realtime_event(
-        call_id,
-        {
-            "type": "input_audio_buffer.committed",
-            "event_id": "evt_input_committed",
-        },
-    )
     await wait_background()
 
     call = await service.db.get_call(call_id)
@@ -231,10 +218,50 @@ async def test_caller_speech_defers_opening_until_input_commits(service, packet,
 
 
 @pytest.mark.asyncio
+async def test_transcript_completion_releases_opening_when_commit_event_is_missing(
+    service, packet, monkeypatch
+):
+    monkeypatch.setattr("app.call_state.OPENING_INPUT_SETTLE_SECONDS", 0)
+    call_id = await seed_call(service.db, packet)
+    await service.handle_sideband_open(call_id)
+
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "input_audio_buffer.speech_started",
+            "event_id": "evt_speech_started",
+        },
+    )
+    await service.handle_participant_status(call_id, "callee", {"CallStatus": "in-progress"})
+
+    call = await service.db.get_call(call_id)
+    assert call["opening_sent"] == 0
+    assert service._test_realtime.events == []
+
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "event_id": "evt_transcript_completed",
+            "item_id": "item_hello",
+            "transcript": "Hello?",
+        },
+    )
+    await wait_background()
+
+    call = await service.db.get_call(call_id)
+    assert call["opening_sent"] == 1
+    assert service._test_realtime.events == [("opening", call_id)]
+    assert service._test_twilio.unmuted == [("CF" + "a" * 32, "CA" + "a" * 32)]
+    transcript = await service.db.get_transcript(call_id)
+    assert [turn.text for turn in transcript] == ["Hello?"]
+
+
+@pytest.mark.asyncio
 async def test_auto_response_adopts_deferred_opening_without_duplicate_create(
     service, packet, monkeypatch
 ):
-    monkeypatch.setattr("app.call_state.OPENING_AUTO_RESPONSE_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr("app.call_state.OPENING_INPUT_SETTLE_SECONDS", 0.01)
     call_id = await seed_call(service.db, packet)
     await service.handle_sideband_open(call_id)
 
@@ -249,8 +276,8 @@ async def test_auto_response_adopts_deferred_opening_without_duplicate_create(
     await service.handle_realtime_event(
         call_id,
         {
-            "type": "input_audio_buffer.committed",
-            "event_id": "evt_input_committed",
+            "type": "input_audio_buffer.speech_stopped",
+            "event_id": "evt_speech_stopped",
         },
     )
     await service.handle_realtime_event(

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -189,6 +189,87 @@ async def test_callee_answered_status_starts_opening_before_conference_join(serv
 
 
 @pytest.mark.asyncio
+async def test_caller_speech_defers_opening_until_input_commits(service, packet, monkeypatch):
+    monkeypatch.setattr("app.call_state.OPENING_AUTO_RESPONSE_GRACE_SECONDS", 0)
+    call_id = await seed_call(service.db, packet)
+    await service.handle_sideband_open(call_id)
+
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "input_audio_buffer.speech_started",
+            "event_id": "evt_speech_started",
+        },
+    )
+    await service.handle_participant_status(call_id, "callee", {"CallStatus": "in-progress"})
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "input_audio_buffer.speech_stopped",
+            "event_id": "evt_speech_stopped",
+        },
+    )
+
+    call = await service.db.get_call(call_id)
+    assert call["opening_sent"] == 0
+    assert service._test_realtime.events == []
+    assert service._test_twilio.unmuted == []
+
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "input_audio_buffer.committed",
+            "event_id": "evt_input_committed",
+        },
+    )
+    await wait_background()
+
+    call = await service.db.get_call(call_id)
+    assert call["opening_sent"] == 1
+    assert service._test_realtime.events == [("opening", call_id)]
+    assert service._test_twilio.unmuted == [("CF" + "a" * 32, "CA" + "a" * 32)]
+
+
+@pytest.mark.asyncio
+async def test_auto_response_adopts_deferred_opening_without_duplicate_create(
+    service, packet, monkeypatch
+):
+    monkeypatch.setattr("app.call_state.OPENING_AUTO_RESPONSE_GRACE_SECONDS", 0.01)
+    call_id = await seed_call(service.db, packet)
+    await service.handle_sideband_open(call_id)
+
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "input_audio_buffer.speech_started",
+            "event_id": "evt_speech_started",
+        },
+    )
+    await service.handle_participant_status(call_id, "callee", {"CallStatus": "in-progress"})
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "input_audio_buffer.committed",
+            "event_id": "evt_input_committed",
+        },
+    )
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "response.created",
+            "event_id": "evt_response_created",
+            "response": {"id": "resp_auto"},
+        },
+    )
+    await wait_background()
+
+    call = await service.db.get_call(call_id)
+    assert call["opening_sent"] == 1
+    assert service._test_realtime.events == []
+    assert service._test_twilio.unmuted == [("CF" + "a" * 32, "CA" + "a" * 32)]
+
+
+@pytest.mark.asyncio
 async def test_opening_exactly_once_after_confirmed_session_update(service, packet):
     call_id = await seed_call(service.db, packet)
     await service.handle_sideband_open(call_id)

--- a/tests/test_bridge_payloads.py
+++ b/tests/test_bridge_payloads.py
@@ -106,12 +106,7 @@ async def test_opening_response_uses_session_context_without_a_script(settings):
 
     await bridge.create_opening("call_1")
 
-    assert websocket.messages == [
-        {
-            "type": "response.create",
-            "response": {"output_modalities": ["audio"]},
-        }
-    ]
+    assert websocket.messages == [{"type": "response.create"}]
 
 
 @pytest.mark.asyncio
@@ -539,7 +534,6 @@ async def test_terminal_function_output_creates_a_dedicated_closing_response(set
         {
             "type": "response.create",
             "response": {
-                "output_modalities": ["audio"],
                 "instructions": "Say one concise goodbye. Do not call any function.",
             },
         },

--- a/tests/test_bridge_payloads.py
+++ b/tests/test_bridge_payloads.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -91,7 +92,8 @@ class FakeConnection:
 
 
 @pytest.mark.asyncio
-async def test_opening_response_uses_session_context_without_a_script(settings):
+async def test_opening_response_uses_session_context_without_a_script(settings, caplog):
+    caplog.set_level(logging.INFO, logger="app.xai_realtime")
     bridge = RealtimeBridge(
         settings,
         SimpleNamespace(),
@@ -107,6 +109,38 @@ async def test_opening_response_uses_session_context_without_a_script(settings):
     await bridge.create_opening("call_1")
 
     assert websocket.messages == [{"type": "response.create"}]
+    assert "Realtime control sent call_id=call_1 type=response.create" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_realtime_lifecycle_log_omits_transcript_content(settings, caplog):
+    caplog.set_level(logging.INFO, logger="app.xai_realtime")
+    bridge = RealtimeBridge(
+        settings,
+        SimpleNamespace(),
+        on_event=_noop,
+        on_open=_noop,
+        on_fatal=_noop,
+    )
+    websocket = StreamingFakeWebSocket({})
+    runtime = RealtimeRuntime(call_id="call_1", xai_call_id="rtc_1", websocket=websocket)
+    await websocket.incoming.put(
+        json.dumps(
+            {
+                "type": "conversation.item.input_audio_transcription.completed",
+                "event_id": "evt_transcript",
+                "transcript": "private spoken content",
+            }
+        )
+    )
+    await websocket.incoming.put(None)
+
+    await bridge._receive_events(runtime, websocket)
+
+    assert "call_id=call_1" in caplog.text
+    assert "type=conversation.item.input_audio_transcription.completed" in caplog.text
+    assert "event_id=evt_transcript" in caplog.text
+    assert "private spoken content" not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Defer the opening turn while the caller is speaking at pickup (Grok's VAD emits `speech_started`); resume it when the input buffer commits, or adopt Grok's auto-created response instead of double-creating.
- Drop the unsupported `response.output_modalities` field from every `response.create` sent to xAI.

## Context
After switching Realtime from OpenAI to xAI (v23), calls connected but the callee heard silence: the opening `response.create` fired into the caller's pickup speech and produced no audio, and with AMD still pending, server VAD was never enabled, so Grok never spoke at all.

## Validation
- `pytest -q`: 225 passed (includes new activation race tests).
- Deployed to Fly (v24) for live call verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)