### PR TITLE
Send human-readable owner summary in post-call Poke push

### DIFF
--- a/app/finalizer.py
+++ b/app/finalizer.py
@@ -25,6 +25,47 @@ from app.settings import Settings
 
 logger = logging.getLogger(__name__)
 
+_OUTCOME_LABELS: dict[str, str] = {
+    "completed": "Done",
+    "partially_completed": "Partially done",
+    "needs_follow_up": "Needs follow-up",
+    "declined": "Declined",
+    "voicemail_left": "Voicemail left",
+    "wrong_number": "Wrong number",
+    "transferred": "Transferred to a human",
+    "failed": "Call failed",
+    "unknown": "Outcome unknown",
+}
+
+
+def format_owner_summary(result: StoredCallResult) -> str:
+    """Short owner-facing text for the post-call Poke push."""
+    lines: list[str] = []
+    summary = result.summary.strip()
+    label = _OUTCOME_LABELS.get(result.outcome, "Outcome unknown")
+    if result.outcome == "completed" and summary:
+        lines.append(f"📞 {summary}")
+    elif summary:
+        lines.append(f"📞 {label}: {summary}")
+    else:
+        lines.append(f"📞 {label}.")
+    if result.confirmation_numbers:
+        values = [item.value for item in result.confirmation_numbers]
+        if len(values) == 1:
+            lines.append(f"Confirmation #{values[0]}")
+        else:
+            lines.append("Confirmations: " + ", ".join(f"#{v}" for v in values))
+    confirmed = [c.value for c in result.commitments if c.status == "confirmed"]
+    if confirmed:
+        lines.append("Confirmed: " + "; ".join(confirmed))
+    actions = [f.value for f in result.follow_ups if f.owner_action_required]
+    if actions:
+        lines.append("Action needed: " + "; ".join(actions))
+    if result.finalization_status != "succeeded":
+        lines.append("Automatic extraction had problems; the full transcript is saved.")
+    lines.append(f"(call {result.call_id} — details via get_call_result)")
+    return "\n".join(lines)
+
 
 class UnknownEvidenceError(ValueError):
     def __init__(self, unknown_ids: set[str]):
@@ -222,4 +263,4 @@ class Finalizer:
     async def _maybe_push(self, result: StoredCallResult) -> None:
         from app.poke_push import push_message_to_poke
 
-        await push_message_to_poke(self.settings, result.model_dump(mode="json"))
+        await push_message_to_poke(self.settings, format_owner_summary(result))

--- a/tests/test_finalizer.py
+++ b/tests/test_finalizer.py
@@ -10,8 +10,8 @@ import respx
 from openai import APIStatusError, APITimeoutError
 from pydantic import SecretStr
 
-from app.finalizer import Finalizer
-from app.models import CallState, ExtractedCallResult
+from app.finalizer import Finalizer, format_owner_summary
+from app.models import CallState, ExtractedCallResult, StoredCallResult
 from tests.conftest import seed_call
 
 
@@ -28,6 +28,81 @@ class FakeResponses:
         if self.error:
             raise self.error
         return SimpleNamespace(output_parsed=self.parsed)
+
+
+def _stored_result(**overrides) -> StoredCallResult:
+    fields = dict(
+        call_id="call_test",
+        call_status="completed",
+        finalization_status="succeeded",
+        outcome="completed",
+        result_source="post_call_extractor",
+        summary="Booked table for 2 at 7pm.",
+        transcript_complete=True,
+        raw_transcript_available=True,
+    )
+    fields.update(overrides)
+    return StoredCallResult(**fields)
+
+
+def test_format_owner_summary_completed_with_confirmation_and_action_follow_up():
+    result = _stored_result(
+        confirmation_numbers=[{"value": "48", "evidence_turn_ids": ["turn_1"]}],
+        follow_ups=[
+            {
+                "value": "Call back to confirm allergy info.",
+                "evidence_turn_ids": ["turn_1"],
+                "owner_action_required": True,
+            },
+            {
+                "value": "No action needed here.",
+                "evidence_turn_ids": ["turn_1"],
+                "owner_action_required": False,
+            },
+        ],
+    )
+
+    text = format_owner_summary(result)
+
+    assert text.startswith("📞 Booked table for 2 at 7pm.")
+    assert "Confirmation #48" in text
+    assert "Action needed: Call back to confirm allergy info." in text
+    assert "No action needed here." not in text
+    assert "call call_test — details via get_call_result" in text
+
+
+def test_format_owner_summary_non_completed_outcome_shows_label():
+    result = _stored_result(outcome="declined", summary="They said no thanks.")
+
+    text = format_owner_summary(result)
+
+    assert text.startswith("📞 Declined: They said no thanks.")
+
+
+def test_format_owner_summary_multiple_confirmation_numbers():
+    result = _stored_result(
+        confirmation_numbers=[
+            {"value": "48", "evidence_turn_ids": ["turn_1"]},
+            {"value": "49", "evidence_turn_ids": ["turn_2"]},
+        ]
+    )
+
+    text = format_owner_summary(result)
+
+    assert "Confirmations: #48, #49" in text
+
+
+def test_format_owner_summary_failed_finalization_notes_extraction_problem():
+    result = _stored_result(
+        finalization_status="failed",
+        outcome="unknown",
+        result_source="extraction_failed",
+        summary="The call ended, but structured extraction failed.",
+    )
+
+    text = format_owner_summary(result)
+
+    assert "Automatic extraction had problems; the full transcript is saved." in text
 
 
 def status_error(status_code: int) -> APIStatusError:
@@ -263,6 +338,43 @@ async def test_optional_push_http_failure_never_changes_stored_result(settings, 
     assert route.called
     assert result.finalization_status == "failed"
     assert await service.db.get_result(call_id) == result
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_optional_push_sends_owner_summary_text(settings, service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.COMPLETED)
+    settings.poke_push_enabled = True
+    settings.poke_api_key = SecretStr("poke-test")
+    route = respx.post("https://poke.com/api/v1/inbound/api-message").mock(
+        return_value=httpx.Response(200)
+    )
+    parsed = ExtractedCallResult(
+        outcome="completed",
+        summary="Booked table for 2 at 7pm.",
+        commitments=[],
+        confirmation_numbers=[{"value": "48", "evidence_turn_ids": ["turn_1"]}],
+        follow_ups=[],
+        confidence=0.95,
+    )
+    await service.db.add_transcript_turn(
+        call_id=call_id,
+        turn_id="turn_1",
+        speaker="callee",
+        text="Your table is confirmed, reference 48.",
+        source_event_type="transcription.completed",
+        source_event_id="evt_1",
+    )
+    finalizer = Finalizer(settings, service.db, SimpleNamespace(responses=FakeResponses(parsed=parsed)))
+
+    result = await finalizer.finalize(call_id)
+
+    assert route.called
+    body = json.loads(route.calls[-1].request.content)
+    assert isinstance(body["message"], str)
+    assert "Booked table for 2 at 7pm." in body["message"]
+    assert "Confirmation #48" in body["message"]
+    assert body == {"message": format_owner_summary(result)}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The post-call Poke push previously dumped the entire `StoredCallResult` as JSON; it now sends a short owner-facing text built by the new `format_owner_summary()` in `app/finalizer.py`. The message includes the outcome label (or the summary directly for completed calls), confirmation numbers, confirmed commitments, action-required follow-ups, a note when automatic extraction failed, and a pointer to `get_call_result` for full details. Unit tests cover the completed/labeled/multi-confirmation/failed-extraction formatting branches, and an end-to-end test asserts the exact payload sent to Poke's inbound API. Full test suite passes (292 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)