### PR TITLE
Keep watchdog alive during assistant speech and tool waits

### DIFF
--- a/app/call_state.py
+++ b/app/call_state.py
@@ -54,6 +54,27 @@ TERMINATION_MEDIA_RETRY_DELAY_SECONDS = 0.1
 TERMINATION_MEDIA_BACKGROUND_RETRY_BASE_SECONDS = 0.5
 TERMINATION_MEDIA_BACKGROUND_RETRY_MAX_SECONDS = 15.0
 
+# Assistant speech / SIP playback evidence. On SIP sidebands, RTP carries the media, so
+# response.audio.delta frames may be sparse or absent while the callee still hears audio.
+# These events (and in-memory "live work" flags) must keep the 15s watchdog from hanging up.
+ASSISTANT_SPEECH_EVENT_TYPES = frozenset(
+    {
+        "response.created",
+        "response.done",
+        "response.output_audio.delta",
+        "response.audio.delta",
+        "response.output_audio.done",
+        "response.audio.done",
+        "response.output_audio_transcript.delta",
+        "response.output_audio_transcript.done",
+        "response.audio_transcript.delta",
+        "response.audio_transcript.done",
+        "output_audio_buffer.started",
+        "output_audio_buffer.stopped",
+        "output_audio_buffer.cleared",
+    }
+)
+
 
 class OwnerTransferDeparted(RuntimeError):
     """The owner leg became terminal before the AI handoff finished."""
@@ -105,6 +126,8 @@ class CallService:
         self._voice_end_pending: dict[str, tuple[str, str | None]] = {}
         self._audio_drain_terminations: dict[str, tuple[str | None, str]] = {}
         self._active_response_ids: dict[str, str | None] = {}
+        self._sip_output_playing: set[str] = set()
+        self._inflight_tools: set[str] = set()
         self._tool_seen_calls: set[str] = set()
         self._queued_latency_events: dict[tuple[str, LatencyStage, str], LatencyMark] = {}
         self._watchdog_task: asyncio.Task[None] | None = None
@@ -207,6 +230,26 @@ class CallService:
             self._dirty_call_activity[call_id] = observed
         return True
 
+    def _assistant_work_is_live(self, call_id: str) -> bool:
+        """True when the assistant is generating, playing SIP audio, or awaiting a tool.
+
+        The 15s stale watchdog only sees sideband/Twilio heartbeats. SIP media and
+        in-flight tool waits can leave that clock idle while the callee still hears
+        (or is about to hear) the assistant, so those states must count as live.
+        """
+        return (
+            call_id in self._active_response_ids
+            or call_id in self._sip_output_playing
+            or call_id in self._audio_drain_terminations
+            or call_id in self._inflight_tools
+        )
+
+    def _clear_assistant_work(self, call_id: str) -> None:
+        self._active_response_ids.pop(call_id, None)
+        self._sip_output_playing.discard(call_id)
+        self._audio_drain_terminations.pop(call_id, None)
+        self._inflight_tools.discard(call_id)
+
     def _clear_call_activity(self, call_id: str) -> None:
         self._latest_call_activity.pop(call_id, None)
         self._dirty_call_activity.pop(call_id, None)
@@ -221,6 +264,7 @@ class CallService:
         )
         while len(self._activity_tombstones) > CALL_ACTIVITY_TOMBSTONE_MAX:
             self._activity_tombstones.popitem(last=False)
+        self._clear_assistant_work(call_id)
         self._clear_call_activity(call_id)
 
     def _prune_activity_tombstones(self, now_ns: int | None = None) -> None:
@@ -795,6 +839,10 @@ class CallService:
         received = LatencyMark.now()
         event_type = event.get("type", "")
         event_id = event.get("event_id") or f"evt_{secrets.token_urlsafe(12)}"
+        # Reader already heartbeats on frame arrival; re-assert here for assistant speech
+        # so dispatcher-only paths (and sparse SIP sidebands) still refresh the watchdog.
+        if event_type in ASSISTANT_SPEECH_EVENT_TYPES:
+            self._note_call_activity(call_id, received)
         if event_type in {
             "response.output_audio_transcript.delta",
             "response.output_audio_transcript.done",
@@ -877,7 +925,10 @@ class CallService:
                     response.get("id") or event.get("response_id"),
                     "voicemail_left",
                 )
+        elif event_type == "output_audio_buffer.started":
+            self._sip_output_playing.add(call_id)
         elif event_type in {"output_audio_buffer.stopped", "output_audio_buffer.cleared"}:
+            self._sip_output_playing.discard(call_id)
             self._handle_output_audio_drained(call_id, event)
         elif event_type in {"session.ended", "call.ended"}:
             self._spawn(
@@ -898,6 +949,9 @@ class CallService:
 
     async def handle_realtime_send(self, call_id: str, event: dict[str, Any]) -> None:
         sent = LatencyMark.now()
+        # Outbound control (response.create, tool results) is proof the call is live even
+        # when the SIP sideband is quiet between assistant audio frames.
+        self._note_call_activity(call_id, sent)
         event_type = event.get("type")
         if event_type == "response.create":
             self._queue_latency(call_id, LatencyStage.FIRST_RESPONSE_CREATE, sent)
@@ -1033,6 +1087,8 @@ class CallService:
                 LatencyMark.now(),
                 event_key=event_key,
             )
+            self._inflight_tools.add(call_id)
+            self._note_call_activity(call_id)
             try:
                 result = await self.exa.search(request.query)
                 output = result.output
@@ -1053,6 +1109,8 @@ class CallService:
                 logger.exception("unexpected Exa search failure call_id=%s", call_id)
                 output = {"ok": False, "error": "search_unavailable"}
             finally:
+                self._inflight_tools.discard(call_id)
+                self._note_call_activity(call_id)
                 self._queue_latency(
                     call_id,
                     LatencyStage.EXA_SEARCH_COMPLETED,
@@ -2011,8 +2069,6 @@ class CallService:
         call_id = call["call_id"]
         self._tombstone_call_activity(call_id)
         self._voice_end_pending.pop(call_id, None)
-        self._audio_drain_terminations.pop(call_id, None)
-        self._active_response_ids.pop(call_id, None)
         media_tasks = [self.realtime.hangup(call.get("openai_call_id"))]
         if not preserve_conference:
             media_tasks.append(
@@ -2411,6 +2467,11 @@ class CallService:
                 continue
             if datetime.fromisoformat(call["last_event_at"]) >= cutoff:
                 continue
+            if self._assistant_work_is_live(call_id):
+                # SIP playback / tool waits can exceed the heartbeat gap without sideband
+                # frames. Refresh liveness so durable last_event_at stays aligned.
+                self._note_call_activity(call_id, now)
+                continue
             activity_before = self._latest_call_activity.get(call_id)
             if (
                 activity_before is not None
@@ -2428,6 +2489,9 @@ class CallService:
                 self._tombstone_call_activity(call_id)
                 continue
             if datetime.fromisoformat(current["last_event_at"]) >= cutoff:
+                continue
+            if self._assistant_work_is_live(call_id):
+                self._note_call_activity(call_id, now)
                 continue
             activity_after = self._latest_call_activity.get(call_id)
             if activity_after is not None:

--- a/tests/test_activity_heartbeat.py
+++ b/tests/test_activity_heartbeat.py
@@ -35,17 +35,10 @@ async def test_realtime_deltas_flush_one_latest_arrival_without_per_event_writes
 
     monkeypatch.setattr(service.db, "touch_calls", record_batch)
     monkeypatch.setattr(service.db, "touch_call", forbid_single_touch)
-    wall_base = datetime.now(UTC) + timedelta(seconds=1)
-    monotonic_base = LatencyMark.now().monotonic_ns
 
-    latest: LatencyMark | None = None
     for sequence in range(125):
-        latest = LatencyMark(
-            occurred_at=(wall_base + timedelta(microseconds=sequence)).isoformat(),
-            monotonic_ns=monotonic_base + sequence,
-        )
-        # Production invokes this on the reader before dispatching the delta.
-        service._note_call_activity(call_id, latest)
+        # Assistant audio deltas note activity in-process; the reader also heartbeats in
+        # production. Either path must coalesce to one durable write.
         await service.handle_realtime_event(
             call_id,
             {"type": "response.audio.delta", "event_id": f"evt_{sequence}"},
@@ -53,9 +46,11 @@ async def test_realtime_deltas_flush_one_latest_arrival_without_per_event_writes
 
     await service._flush_call_activity()
 
-    assert latest is not None
-    assert batches == [[(call_id, latest.occurred_at)]]
-    assert (await service.db.get_call(call_id))["last_event_at"] == latest.occurred_at
+    assert len(batches) == 1
+    assert len(batches[0]) == 1
+    assert batches[0][0][0] == call_id
+    assert (await service.db.get_call(call_id))["last_event_at"] == batches[0][0][1]
+    assert call_id in service._latest_call_activity
 
 
 @pytest.mark.asyncio
@@ -338,3 +333,80 @@ async def test_twilio_callbacks_for_missing_call_leave_no_activity(service):
     assert call_id not in service._dirty_call_activity
     assert call_id not in service._watchdog_claims
     assert call_id not in service._activity_tombstones
+
+
+@pytest.mark.asyncio
+async def test_assistant_speech_events_refresh_activity_and_block_stale_watchdog(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    await _make_call_stale(service, call_id)
+
+    await service.handle_realtime_event(
+        call_id,
+        {"type": "response.output_audio.delta", "event_id": "evt_speech", "delta": "qq=="},
+    )
+
+    assert call_id in service._latest_call_activity
+    assert call_id in service._dirty_call_activity
+    await service._watchdog_once()
+    assert (await service.db.get_call(call_id))["state"] == CallState.ACTIVE.value
+    assert call_id not in service._watchdog_claims
+
+
+@pytest.mark.asyncio
+async def test_active_assistant_response_prevents_stale_timeout_without_sideband_frames(
+    service, packet
+):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    await _make_call_stale(service, call_id)
+    service._active_response_ids[call_id] = "resp_speaking"
+
+    await service._watchdog_once()
+
+    assert (await service.db.get_call(call_id))["state"] == CallState.ACTIVE.value
+    assert call_id not in service._watchdog_claims
+    assert call_id in service._latest_call_activity
+
+
+@pytest.mark.asyncio
+async def test_sip_output_playback_prevents_stale_timeout(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    await _make_call_stale(service, call_id)
+
+    await service.handle_realtime_event(
+        call_id, {"type": "output_audio_buffer.started", "event_id": "evt_play"}
+    )
+    assert call_id in service._sip_output_playing
+
+    await service._watchdog_once()
+    assert (await service.db.get_call(call_id))["state"] == CallState.ACTIVE.value
+
+    await service.handle_realtime_event(
+        call_id, {"type": "output_audio_buffer.stopped", "event_id": "evt_stop"}
+    )
+    assert call_id not in service._sip_output_playing
+
+
+@pytest.mark.asyncio
+async def test_inflight_tool_prevents_stale_timeout(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    await _make_call_stale(service, call_id)
+    service._inflight_tools.add(call_id)
+
+    await service._watchdog_once()
+
+    assert (await service.db.get_call(call_id))["state"] == CallState.ACTIVE.value
+    assert call_id not in service._watchdog_claims
+
+
+@pytest.mark.asyncio
+async def test_outbound_realtime_send_refreshes_activity(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    await _make_call_stale(service, call_id)
+
+    await service.handle_realtime_send(call_id, {"type": "response.create"})
+    await service._flush_call_activity()
+
+    call = await service.db.get_call(call_id)
+    assert datetime.fromisoformat(call["last_event_at"]) > datetime.now(UTC) - timedelta(seconds=5)
+    await service._watchdog_once()
+    assert (await service.db.get_call(call_id))["state"] == CallState.ACTIVE.value


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The 15s stale watchdog could hang up a live SIP call while the assistant was still speaking (or waiting on a tool). Activity was only refreshed from sideband/Twilio frames, but SIP audio rides RTP and the sideband can stay quiet for longer than 15s.

## Changes
- Refresh call activity on assistant speech/audio events and outbound realtime sends
- Treat active responses, SIP output playback, audio drain, and in-flight tools as live so the watchdog does not claim `watchdog_stale`
- Track in-flight `search_web` so Exa waits do not look idle
- Add regression coverage in `tests/test_activity_heartbeat.py`

## Risks
- Live-call teardown: lower risk of false `watchdog_stale` mid-speech; stuck active-response/tool state could delay stale detection until Twilio max duration or another terminal path
- Billing: no intentional change to call duration limits; may slightly lengthen calls that previously died falsely at 15s idle during speech/tool waits

## Validation
- `uv run ruff format --check app tests scripts`
- `uv run ruff check app tests scripts`
- `uv run pytest -q` (254 passed)
- Deployed to Fly (`poke-call` image `deployment-01KXMC425ANDYT7AN7H7MWN3Z0`); `/healthz` returned `{"status":"ok"}` and the new helpers are present on the running machine

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a66047f-4199-4d77-811d-df5e2cfc1d35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a66047f-4199-4d77-811d-df5e2cfc1d35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

