### PR TITLE
Add pull request CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.9.27"
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Install locked dependencies
+        run: uv sync --all-groups --frozen
+
+      - name: Verify application
+        run: |
+          uv run ruff format --check app tests scripts
+          uv run ruff check app tests scripts
+          uv run pytest -q

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -31,12 +31,12 @@ jobs:
           enable-cache: true
 
       - name: Install locked dependencies
-        run: uv sync --frozen
+        run: uv sync --all-groups --frozen
 
       - name: Verify application
         run: |
-          uv run ruff format --check app tests
-          uv run ruff check app tests
+          uv run ruff format --check app tests scripts
+          uv run ruff check app tests scripts
           uv run pytest -q
 
       - name: Install flyctl


### PR DESCRIPTION
## Summary

- add deterministic CI for pull requests and pushes to `main`
- run Ruff format/lint checks across `app`, `tests`, and `scripts`
- run the full pytest suite before merge
- align production pre-deploy verification with the same locked development dependencies and paths

## Validation

- `uv run ruff format --check app tests scripts`
- `uv run ruff check app tests scripts`
- `uv run pytest -q` — 323 passed

No deployment, secret, lease, or health-check behavior was changed.