### PR TITLE
Add ask_poke MCP and lifecycle tracing logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.9.27"
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Install locked dependencies
+        run: uv sync --all-groups --frozen
+
+      - name: Verify application
+        run: |
+          uv run ruff format --check app tests scripts
+          uv run ruff check app tests scripts
+          uv run pytest -q

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -1514,13 +1514,14 @@ class CallService:
         )
         logger.info(
             "ask_poke asked call_id=%s question_id=%s tool_call_id=%s sequence=%s "
-            "question=%r reason=%r",
+            "question_chars=%s question=%r reason=%r",
             call_id,
             row["question_id"],
             tool_call_id,
             row["sequence_number"],
-            request.question,
-            request.reason,
+            len(request.question),
+            _truncate_for_log(request.question),
+            None if request.reason is None else _truncate_for_log(request.reason),
         )
         if self.settings.poke_push_enabled:
             self._spawn(

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -65,6 +65,13 @@ TERMINATION_MEDIA_BACKGROUND_RETRY_MAX_SECONDS = 15.0
 # cancel_response + function_call_output each bound to REALTIME_SEND_TIMEOUT_SECONDS; keep
 # the stale-call carve-out long enough for both sends after the answer deadline fires.
 WATCHDOG_QUESTION_GRACE_SECONDS = 2 * REALTIME_SEND_TIMEOUT_SECONDS + 5.0
+ASK_POKE_LOG_TEXT_LIMIT = 200
+
+
+def _truncate_for_log(text: str, *, limit: int = ASK_POKE_LOG_TEXT_LIMIT) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "…"
 
 
 @dataclass(slots=True)
@@ -1456,6 +1463,12 @@ class CallService:
         received: LatencyMark,
         event_key: str,
     ) -> None:
+        logger.info(
+            "ask_poke rejected call_id=%s tool_call_id=%s error=%s",
+            call_id,
+            tool_call_id,
+            error,
+        )
         await self._send_nontransfer_tool_result(
             call_id,
             tool_call_id,
@@ -1498,6 +1511,16 @@ class CallService:
             LatencyStage.ASK_POKE_ASKED,
             LatencyMark.now(),
             event_key=str(row["question_id"]),
+        )
+        logger.info(
+            "ask_poke asked call_id=%s question_id=%s tool_call_id=%s sequence=%s "
+            "question=%r reason=%r",
+            call_id,
+            row["question_id"],
+            tool_call_id,
+            row["sequence_number"],
+            request.question,
+            request.reason,
         )
         if self.settings.poke_push_enabled:
             self._spawn(
@@ -1585,6 +1608,12 @@ class CallService:
             and existing_pending.question_id == row["question_id"]
             and existing_pending.tool_call_id == tool_call_id
         ):
+            logger.info(
+                "ask_poke redelivered call_id=%s question_id=%s tool_call_id=%s",
+                call_id,
+                row["question_id"],
+                tool_call_id,
+            )
             return
 
         await self._register_ask_poke_question(
@@ -1706,15 +1735,21 @@ class CallService:
             pending.delivering = True
 
     async def _deliver_question_answer(self, call_id: str, question_row: dict[str, Any]) -> None:
+        question_id = question_row["question_id"]
         if call_id in self._voice_end_pending:
             # The goodbye turn owns the sideband now; do not inject an answer relay.
-            logger.info("suppressing question answer delivery during voice end call_id=%s", call_id)
-            self._clear_pending_question(call_id, question_row["question_id"])
+            logger.info(
+                "ask_poke answer delivery suppressed during voice end call_id=%s question_id=%s",
+                call_id,
+                question_id,
+            )
+            self._clear_pending_question(call_id, question_id)
             self._notify_call_event(call_id)
             return
-        self._mark_question_delivering(call_id, question_row["question_id"])
+        self._mark_question_delivering(call_id, question_id)
         await self._cancel_active_response(call_id)
-        output = {"status": "answered", "answer": question_row["answer"]}
+        answer = question_row["answer"] or ""
+        output = {"status": "answered", "answer": answer}
         delivered = await self._guarded_send_tool_result(
             call_id,
             question_row["tool_call_id"],
@@ -1727,22 +1762,37 @@ class CallService:
         if delivered:
             undelivered = self._undelivered_answers.get(call_id)
             if undelivered is not None:
-                undelivered.discard(question_row["question_id"])
+                undelivered.discard(question_id)
                 if not undelivered:
                     self._undelivered_answers.pop(call_id, None)
             self._queue_latency(
                 call_id,
                 LatencyStage.ASK_POKE_RESOLVED,
                 LatencyMark.now(),
-                event_key=str(question_row["question_id"]),
+                event_key=str(question_id),
             )
             self._activity.note(call_id)
+            logger.info(
+                "ask_poke answer delivered call_id=%s question_id=%s tool_call_id=%s "
+                "answer_chars=%s answer=%r",
+                call_id,
+                question_id,
+                question_row["tool_call_id"],
+                len(answer),
+                _truncate_for_log(answer),
+            )
         else:
             # The question is durably 'answered' but the model never saw the output.
             # Remember it so a Poke retry re-attempts delivery instead of stopping at
             # already_answered with the function call still open.
-            self._undelivered_answers.setdefault(call_id, set()).add(question_row["question_id"])
-        self._clear_pending_question(call_id, question_row["question_id"])
+            self._undelivered_answers.setdefault(call_id, set()).add(question_id)
+            logger.warning(
+                "ask_poke answer delivery failed call_id=%s question_id=%s tool_call_id=%s",
+                call_id,
+                question_id,
+                question_row["tool_call_id"],
+            )
+        self._clear_pending_question(call_id, question_id)
         self._notify_call_event(call_id)
 
     async def _question_deadline(self, call_id: str, question_id: str) -> None:
@@ -1788,6 +1838,12 @@ class CallService:
             event_key=question_id,
         )
         self._activity.note(call_id)
+        logger.info(
+            "ask_poke timed out call_id=%s question_id=%s tool_call_id=%s",
+            call_id,
+            question_id,
+            row["tool_call_id"],
+        )
         self._clear_pending_question(call_id, question_id)
         self._notify_call_event(call_id)
 
@@ -1804,6 +1860,12 @@ class CallService:
         deadline = loop.time() + timeout
         # Clamp to SQLite's INTEGER range; an absurd cursor is a caller bug, not a 500.
         after = min(max(0, int(after_sequence)), 2**63 - 1)
+        logger.info(
+            "wait_for_call_event started call_id=%s after_sequence=%s timeout_seconds=%.2f",
+            call_id,
+            after,
+            timeout,
+        )
 
         while True:
             # Subscribe before reading so a notify that fires between the reads below
@@ -1851,6 +1913,28 @@ class CallService:
                     next_action = (
                         "No new events; re-enter wait_for_call_event with the same after_sequence."
                     )
+                if events or terminal:
+                    logger.info(
+                        "wait_for_call_event returned call_id=%s after_sequence=%s "
+                        "next_after_sequence=%s state=%s terminal=%s event_count=%s "
+                        "event_statuses=%s",
+                        call_id,
+                        after,
+                        next_after,
+                        state.value,
+                        terminal,
+                        len(events),
+                        [event["status"] for event in events],
+                    )
+                else:
+                    logger.debug(
+                        "wait_for_call_event idle timeout call_id=%s after_sequence=%s "
+                        "state=%s waited_seconds=%.2f",
+                        call_id,
+                        after,
+                        state.value,
+                        timeout,
+                    )
                 return {
                     "call_id": call_id,
                     "state": state.value,
@@ -1868,6 +1952,13 @@ class CallService:
         question_id: str,
         answer: str,
     ) -> dict[str, Any]:
+        logger.info(
+            "answer_call_question received call_id=%s question_id=%s answer_chars=%s answer=%r",
+            call_id,
+            question_id,
+            len(answer),
+            _truncate_for_log(answer),
+        )
         row = await self.db.claim_question_answer(call_id, question_id, answer)
         if row is not None:
             self._spawn(
@@ -1875,10 +1966,20 @@ class CallService:
                 name=f"deliver-question:{call_id}:{question_id}",
                 must_finish=True,
             )
+            logger.info(
+                "answer_call_question accepted call_id=%s question_id=%s",
+                call_id,
+                question_id,
+            )
             return {"status": "accepted", "question_id": question_id}
 
         existing = await self.db.get_question(question_id)
         if existing is None or existing.get("call_id") != call_id:
+            logger.info(
+                "answer_call_question unknown question call_id=%s question_id=%s",
+                call_id,
+                question_id,
+            )
             raise LookupError("unknown question")
         status = existing.get("status")
         if status == "answered":
@@ -1891,6 +1992,11 @@ class CallService:
                     self._undelivered_answers.pop(call_id, None)
                 call = await self.db.get_call(call_id)
                 if call is None or self._call_activity_is_closed(call):
+                    logger.info(
+                        "answer_call_question call_ended on retry call_id=%s question_id=%s",
+                        call_id,
+                        question_id,
+                    )
                     return {"status": "call_ended"}
                 if call_id not in self._pending_questions:
                     # Restore the watchdog carve-out for the re-delivery window.
@@ -1905,20 +2011,52 @@ class CallService:
                     name=f"deliver-question:{call_id}:{question_id}",
                     must_finish=True,
                 )
+                logger.info(
+                    "answer_call_question retrying undelivered answer call_id=%s question_id=%s",
+                    call_id,
+                    question_id,
+                )
                 return {"status": "accepted", "question_id": question_id}
+            logger.info(
+                "answer_call_question already_answered call_id=%s question_id=%s",
+                call_id,
+                question_id,
+            )
             return {"status": "already_answered"}
         if status == "expired":
+            logger.info(
+                "answer_call_question expired call_id=%s question_id=%s",
+                call_id,
+                question_id,
+            )
             return {
                 "status": "expired",
                 "detail": "timeout already sent to the agent",
             }
         if status == "cancelled":
+            logger.info(
+                "answer_call_question call_ended call_id=%s question_id=%s status=%s",
+                call_id,
+                question_id,
+                status,
+            )
             return {"status": "call_ended"}
         call = await self.db.get_call(call_id)
         if call is None or self._activity.is_closed(call):
+            logger.info(
+                "answer_call_question call_ended call_id=%s question_id=%s status=%s",
+                call_id,
+                question_id,
+                status,
+            )
             return {"status": "call_ended"}
         # Pending claim lost to a concurrent race without a readable winner — treat as
         # already handled so Poke can advance rather than retry forever.
+        logger.info(
+            "answer_call_question already_answered after race call_id=%s question_id=%s",
+            call_id,
+            question_id,
+        )
         return {"status": "already_answered"}
 
     async def _handle_voice_end_response_done(self, call_id: str, event: dict[str, Any]) -> None:

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 
 from fastmcp import FastMCP
@@ -9,6 +10,8 @@ from pydantic import ValidationError
 
 from app.call_state import CallService
 from app.models import AnswerCallQuestionRequest, ContextPacket, PreparePhoneCallInput
+
+logger = logging.getLogger(__name__)
 
 CONTEXT_GUIDANCE = (
     "Assemble only call-relevant facts from Poke memory and integrations. Resolve relative dates "
@@ -115,18 +118,43 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
         after_sequence: int = 0,
         timeout_seconds: float = 20.0,
     ) -> dict:
+        logger.info(
+            "mcp tool wait_for_call_event call_id=%s after_sequence=%s timeout_seconds=%s",
+            call_id,
+            after_sequence,
+            timeout_seconds,
+        )
         try:
-            return await get_service().wait_for_call_event(
+            result = await get_service().wait_for_call_event(
                 call_id,
                 after_sequence=after_sequence,
                 timeout_seconds=timeout_seconds,
             )
         except LookupError as exc:
+            logger.info(
+                "mcp tool wait_for_call_event call_not_found call_id=%s",
+                call_id,
+            )
             raise ToolError(json.dumps({"code": "call_not_found", "message": str(exc)})) from exc
         except ValueError as exc:
+            logger.info(
+                "mcp tool wait_for_call_event invalid_call_state call_id=%s error=%s",
+                call_id,
+                exc,
+            )
             raise ToolError(
                 json.dumps({"code": "invalid_call_state", "message": str(exc)})
             ) from exc
+        logger.info(
+            "mcp tool wait_for_call_event completed call_id=%s state=%s terminal=%s "
+            "event_count=%s next_after_sequence=%s",
+            call_id,
+            result.get("state"),
+            result.get("terminal"),
+            len(result.get("events") or ()),
+            result.get("next_after_sequence"),
+        )
+        return result
 
     @mcp.tool(
         name="answer_call_question",
@@ -137,6 +165,12 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
         ),
     )
     async def answer_call_question(call_id: str, question_id: str, answer: str) -> dict:
+        logger.info(
+            "mcp tool answer_call_question call_id=%s question_id=%s answer_chars=%s",
+            call_id,
+            question_id,
+            len(answer),
+        )
         try:
             request = AnswerCallQuestionRequest(
                 call_id=call_id,
@@ -144,16 +178,40 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
                 answer=answer,
             )
         except ValidationError as exc:
+            logger.info(
+                "mcp tool answer_call_question invalid_request call_id=%s question_id=%s",
+                call_id,
+                question_id,
+            )
             raise ToolError(str(exc)) from exc
         try:
-            return await get_service().answer_call_question(
+            result = await get_service().answer_call_question(
                 request.call_id,
                 request.question_id,
                 request.answer,
             )
         except LookupError as exc:
+            logger.info(
+                "mcp tool answer_call_question unknown_question call_id=%s question_id=%s",
+                call_id,
+                question_id,
+            )
             raise ToolError("unknown question") from exc
         except ValueError as exc:
+            logger.info(
+                "mcp tool answer_call_question invalid_call_state call_id=%s "
+                "question_id=%s error=%s",
+                call_id,
+                question_id,
+                exc,
+            )
             raise ToolError(
                 json.dumps({"code": "invalid_call_state", "message": str(exc)})
             ) from exc
+        logger.info(
+            "mcp tool answer_call_question completed call_id=%s question_id=%s status=%s",
+            call_id,
+            question_id,
+            result.get("status"),
+        )
+        return result

--- a/tests/test_ask_poke.py
+++ b/tests/test_ask_poke.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
 import time
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
+from fastmcp import FastMCP
 
 from app.call_state import WATCHDOG_QUESTION_GRACE_SECONDS, PendingQuestion
+from app.mcp_tools import register_tools
 from app.models import CallState, StartPhoneCallOutput
 from app.openai_realtime import RealtimeBridge
 from tests.conftest import seed_call, wait_background
@@ -33,7 +37,6 @@ async def _ask(
     payload = {"question": question}
     if reason is not None:
         payload["reason"] = reason
-    import json
 
     await service.handle_realtime_event(
         call_id,
@@ -642,3 +645,111 @@ async def test_failed_answer_delivery_is_retryable(ask_service, packet):
     await wait_background()
     assert third["status"] == "already_answered"
     assert len([r for r in ask_service._test_realtime.tool_results if r[1] == "tc_retry"]) == 1
+
+
+def _messages(caplog: pytest.LogCaptureFixture, *, logger_name: str) -> list[str]:
+    return [record.getMessage() for record in caplog.records if record.name == logger_name]
+
+
+@pytest.mark.asyncio
+async def test_ask_poke_lifecycle_emits_trace_logs(ask_service, packet, caplog):
+    call_id = await seed_call(ask_service.db, packet, state=CallState.ACTIVE)
+
+    with caplog.at_level(logging.INFO, logger="app.call_state"):
+        await _ask(ask_service, call_id, tool_call_id="tc_log")
+        await wait_background()
+        rows = await ask_service.db.get_questions_after(call_id, 0)
+        question_id = rows[0]["question_id"]
+        waited = await ask_service.wait_for_call_event(
+            call_id, after_sequence=0, timeout_seconds=0.05
+        )
+        answered = await ask_service.answer_call_question(
+            call_id, question_id, "CVS on Market Street"
+        )
+        await wait_background()
+
+    assert waited["events"]
+    assert answered["status"] == "accepted"
+    messages = _messages(caplog, logger_name="app.call_state")
+    assert any("ask_poke asked" in message and question_id in message for message in messages)
+    assert any("wait_for_call_event returned" in message for message in messages)
+    assert any("answer_call_question received" in message for message in messages)
+    assert any("answer_call_question accepted" in message for message in messages)
+    assert any("ask_poke answer delivered" in message for message in messages)
+
+
+@pytest.mark.asyncio
+async def test_ask_poke_reject_and_timeout_emit_trace_logs(ask_service, packet, caplog):
+    ask_service.settings.ask_poke_answer_timeout_seconds = 0.05
+    call_id = await seed_call(ask_service.db, packet, state=CallState.ACTIVE)
+
+    with caplog.at_level(logging.INFO, logger="app.call_state"):
+        await _ask(ask_service, call_id, tool_call_id="tc_timeout_log")
+        await wait_background()
+        await asyncio.sleep(0.12)
+        await wait_background()
+
+        ask_service.settings.ask_poke_answer_timeout_seconds = 30.0
+        await _ask(
+            ask_service,
+            call_id,
+            tool_call_id="tc_pending_log",
+            question="What is the account number on file?",
+        )
+        await wait_background()
+        await _ask(
+            ask_service,
+            call_id,
+            tool_call_id="tc_pending_log_2",
+            question="What is the billing zip code?",
+        )
+        await wait_background()
+
+    messages = _messages(caplog, logger_name="app.call_state")
+    assert any("ask_poke timed out" in message for message in messages)
+    assert any(
+        "ask_poke rejected" in message and "question_pending" in message for message in messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_ask_poke_tools_emit_invocation_logs(ask_service, packet, caplog):
+    call_id = await seed_call(ask_service.db, packet, state=CallState.ACTIVE)
+    await _ask(ask_service, call_id, tool_call_id="tc_mcp_log")
+    await wait_background()
+    rows = await ask_service.db.get_questions_after(call_id, 0)
+    question_id = rows[0]["question_id"]
+
+    mcp = FastMCP("test-ask-poke-logging")
+    register_tools(mcp, lambda: ask_service)
+
+    with caplog.at_level(logging.INFO, logger="app.mcp_tools"):
+        wait_result = await mcp.call_tool(
+            "wait_for_call_event",
+            {"call_id": call_id, "after_sequence": 0, "timeout_seconds": 0.05},
+        )
+        answer_result = await mcp.call_tool(
+            "answer_call_question",
+            {
+                "call_id": call_id,
+                "question_id": question_id,
+                "answer": "CVS on Market Street",
+            },
+        )
+        await wait_background()
+
+    assert wait_result.is_error is False
+    assert answer_result.is_error is False
+    wait_payload = wait_result.structured_content or {}
+    answer_payload = answer_result.structured_content or {}
+    assert wait_payload["events"]
+    assert answer_payload["status"] == "accepted"
+
+    messages = _messages(caplog, logger_name="app.mcp_tools")
+    assert any("mcp tool wait_for_call_event call_id=" in message for message in messages)
+    assert any("mcp tool wait_for_call_event completed" in message for message in messages)
+    assert any("mcp tool answer_call_question call_id=" in message for message in messages)
+    assert any(
+        "mcp tool answer_call_question completed" in message and "status=accepted" in message
+        for message in messages
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds structured logging so mid-call `ask_poke` round-trips can be traced when the voice model asks and when Poke invokes the MCP tools.

Also lands the missing `.github/workflows/ci.yml` so the Protect main required **Verify** status check actually runs on pull requests (it was defined in the ruleset but the workflow never merged to `main`).

## What changed
- **Realtime `ask_poke`**: INFO logs on ask, reject (with error code), redelivery, answer delivery/failure, and timeout.
- **MCP tools**: entry + completion logs for `wait_for_call_event` and `answer_call_question` (status, event counts, ids).
- **Service path**: matching lifecycle logs for wait/answer outcomes; idle long-poll timeouts stay at DEBUG to avoid noise.
- Question/answer text truncated in logs (`~200` chars); full length retained via `*_chars` fields.
- **CI**: add `CI` / `Verify` workflow (ruff + pytest) on `pull_request` and `push` to `main`.

## Risks
- Log volume increases during active ask_poke usage (especially long-poll entry/completion). Idle empty waits remain DEBUG.
- Truncated answer/question text still appears in logs; same sensitivity class as existing Exa/hold transcript snippets.

## Validation
- `ruff format --check` + `ruff check` on `app tests scripts`
- `pytest -q` — 326 passed
- GitHub Actions `Verify` check on this PR
- Addressed cubic review: truncate question text in ask logs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6efe-96e9-7d78-b604-861fbfc13ff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6efe-96e9-7d78-b604-861fbfc13ff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

