### PR TITLE
Rewrite README with friendlier structure and visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,54 @@
-# Poke Phone-Call Bridge
-
 <p align="center">
   <a href="https://poke.com"><img src="docs/images/poke-og.jpg" alt="Poke" width="720"/></a>
 </p>
 
+<h1 align="center">📞 Poke Phone-Call Bridge</h1>
+
 <p align="center">
-  <img src="docs/images/poke-icon.png" alt="Poke" height="64"/>
+  <em>Text Poke. Poke calls a human. An AI does the talking. You get the transcript.</em>
 </p>
 
-Single-user FastAPI + FastMCP service that lets [Poke](https://poke.com) prepare, confirm, start, monitor, and end outbound phone calls for Irvin. [Twilio](https://www.twilio.com) originates an [OpenAI](https://openai.com) SIP agent leg into a private conference, the service accepts and prewarms `gpt-realtime-2.1` over a sideband WebSocket, and only then dials the callee. SQLite stores plans, state, ordered transcripts, and deterministic final results.
+<p align="center">
+  <img src="docs/images/poke-icon.png" alt="Poke" height="56"/>
+</p>
 
-## Built with
+<p align="center">
+  <a href="#-quick-start">Quick start</a> ·
+  <a href="#-how-a-call-happens">How it works</a> ·
+  <a href="#-the-seven-tools">MCP tools</a> ·
+  <a href="#-safety-rails">Safety</a> ·
+  <a href="#-deploying">Deploy</a>
+</p>
 
-Official art from the sites this bridge calls out to:
+---
+
+A single-user [FastAPI](https://fastapi.tiangolo.com) + FastMCP service that lets [Poke](https://poke.com) prepare, confirm, start, monitor, and end outbound phone calls for Irvin. [Twilio](https://www.twilio.com) dials an [OpenAI](https://openai.com) SIP voice agent into a private conference, the service prewarms `gpt-realtime-2.1` over a sideband WebSocket, and only then rings the callee. SQLite keeps the receipts: plans, state, ordered transcripts, and deterministic final results.
+
+## ✨ How a call happens
+
+```mermaid
+sequenceDiagram
+    participant P as 💬 Poke
+    participant B as 🌉 Bridge
+    participant O as 🤖 OpenAI SIP agent
+    participant T as ☎️ Twilio
+    participant C as 🧑 Callee
+
+    P->>B: prepare_phone_call (plan + policy checks)
+    P->>B: start_phone_call (explicit confirmation)
+    B->>T: create conference, dial OpenAI SIP leg
+    O-->>B: realtime.call.incoming webhook
+    B->>O: accept + prewarm over sideband WebSocket
+    B->>T: now dial the callee (with AMD)
+    T->>C: 🔔 ring ring
+    O<<->>C: conversation (transcribed live)
+    O->>B: end_call → one spoken goodbye → teardown
+    P->>B: wait_for_call_event → get_call_result
+```
+
+The callee's phone never rings until the AI is already on the line, warmed up, and ready to speak.
+
+## 🧰 Built with
 
 <p align="center">
   <a href="https://developers.openai.com/api/docs/guides/realtime-sip"><img src="docs/images/openai-realtime-sip.png" alt="OpenAI Realtime API with SIP" width="49%"/></a>
@@ -25,68 +61,29 @@ Official art from the sites this bridge calls out to:
   <a href="https://fly.io"><img src="docs/images/fly-og.jpg" alt="Fly.io" width="32%"/></a>
 </p>
 
-<p align="center">
-  <a href="https://fastapi.tiangolo.com"><img src="docs/images/fastapi-logo.png" alt="FastAPI" height="48"/></a>
-  &nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://astral.sh"><img src="docs/images/astral-og.jpg" alt="Astral" height="48"/></a>
-</p>
+| Piece | Job |
+| --- | --- |
+| [Poke](https://poke.com) | MCP client, call intent, optional push |
+| [OpenAI Realtime SIP](https://developers.openai.com/api/docs/guides/realtime-sip) | Voice agent, accept, sideband control |
+| [Twilio](https://www.twilio.com) | Conference, callee dial, answering-machine detection |
+| [Exa](https://exa.ai) | In-call public-web search |
+| [FastAPI](https://fastapi.tiangolo.com) + FastMCP | HTTP surface and MCP tools |
+| [Fly.io](https://fly.io) | Production host, volume-backed SQLite |
+| [Astral](https://astral.sh) uv / Ruff | Package lock and lint |
 
-- **[Poke](https://poke.com)** — MCP client, call intent, optional push
-- **[OpenAI Realtime SIP](https://developers.openai.com/api/docs/guides/realtime-sip)** — voice agent, accept, sideband control
-- **[Twilio](https://www.twilio.com)** — conference, callee dial, AMD
-- **[Exa](https://exa.ai)** — in-call public-web search
-- **[FastAPI](https://fastapi.tiangolo.com) + FastMCP** — HTTP surface and MCP tools
-- **[Fly.io](https://fly.io)** — production host and volume-backed SQLite
-- **[Astral uv / Ruff](https://astral.sh)** — package lock and lint
+## 🚀 Quick start
 
-## Safety and operating model
-
-- The MCP endpoint always requires its bearer token. It also validates the configured Poke user ID whenever Poke supplies the header; Poke's refresh follow-up currently omits it.
-- Every OpenAI and Twilio webhook is signature-verified; OpenAI delivery IDs are replay-protected.
-- A call cannot start without an unexpired prepared plan and explicit confirmation text.
-- Destination policy blocks malformed E.164, emergency/N11/short codes, premium-rate prefixes, disallowed country codes, and the service's own Twilio number.
-- The voice model chooses how to open from Poke's approved call context; the bridge does not impose identity, disclosure, or recipient-confirmation wording. It may not share or request passwords, auth codes, payment credentials, or government identifiers.
-- The in-call voice model decides when the conversation is finished and invokes its private `end_call` function. The bridge asks it for one final spoken goodbye, waits for that closing response to complete, and then tears down OpenAI and Twilio. The public `end_phone_call` MCP tool remains a manual stop.
-- Poke push is optional and non-canonical. During a live call, `wait_for_call_event` is the
-  canonical monitoring loop; after it reports a terminal state, call `get_call_result`.
-
-Do not deploy or restart while a call is active. Recovery stops stranded billable media and finalizes missing results, but a process restart necessarily ends the live call.
-
-Calls are retained as transcripts. The application does not force a verbal identity or AI-disclosure script; the owner remains responsible for jurisdiction-specific disclosure, recording, robocall, consent, and retention compliance. Apply transcript retention independently of extraction success or failure.
-
-## Requirements
-
-- Python 3.12+ and [uv](https://docs.astral.sh/uv/)
-- A paid/voice-enabled Twilio account, an E.164 caller ID, and outbound SIP/Conference Participant AMD access
-- An OpenAI project with Realtime SIP access, an API key, and a webhook signing secret
-- An Exa API key for in-call public-web search
-- A stable public HTTPS URL (tunnel for local work; always-on Render instance for deployment)
-
-The locked implementation was developed against OpenAI Python `2.45.0`, Twilio Python `9.10.9`, FastMCP `3.4.4`, FastAPI `0.139.0`, and websockets `16.1`. `uv.lock` is authoritative.
-
-## Local setup
+You'll need Python 3.12+, [uv](https://docs.astral.sh/uv/), a voice-enabled Twilio account (E.164 caller ID, outbound SIP + Conference Participant AMD), an OpenAI project with Realtime SIP access and a webhook signing secret, an Exa API key, and a stable public HTTPS URL.
 
 ```bash
-test -e .env.local || cp .env.example .env.local
+test -e .env.local || cp .env.example .env.local   # guarded: keeps a saved key
 uv sync --all-groups --frozen
 uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 ```
 
-Fill every required value in `.env.local`; the guarded copy command deliberately preserves a key previously saved by the OpenAI Platform picker. Generate `MCP_BEARER_TOKEN` and `DEBUG_API_TOKEN` with a password generator or `openssl rand -hex 32`. Never commit env files; `.gitignore` excludes them.
+Fill every required value in `.env.local`. Generate `MCP_BEARER_TOKEN` and `DEBUG_API_TOKEN` with `openssl rand -hex 32`. Never commit env files — `.gitignore` already excludes them.
 
-Live-call control requests use `OPENAI_CONNECT_TIMEOUT_SECONDS` and
-`OPENAI_HTTP_TIMEOUT_SECONDS` (3 and 10 seconds by default) with no SDK retries; post-call
-extraction uses `OPENAI_EXTRACTION_TIMEOUT_SECONDS` and retains its single application-level
-retry. Twilio requests use the pooled, no-retry transport bounded by
-`TWILIO_HTTP_TIMEOUT_SECONDS`. `SEMANTIC_VAD_EAGERNESS` defaults to `auto` (OpenAI's
-medium-eagerness behavior); set it to `high` for quicker turn completion.
-`OPENAI_KEEPALIVE_EXPIRY_SECONDS=60` keeps the control-plane TLS connection reusable between
-sporadic calls; set it only to a bounded 5-300 second value.
-The voice model can call `search_web` for current or uncertain facts. The application fixes Exa
-Search to `type=auto`, 10 results, moderation, and token-efficient highlights, with a three-second
-wall-clock deadline controlled by `EXA_SEARCH_TIMEOUT_SECONDS`.
-
-Run validation:
+Then check your work:
 
 ```bash
 uv run ruff format --check app tests scripts
@@ -94,60 +91,81 @@ uv run ruff check app tests scripts
 uv run pytest -q
 ```
 
-## HTTPS tunnel and webhooks
+### Expose it to the world
 
-Start the server, then expose port 8000. Either command works:
+Webhooks need a public HTTPS origin. Start the server, then tunnel port 8000:
 
 ```bash
-ngrok http 8000
-# or
-cloudflared tunnel --url http://localhost:8000
+ngrok http 8000            # or: cloudflared tunnel --url http://localhost:8000
 ```
 
-Set `PUBLIC_BASE_URL` to the exact HTTPS origin printed by the tunnel, without a trailing slash, and restart the service. This exact value is security-critical because Twilio signs the full public callback URL.
+Set `PUBLIC_BASE_URL` to the exact HTTPS origin the tunnel prints — no trailing slash — and restart. This value is security-critical: Twilio signs the full public callback URL.
 
-In **OpenAI Platform → Project → Webhooks**, create an endpoint:
+In **OpenAI Platform → Project → Webhooks**, create `https://YOUR_HOST/webhooks/openai`, subscribe it to `realtime.call.incoming`, and copy the signing secret to `OPENAI_WEBHOOK_SECRET`. The OpenAI project in the SIP URI is `OPENAI_PROJECT_ID`.
 
-```text
-https://YOUR_HOST/webhooks/openai
-```
+No static Twilio webhook is needed — every Conference Participant request carries its own signed status, conference, and AMD callback URLs. Just confirm the Twilio account can call the OpenAI SIP URI and can use AMD on `/Participants`.
 
-Subscribe it to `realtime.call.incoming`, copy its signing secret to `OPENAI_WEBHOOK_SECRET`, and restart. The OpenAI project in the SIP URI is `OPENAI_PROJECT_ID`.
-
-No static Twilio webhook needs to be configured: each Conference Participant request supplies its signed status, conference, and AMD callback URL. Confirm that the Twilio account can call the OpenAI SIP URI and can use AMD on `/Participants`. The service supplies `DetectMessageEnd` and an AMD callback on every callee leg.
-
-Configure Poke's MCP connection as:
+### Point Poke at it
 
 ```text
-URL: https://YOUR_HOST/mcp/
-Authorization: Bearer MCP_BEARER_TOKEN
+URL:            https://YOUR_HOST/mcp/
+Authorization:  Bearer MCP_BEARER_TOKEN
 X-Poke-User-Id: ALLOWED_POKE_USER_ID
-Transport: Streamable HTTP
+Transport:      Streamable HTTP
 ```
 
-The server exposes exactly seven tools: `prepare_phone_call`, `start_phone_call`, `get_call_result`, `end_phone_call`, `get_phone_call`, `wait_for_call_event`, and `answer_call_question`.
+## 🛠️ The seven tools
 
-## Live SIP canary
+The server exposes exactly seven MCP tools — no more, no less:
 
-Deploy or tunnel the service first. The full canary calls `OWNER_PHONE_E164`, prints a random spoken nonce, asks you to interrupt the assistant once, and checks accept status, echoed transcription configuration, semantic VAD, nonce transcription, function-tool use, interruption, and the terminal result:
+| Tool | What it does |
+| --- | --- |
+| `prepare_phone_call` | Validate destination policy, persist a plan |
+| `start_phone_call` | Explicit confirmation → dial |
+| `wait_for_call_event` | Canonical live-call monitoring loop |
+| `get_phone_call` | Snapshot of call state |
+| `answer_call_question` | Feed an answer to the live agent |
+| `end_phone_call` | Manual stop button |
+| `get_call_result` | Deterministic final result + transcript |
+
+During a live call, `wait_for_call_event` is the canonical monitoring loop; once it reports a terminal state, call `get_call_result`. Poke push is optional and non-canonical — a push failure is logged and never changes call state.
+
+## 🛡️ Safety rails
+
+- 🔑 The MCP endpoint always requires its bearer token, and validates the configured Poke user ID whenever Poke supplies the header (Poke's refresh follow-up currently omits it).
+- ✍️ Every OpenAI and Twilio webhook is signature-verified; OpenAI delivery IDs are replay-protected.
+- 🙋 A call cannot start without an unexpired prepared plan **and** explicit confirmation text.
+- 🚫 Destination policy blocks malformed E.164, emergency/N11/short codes, premium-rate prefixes, disallowed country codes, and the service's own Twilio number.
+- 🤐 The voice model may not share or request passwords, auth codes, payment credentials, or government identifiers. It chooses how to open from Poke's approved call context; the bridge does not impose identity, disclosure, or recipient-confirmation wording.
+- 👋 The in-call model decides when the conversation is done and invokes its private `end_call` function; the bridge asks for one final spoken goodbye, waits for it, then tears down OpenAI and Twilio.
+
+> [!WARNING]
+> Do not deploy or restart while a call is active. Recovery stops stranded billable media and finalizes missing results, but a process restart necessarily ends the live call.
+
+Calls are retained as transcripts. The owner remains responsible for jurisdiction-specific disclosure, recording, robocall, consent, and retention compliance. Apply transcript retention independently of extraction success or failure.
+
+## 🐦 Live SIP canary
+
+Before trusting a deployment, make it prove itself with a real call to `OWNER_PHONE_E164`:
 
 ```bash
 uv run python scripts/run_sip_canary.py --mode full
 ```
 
-Answer the call, say the printed nonce when asked, and speak over the assistant once. After the call, the script asks you to confirm that audible assistant speech stopped promptly; the server-side cancellation event must also be present. Then run the no-advisory-tool variant to prove the deterministic finalizer does not depend on `record_call_outcome`:
+Answer the phone, say the printed nonce when asked, and talk over the assistant once. The script gates on accept status, echoed transcription configuration, semantic VAD, nonce transcription, function-tool use, interruption handling, and the terminal result. Then run the second variant to prove the deterministic finalizer does not depend on `record_call_outcome`:
 
 ```bash
 uv run python scripts/run_sip_canary.py --mode no-outcome-tool
 ```
 
-Both commands exit nonzero if any gate fails. The debug evidence endpoint they use requires `DEBUG_API_TOKEN`.
+Both exit nonzero if any gate fails. The debug evidence endpoint they use requires `DEBUG_API_TOKEN`.
 
-No mini realtime model can be selected by configuration in v1. Do not relax the `realtime_model` literal or `MINI_MODELS_ENABLED=false` gate until that exact model passes both canaries, including SIP tool calling.
+> [!NOTE]
+> No mini realtime model can be selected by configuration in v1. Do not relax the `realtime_model` literal or the `MINI_MODELS_ENABLED=false` gate until that exact model passes both canaries, including SIP tool calling.
 
-## Fly.io deployment
+## 🎈 Deploying
 
-`fly.toml` defines the production deployment at `https://poke-call.fly.dev`: one always-on shared CPU machine with 512 MB RAM and a 1 GB persistent volume mounted at `/data`. SQLite uses `sqlite:////data/poke_call.db`. Validate and deploy it with:
+`fly.toml` defines production at `https://poke-call.fly.dev`: one always-on shared-CPU machine, 512 MB RAM, a 1 GB volume at `/data`, and SQLite at `sqlite:////data/poke_call.db`.
 
 ```bash
 flyctl config validate
@@ -155,28 +173,34 @@ flyctl deploy --ha=false --remote-only
 curl -fsS https://poke-call.fly.dev/healthz
 ```
 
-Set every required value from `.env.example` with `flyctl secrets set` or `flyctl secrets import`; never commit secret values. The OpenAI project webhook must point to `https://poke-call.fly.dev/webhooks/openai` and subscribe to `realtime.call.incoming`. After rotating its signing secret, activate staged values with:
+Set every required value from `.env.example` with `flyctl secrets set` or `flyctl secrets import`. Point the OpenAI project webhook at `https://poke-call.fly.dev/webhooks/openai` (subscribed to `realtime.call.incoming`). After rotating the signing secret:
 
 ```bash
 flyctl secrets deploy -a poke-call
 flyctl status -a poke-call
 ```
 
-Keep exactly one Machine for this SQLite deployment. A second Machine would need its own local volume and would not share call state. `render.yaml` remains available as a paid Render alternative.
+> [!IMPORTANT]
+> Keep exactly **one** Machine. SQLite state is volume-local; a second Machine would not share call state. `render.yaml` remains available as a paid Render alternative.
 
-Automated deployments use the authenticated `/internal/deployment-lock` lease before replacing
-the Machine. The lease is acquired atomically only when no call is active, blocks new calls while
-the deployment starts, expires after 15 minutes if a deployment is canceled, and is cleared by a
-successful application restart. Store `DEPLOY_GUARD_TOKEN` independently from the MCP and debug
-tokens; it can only access this deployment lease.
+**CI/CD:** `.github/workflows/fly-deploy.yml` runs the locked test suite and deploys every push to `main`. It serializes production deployments, waits up to 10 minutes for active calls to finish via the authenticated `/internal/deployment-lock` lease, keeps `--ha=false`, and checks `/healthz` before reporting success. It needs the repository secrets `FLY_API_TOKEN` (app-scoped deploy token) and `DEPLOY_GUARD_TOKEN` — store the latter independently from the MCP and debug tokens; it can only touch the deployment lease. The lease is acquired atomically only when no call is active, blocks new calls while a deployment starts, expires after 15 minutes if canceled, and is cleared by a successful restart.
 
-`.github/workflows/fly-deploy.yml` runs the locked test suite and deploys every push to `main`,
-including every merged pull request. It serializes production deployments, waits up to 10 minutes
-for active calls to finish, preserves the single-Machine volume topology with `--ha=false`, and
-checks `/healthz` before reporting success. GitHub Actions requires the repository secrets
-`FLY_API_TOKEN` (an app-scoped Fly deploy token) and `DEPLOY_GUARD_TOKEN`.
+## 🔬 The fine print
 
-## API/schema decisions verified on 2026-07-13
+<details>
+<summary><strong>Tuning knobs (timeouts, VAD, search)</strong></summary>
+
+- Live-call control requests use `OPENAI_CONNECT_TIMEOUT_SECONDS` and `OPENAI_HTTP_TIMEOUT_SECONDS` (3 and 10 seconds by default) with no SDK retries; post-call extraction uses `OPENAI_EXTRACTION_TIMEOUT_SECONDS` and keeps its single application-level retry.
+- Twilio requests use the pooled, no-retry transport bounded by `TWILIO_HTTP_TIMEOUT_SECONDS`.
+- `SEMANTIC_VAD_EAGERNESS` defaults to `auto` (OpenAI's medium-eagerness behavior); set `high` for quicker turn completion.
+- `OPENAI_KEEPALIVE_EXPIRY_SECONDS=60` keeps the control-plane TLS connection reusable between sporadic calls; only set it to a bounded 5–300 second value.
+- The voice model can call `search_web` for current or uncertain facts. The application fixes Exa Search to `type=auto`, 10 results, moderation, and token-efficient highlights, with a three-second wall-clock deadline controlled by `EXA_SEARCH_TIMEOUT_SECONDS`.
+- Locked dependency versions: OpenAI Python `2.45.0`, Twilio Python `9.10.9`, FastMCP `3.4.4`, FastAPI `0.139.0`, websockets `16.1`. `uv.lock` is authoritative.
+
+</details>
+
+<details>
+<summary><strong>API/schema decisions (verified 2026-07-13)</strong></summary>
 
 The implementation follows the current [OpenAI Realtime SIP guide](https://developers.openai.com/api/docs/guides/realtime-sip), [server-side controls guide](https://developers.openai.com/api/docs/guides/realtime-server-controls), [Realtime prompting guide](https://developers.openai.com/api/docs/guides/realtime-models-prompting), [webhook guide](https://developers.openai.com/api/docs/guides/webhooks), [Structured Outputs guide](https://developers.openai.com/api/docs/guides/structured-outputs), [Twilio Conference Participant reference](https://www.twilio.com/docs/voice/api/conference-participant-resource), [Twilio AMD guide](https://www.twilio.com/docs/voice/answering-machine-detection), and [Twilio request validation guide](https://www.twilio.com/docs/usage/security).
 
@@ -188,12 +212,21 @@ Live-schema deviations from the original contract are intentional:
 - The installed transcription schema permits `INPUT_TRANSCRIPTION_DELAY` only for `gpt-realtime-whisper`, with `minimal|low|medium|high|xhigh` values.
 - The OpenAI SIP agent participant is created with `early_media=false` and is explicitly unmuted before the model's opening turn, because Twilio mutes legs that join with `start_conference_on_enter=false` until the conference starts.
 
-## Result semantics
+</details>
+
+<details>
+<summary><strong>Result semantics</strong></summary>
 
 Telephony state and extraction state remain separate. A successful phone call whose extractor fails stays `call_status=completed`, gets `finalization_status=failed`, `outcome=unknown`, retains its raw transcript, and tells the owner to review it. The service saves a telephony-only result and transcript transactionally before making the external Responses API extraction request. Only transient connection, timeout, or rate-limit failures receive one retry.
 
-Optional Poke push remains disabled by default. A push failure is logged and never changes call state or polling availability.
+</details>
 
 ---
 
-Brand images in `docs/images/` were fetched from official sites ([poke.com](https://poke.com), [developers.openai.com](https://developers.openai.com), [twilio.com](https://www.twilio.com), [exa.ai](https://exa.ai), [fly.io](https://fly.io), [fastapi.tiangolo.com](https://fastapi.tiangolo.com), [astral.sh](https://astral.sh)). Marks belong to their respective owners.
+<p align="center">
+  <sub>Brand images in <code>docs/images/</code> were fetched from official sites
+  (<a href="https://poke.com">poke.com</a>, <a href="https://developers.openai.com">developers.openai.com</a>,
+  <a href="https://www.twilio.com">twilio.com</a>, <a href="https://exa.ai">exa.ai</a>,
+  <a href="https://fly.io">fly.io</a>, <a href="https://fastapi.tiangolo.com">fastapi.tiangolo.com</a>,
+  <a href="https://astral.sh">astral.sh</a>). Marks belong to their respective owners.</sub>
+</p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Docs-only rewrite of `README.md` to make it easier to skim and more pleasant to read. No code, configuration, or behavioral changes.

- Adds a centered hero header with tagline and a jump-link nav bar.
- Adds a Mermaid sequence diagram showing the full call lifecycle (prepare → confirm → conference → SIP accept/prewarm → callee dial → teardown → result).
- Converts the "Built with" and MCP tool lists into tables; the seven-tool list now includes a one-line purpose per tool (names verified against `app/mcp_tools.py`).
- Restructures setup into a single "Quick start" flow (env, tunnel, webhooks, Poke MCP config).
- Uses GitHub alert blocks (`[!WARNING]`, `[!IMPORTANT]`, `[!NOTE]`) for the deploy/restart, single-Machine, and mini-model warnings.
- Moves dense reference material (tuning knobs, verified API/schema decisions, result semantics) into collapsible `<details>` sections so it's preserved but out of the main reading path.

All safety, canary, deployment, and schema-deviation content from the old README is retained — only reorganized and reworded.

## Validation

- Mermaid diagram syntax validated with `@mermaid-js/mermaid-cli`:
  ![Rendered call-flow diagram](https://cursor.com/artifacts/c/art-452d08d3-13d5-41ae-92d2-8c2519d39852)
- GitHub-rendered preview (via grip + headless Chrome; Mermaid renders client-side on GitHub):
  ![Rendered README top](https://cursor.com/artifacts/c/art-daa3a1e8-2f35-4c7f-a77a-17bb8abe7652)

## Risks

None to live-call teardown or billing; documentation only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7124cbf0-2a2b-4ae6-87a1-56ada047c2c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7124cbf0-2a2b-4ae6-87a1-56ada047c2c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

