### PR TITLE
Harden post-call extraction against invalid turn_id citations

### DIFF
--- a/app/finalizer.py
+++ b/app/finalizer.py
@@ -26,6 +26,12 @@ from app.settings import Settings
 logger = logging.getLogger(__name__)
 
 
+class UnknownEvidenceError(ValueError):
+    def __init__(self, unknown_ids: set[str]):
+        self.unknown_ids = unknown_ids
+        super().__init__(f"extractor cited unknown transcript turn_ids: {sorted(unknown_ids)}")
+
+
 class Finalizer:
     def __init__(self, settings: Settings, db: Database, openai: AsyncOpenAI):
         self.settings = settings
@@ -159,13 +165,26 @@ class Finalizer:
             "duration_seconds": call.get("duration_seconds"),
             "transfer_outcome": call.get("transfer_outcome"),
             "realtime_advisory_outcome": call.get("advisory_outcome"),
-            "transcript": [turn.model_dump(mode="json") for turn in transcript],
+            # Only the citable id is exposed; source_event_id and friends are omitted so
+            # the extractor cannot confuse a similar-looking id namespace with turn_id.
+            "transcript": [
+                {"turn_id": turn.turn_id, "speaker": turn.speaker, "text": turn.text}
+                for turn in transcript
+            ],
         }
+        last_unknown: list[str] = []
         for attempt in range(2):
+            instructions = EXTRACTOR_INSTRUCTIONS
+            if last_unknown:
+                instructions += (
+                    "\nYour previous attempt cited turn_ids that do not exist in the "
+                    f"transcript: {', '.join(last_unknown)}. Cite only exact turn_id "
+                    "values that appear in the provided transcript entries."
+                )
             try:
                 response = await self.openai.responses.parse(
                     model=self.settings.extractor_model,
-                    instructions=EXTRACTOR_INSTRUCTIONS,
+                    instructions=instructions,
                     input=json.dumps(payload, ensure_ascii=False),
                     text_format=ExtractedCallResult,
                     store=False,
@@ -174,15 +193,25 @@ class Finalizer:
                 parsed = response.output_parsed
                 if parsed is None:
                     raise ValueError("extractor returned no parsed output")
-                for group in (
-                    parsed.commitments,
-                    parsed.confirmation_numbers,
-                    parsed.follow_ups,
-                ):
-                    for item in group:
-                        if not set(item.evidence_turn_ids).issubset(evidence_ids):
-                            raise ValueError("extractor cited an unknown transcript turn_id")
+                unknown = {
+                    turn_id
+                    for group in (
+                        parsed.commitments,
+                        parsed.confirmation_numbers,
+                        parsed.follow_ups,
+                    )
+                    for item in group
+                    for turn_id in item.evidence_turn_ids
+                    if turn_id not in evidence_ids
+                }
+                if unknown:
+                    raise UnknownEvidenceError(unknown)
                 return parsed
+            except UnknownEvidenceError as exc:
+                if attempt == 0:
+                    last_unknown = sorted(exc.unknown_ids)
+                    continue
+                raise
             except Exception as exc:
                 if attempt == 0 and self._retryable_extraction_error(exc):
                     await asyncio.sleep(0.25)

--- a/app/models.py
+++ b/app/models.py
@@ -120,7 +120,13 @@ class EvidenceValue(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     value: str
-    evidence_turn_ids: list[str] = Field(min_length=1)
+    evidence_turn_ids: list[str] = Field(
+        min_length=1,
+        description=(
+            "Exact turn_id values copied verbatim from the provided transcript entries. "
+            "Never invent, alter, or abbreviate an id."
+        ),
+    )
 
 
 class Commitment(EvidenceValue):

--- a/app/prompts.py
+++ b/app/prompts.py
@@ -117,7 +117,8 @@ Use end_call when the conversation is finished; the application coordinates the 
 EXTRACTOR_INSTRUCTIONS = """Extract a conservative structured call result.
 Use only facts explicitly supported by the ordered transcript and supplied telephony metadata.
 Never infer that a commitment succeeded without explicit confirmation.
-Every commitment, confirmation number, and follow-up must cite at least one provided transcript turn_id.
+Every commitment, confirmation number, and follow-up must cite at least one transcript turn via evidence_turn_ids.
+evidence_turn_ids must contain turn_id values copied verbatim from the provided transcript entries; never invent, alter, or abbreviate an id.
 If evidence is thin or missing, use unknown or needs_follow_up and lower confidence.
 Do not treat the realtime advisory outcome as ground truth; use it only when transcript evidence supports it.
 Treat mid-call Poke answers relayed by the agent as agent-asserted, same evidentiary tier as the advisory outcome (do not treat as ground truth).

--- a/tests/test_finalizer.py
+++ b/tests/test_finalizer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from types import SimpleNamespace
 
 import httpx
@@ -117,18 +118,105 @@ async def test_extractor_rejects_unknown_evidence_and_preserves_raw_transcript(
         follow_ups=[],
         confidence=0.9,
     )
-    finalizer = Finalizer(
-        settings,
-        service.db,
-        SimpleNamespace(responses=FakeResponses(parsed=parsed)),
-    )
+    responses = FakeResponses(parsed=parsed)
+    finalizer = Finalizer(settings, service.db, SimpleNamespace(responses=responses))
     result = await finalizer.finalize(call_id)
+    assert responses.calls == 2
     assert result.call_status == "completed"
     assert result.finalization_status == "failed"
     assert result.outcome == "unknown"
     assert result.result_source == "extraction_failed"
     assert result.raw_transcript_available is True
     assert (await service.db.get_transcript(call_id))[0].text == "Reference ABC-123."
+
+
+@pytest.mark.asyncio
+async def test_extractor_unknown_evidence_retry_carries_feedback_and_can_recover(
+    settings, service, packet
+):
+    call_id = await seed_call(service.db, packet, state=CallState.COMPLETED)
+    await service.db.add_transcript_turn(
+        call_id=call_id,
+        turn_id="turn_real",
+        speaker="callee",
+        text="Reference ABC-123.",
+        source_event_type="transcription.completed",
+        source_event_id="evt_real",
+    )
+    bad = ExtractedCallResult(
+        outcome="completed",
+        summary="Completed.",
+        commitments=[],
+        confirmation_numbers=[{"value": "ABC-123", "evidence_turn_ids": ["evt_real"]}],
+        follow_ups=[],
+        confidence=0.9,
+    )
+    good = ExtractedCallResult(
+        outcome="completed",
+        summary="Completed.",
+        commitments=[],
+        confirmation_numbers=[{"value": "ABC-123", "evidence_turn_ids": ["turn_real"]}],
+        follow_ups=[],
+        confidence=0.9,
+    )
+
+    class BadThenGood(FakeResponses):
+        def __init__(self):
+            super().__init__()
+            self.instructions_seen: list[str] = []
+
+        async def parse(inner_self, **kwargs):
+            inner_self.calls += 1
+            inner_self.instructions_seen.append(kwargs["instructions"])
+            return SimpleNamespace(output_parsed=bad if inner_self.calls == 1 else good)
+
+    responses = BadThenGood()
+    result = await Finalizer(settings, service.db, SimpleNamespace(responses=responses)).finalize(
+        call_id
+    )
+
+    assert responses.calls == 2
+    assert "evt_real" in responses.instructions_seen[1]
+    assert result.finalization_status == "succeeded"
+    assert result.result_source == "post_call_extractor"
+
+
+@pytest.mark.asyncio
+async def test_extractor_payload_exposes_only_citable_turn_fields(settings, service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.COMPLETED)
+    await service.db.add_transcript_turn(
+        call_id=call_id,
+        turn_id="item_abc",
+        speaker="callee",
+        text="Confirmed for 7 PM.",
+        source_event_type="transcription.completed",
+        source_event_id="event_xyz",
+    )
+    parsed = ExtractedCallResult(
+        outcome="completed",
+        summary="Completed.",
+        commitments=[],
+        confirmation_numbers=[],
+        follow_ups=[],
+        confidence=0.9,
+    )
+
+    class CapturingResponses(FakeResponses):
+        def __init__(self, parsed):
+            super().__init__(parsed=parsed)
+            self.inputs: list[str] = []
+
+        async def parse(inner_self, **kwargs):
+            inner_self.inputs.append(kwargs["input"])
+            return await super().parse(**kwargs)
+
+    responses = CapturingResponses(parsed)
+    await Finalizer(settings, service.db, SimpleNamespace(responses=responses)).finalize(call_id)
+
+    payload = json.loads(responses.inputs[0])
+    assert payload["transcript"] == [
+        {"turn_id": "item_abc", "speaker": "callee", "text": "Confirmed for 7 PM."}
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A production call (2026-07-16, `call_T1qXP8...`) booked successfully, but the stored structured result was the fallback (`outcome: "unknown"`, `result_source: "extraction_failed"`): the post-call extractor cited a `turn_id` not present in the stored transcript, and `Finalizer._extract` rejected the whole extraction with `ValueError: extractor cited an unknown transcript turn_id`.

## Root cause

- Each transcript entry in the extractor payload carried **two id-like fields**: `turn_id` (OpenAI realtime `item_...` id) and the visually similar `source_event_id` (`event_.../evt_...`) — an easy trap for the model to cite the wrong one.
- The prompt only said "must cite at least one provided transcript turn_id" — nothing about verbatim copying — and the `evidence_turn_ids` schema field had no description.
- A citation mistake was non-retryable: one bad id discarded the entire extraction, and the exception didn't log the offending ids (with `store=False` on the API call, the actual bad id is unrecoverable).

## Fix

- **Payload**: transcript entries now expose only `{turn_id, speaker, text}` — the confusable `source_event_id` namespace is gone.
- **Prompt + schema**: `EXTRACTOR_INSTRUCTIONS` and a new `Field(description=...)` on `evidence_turn_ids` both require exact, verbatim `turn_id` values.
- **Retry + diagnosability**: citation failures raise `UnknownEvidenceError` naming the offending ids and get one retry whose instructions list the bad ids and demand exact transcript ids. If the retry also miscites, the conservative `extraction_failed` fallback still applies.

## Tests

- Updated the unknown-evidence rejection test to cover the retry (asserts 2 attempts, unchanged fallback).
- New: bad-then-good recovery test asserting the corrective feedback reaches the second attempt.
- New: payload-shape test pinning the slimmed transcript format (`item_.../event_...` ids scenario).

`ruff` clean; 284 tests pass; live smoke (`scripts/live_smoke.sh`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)