### PR TITLE
Make call openings and endings sound natural

### DIFF
--- a/app/call_state.py
+++ b/app/call_state.py
@@ -1198,8 +1198,8 @@ class CallService:
                 received=received,
                 event_key=event_key,
                 continuation_instructions=(
-                    "The call is now ending. Briefly confirm the outcome or next step if useful, "
-                    "then say one concise, natural goodbye. Do not call any function."
+                    "The call is now ending. Say one short, natural goodbye and nothing else. "
+                    "Do not recap details already confirmed. Do not call any function."
                 ),
             )
         elif name == "transfer_to_owner":

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -13,7 +13,10 @@ from app.models import AnswerCallQuestionRequest, ContextPacket, PreparePhoneCal
 CONTEXT_GUIDANCE = (
     "Assemble only call-relevant facts from Poke memory and integrations. Resolve relative dates "
     "to explicit datetimes in the owner's timezone. Never invent phone numbers or facts. Never "
-    "include passwords, authentication codes, payment credentials, or government identifiers."
+    "include passwords, authentication codes, payment credentials, or government identifiers. "
+    "Write the objective from the agent's perspective as the caller: who the agent calls and what "
+    "the agent, acting for the owner, must achieve. Avoid parentheticals or phrasing that could "
+    "reassign roles between the agent and the callee."
 )
 
 

--- a/app/prompts.py
+++ b/app/prompts.py
@@ -25,7 +25,19 @@ def realtime_instructions(packet: ContextPacket, *, ask_poke_enabled: bool = Fal
     def compose(ask_poke_line: str) -> str:
         return f"""# Objective
 Complete only the approved objective in the context below.
-Choose how to open the call from the approved context; the application does not prescribe an opening.
+
+# Role
+You are always the caller, acting on behalf of the owner in the approved context.
+The callee is the target. Never present yourself as the callee's business, staff, or their side
+of the call, even if the objective's wording is ambiguous — when in doubt, you are the owner's
+assistant calling out.
+If asked whether you are human, say once, plainly, that you are an AI assistant calling for the
+owner, then return to the task. Do not philosophize about it.
+
+# Opening
+Open with one short turn: greet, say who you are calling for, and make the single main ask.
+Hold fallbacks, flexibility windows, spellings, and contact details until asked or until the
+first ask fails. Approved context is your authority and ammunition, not a script to read aloud.
 
 # Personality and tone
 You are a sassy personal assistant, not a corporate helpdesk bot.
@@ -49,6 +61,8 @@ When starting a task or bridging a beat, prefer low-energy acknowledgements like
 Before a tool call or any pause that would leave dead air, talk through it with a short casual
 bridge ("hang on," "one sec," "uh, checking"). Describe the action, not internal reasoning.
 Skip preambles for direct answers, simple yes/no, clarifications, and unclear audio.
+Never preamble end_call or record_call_outcome: the goodbye itself is the close. Do not narrate
+wrapping up, recording the outcome, or ending the call.
 
 # Conversation behavior
 Listen before responding.

--- a/tests/test_bridge_payloads.py
+++ b/tests/test_bridge_payloads.py
@@ -177,7 +177,7 @@ async def test_voicemail_prompt_does_not_script_identity_or_callback_wording(set
     assert "callback" not in instructions
 
 
-def test_session_prompt_leaves_opening_identity_and_wording_to_poke(settings, packet):
+def test_session_prompt_anchors_caller_role_without_scripting_wording(settings, packet):
     instructions = (
         RealtimeBridge(
             settings,
@@ -190,8 +190,9 @@ def test_session_prompt_leaves_opening_identity_and_wording_to_poke(settings, pa
         .instructions
     )
 
-    assert "Choose how to open the call from the approved context" in instructions
-    assert "# Identity and disclosure" not in instructions
+    assert "# Role" in instructions
+    assert "You are always the caller" in instructions
+    assert "# Opening" in instructions
     assert "Always identify yourself" not in instructions
     assert "You are Poke" not in instructions
     assert "Am I speaking with" not in instructions


### PR DESCRIPTION
## Problem

A live test call ([`call_T1qXP8UXbEdbildwgQfqxJ-A`] transcript review) showed the voice agent behaving unnaturally at both ends of the call:

1. **Identity inversion** — the agent opened with "你好，这里是餐厅订位" and later claimed to be "餐厅这边的语音助手", presenting itself as the *callee's* restaurant staff. Poke's objective contained an ambiguous parenthetical ("Call Irvin (pretending to be a restaurant)…") and nothing in the prompt anchored which side of the call the agent is on.
2. **Strategy leaked as script** — the opening turn dumped the full context packet in one breath: name, party size, exact date, time, *and* the fallback flexibility window, revealing its entire negotiating position before hearing "no".
3. **Mechanical ending** — after the callee said goodbye, the agent narrated its internal workflow ("我这边把预订状态收个尾，然后结束通话", a preamble for the `end_call` tool) and then re-recited every already-confirmed booking detail (invited by the injected "Briefly confirm the outcome…" goodbye instruction).

## Changes

- **`app/prompts.py`** — new `# Role` section (always the caller acting for the owner; never adopt the callee's business identity; answer "are you human?" once, plainly) and `# Opening` section (one short turn; hold fallbacks/spellings/contact details until needed). Preamble rule now exempts `end_call`/`record_call_outcome`.
- **`app/call_state.py`** — the post-`end_call` goodbye injection becomes "Say one short, natural goodbye and nothing else. Do not recap details already confirmed."
- **`app/mcp_tools.py`** — `CONTEXT_GUIDANCE` now tells Poke to write objectives from the agent-as-caller perspective and avoid role-reassigning parentheticals, fixing the ambiguity at the source.
- **`tests/test_bridge_payloads.py`** — replaced `test_session_prompt_leaves_opening_identity_and_wording_to_poke` (which asserted the design decision this PR reverses) with `test_session_prompt_anchors_caller_role_without_scripting_wording`.

## Testing

- Full suite: 282 passed.
- Not yet re-verified with a live call; needs a deploy + test call to confirm the new opening/ending behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)