### PR TITLE
Add agent readiness tooling for typing, secrets, and rollback

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "type/tech-debt"
+      - "area/ci"
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "type/tech-debt"
+      - "area/ci"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           uv run ruff format --check app tests
           uv run ruff check app tests
+          uv run mypy app
           uv run pytest -q
 
       - name: Install flyctl

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   gitleaks:
@@ -21,6 +22,6 @@ jobs:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,26 @@
+name: Secret scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,23 @@
 __pycache__/
 *.py[cod]
 .pytest_cache/
+.mypy_cache/
+.ruff_cache/
 .coverage
 htmlcov/
 *.db
 *.db-shm
 *.db-wal
 .playwright-mcp/
+dist/
+*.egg-info/
 
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,11 @@ repos:
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.24.2
     hooks:
+      # Override the default `--staged` entry so `pre-commit run --all-files`
+      # (and normal commits) actually audit the full working tree.
       - id: gitleaks
+        entry: gitleaks detect --source . --verbose --redact
+        pass_filenames: false
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+# Local quality gates for agents and humans. Install once:
+#   uv run pre-commit install
+# Run on all files:
+#   uv run pre-commit run --all-files
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.21
+    hooks:
+      - id: ruff
+        args: [--fix]
+        types_or: [python, pyi]
+      - id: ruff-format
+        types_or: [python, pyi]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        exclude: '\.md$'
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.2
+    hooks:
+      - id: gitleaks
+
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: uv run mypy
+        language: system
+        types: [python]
+        pass_filenames: false
+        args: [app]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,20 +33,20 @@ Recent history uses short, imperative, sentence-case subjects such as `Add call-
 
 Copy `.env.example` to `.env.local`; never commit secrets, transcripts, or database files. Preserve webhook signature checks, replay protection, destination policy, and explicit call confirmation. Do not deploy or restart while a call is active, and keep production to one Fly Machine because SQLite state is volume-local.
 
-### Rollback (one-command recovery)
+### Rollback (prior-image recovery)
 
 If a deploy breaks production, do not redeploy a fix while debugging. Roll back first:
 
-1. Confirm no active calls (or wait for them to finish):
-   `curl -sS -H "Authorization: Bearer $DEPLOY_GUARD_TOKEN" https://poke-call.fly.dev/internal/deployment-lock`
-2. List recent releases:
-   `flyctl releases -a poke-call`
-3. Roll back to the previous healthy image (one click / one command):
-   `flyctl releases rollback -a poke-call`
+1. Confirm no active calls (or wait for them to finish); this POST acquires the deployment lease and fails with HTTP 409 while calls are active:
+   `curl --fail-with-body -sS --request POST -H "Authorization: Bearer $DEPLOY_GUARD_TOKEN" https://poke-call.fly.dev/internal/deployment-lock`
+2. List recent releases with image references:
+   `flyctl releases --image -a poke-call`
+3. Redeploy the previous healthy image (no rebuild):
+   `flyctl deploy --image <previous-image-reference> -a poke-call --ha=false --remote-only`
 4. Verify:
    `curl -fsS https://poke-call.fly.dev/healthz`
 
-`flyctl releases rollback` restores the prior release image without a full rebuild. Only re-deploy after calls are idle and the fix is verified locally (`ruff` + `mypy` + `pytest`).
+Redeploying a prior image restores the last healthy release without a full rebuild. Only ship a new build after calls are idle and the fix is verified locally (`ruff` + `mypy` + `pytest`).
 
 ## Cursor Cloud specific instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ If a deploy breaks production, do not redeploy a fix while debugging. Roll back 
 4. Verify:
    `curl -fsS https://poke-call.fly.dev/healthz`
 
-Redeploying a prior image restores the last healthy release without a full rebuild. Only ship a new build after calls are idle and the fix is verified locally (`ruff` + `mypy` + `pytest`).
+Redeploying a prior image restores only the application image without a full rebuild; it does not roll back the current Fly configuration, environment variables, or secrets. Only ship a new build after calls are idle and the fix is verified locally (`ruff` + `mypy` + `pytest`).
 
 ## Cursor Cloud specific instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,9 @@
 - `uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload`: run the local service with reload.
 - `uv run ruff format --check app tests scripts`: verify formatting.
 - `uv run ruff check app tests scripts`: run configured lint and import checks.
+- `uv run mypy app`: run strict mypy type checking on the application package.
+- `uv run pre-commit install`: install local git hooks (ruff, large-file check, gitleaks, mypy).
+- `uv run pre-commit run --all-files`: run the same hooks on the full tree.
 - `uv run pytest -q`: run the automated test suite.
 - `uv run pytest -q tests/test_security.py`: run one focused test module.
 - `uv run python scripts/run_sip_canary.py --mode full`: validate a deployed SIP flow; this places a real call and requires configured credentials.
@@ -29,6 +32,21 @@ Recent history uses short, imperative, sentence-case subjects such as `Add call-
 ## Security & Operations
 
 Copy `.env.example` to `.env.local`; never commit secrets, transcripts, or database files. Preserve webhook signature checks, replay protection, destination policy, and explicit call confirmation. Do not deploy or restart while a call is active, and keep production to one Fly Machine because SQLite state is volume-local.
+
+### Rollback (one-command recovery)
+
+If a deploy breaks production, do not redeploy a fix while debugging. Roll back first:
+
+1. Confirm no active calls (or wait for them to finish):
+   `curl -sS -H "Authorization: Bearer $DEPLOY_GUARD_TOKEN" https://poke-call.fly.dev/internal/deployment-lock`
+2. List recent releases:
+   `flyctl releases -a poke-call`
+3. Roll back to the previous healthy image (one click / one command):
+   `flyctl releases rollback -a poke-call`
+4. Verify:
+   `curl -fsS https://poke-call.fly.dev/healthz`
+
+`flyctl releases rollback` restores the prior release image without a full rebuild. Only re-deploy after calls are idle and the fix is verified locally (`ruff` + `mypy` + `pytest`).
 
 ## Cursor Cloud specific instructions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,3 @@ ENV PATH="/app/.venv/bin:$PATH"
 EXPOSE 8000
 
 CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --proxy-headers --forwarded-allow-ips='*'"]
-

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ flyctl deploy --image <previous-image-reference> -a poke-call --ha=false --remot
 curl -fsS https://poke-call.fly.dev/healthz
 ```
 
-Redeploying a prior image restores the last healthy release without a full rebuild. Ship a new build only after calls are idle and local checks pass (`ruff`, `mypy`, `pytest`).
+Redeploying a prior image restores only the application image without a full rebuild; it does not roll back the current Fly configuration, environment variables, or secrets. Ship a new build only after calls are idle and local checks pass (`ruff`, `mypy`, `pytest`).
 
 **CI/CD:** `.github/workflows/fly-deploy.yml` runs the locked test suite and deploys every push to `main`. It serializes production deployments, waits up to 10 minutes for active calls to finish via the authenticated `/internal/deployment-lock` lease, keeps `--ha=false`, and checks `/healthz` before reporting success. It needs the repository secrets `FLY_API_TOKEN` (app-scoped deploy token) and `DEPLOY_GUARD_TOKEN` — store the latter independently from the MCP and debug tokens; it can only touch the deployment lease. The lease is acquired atomically only when no call is active, blocks new calls while a deployment starts, expires after 15 minutes if canceled, and is cleared by a successful restart.
 

--- a/README.md
+++ b/README.md
@@ -190,19 +190,20 @@ flyctl status -a poke-call
 If a bad deploy reaches production, roll back first (do not redeploy while diagnosing):
 
 ```bash
-# Confirm no active calls, or wait for them
-curl -sS -H "Authorization: Bearer $DEPLOY_GUARD_TOKEN" \
+# Confirm no active calls (POST acquires the lease; HTTP 409 means wait)
+curl --fail-with-body -sS --request POST \
+  -H "Authorization: Bearer $DEPLOY_GUARD_TOKEN" \
   https://poke-call.fly.dev/internal/deployment-lock
 
-# List recent releases and restore the previous healthy image
-flyctl releases -a poke-call
-flyctl releases rollback -a poke-call
+# List image references and redeploy the previous healthy image
+flyctl releases --image -a poke-call
+flyctl deploy --image <previous-image-reference> -a poke-call --ha=false --remote-only
 
 # Verify
 curl -fsS https://poke-call.fly.dev/healthz
 ```
 
-`flyctl releases rollback` restores the prior release image without a full rebuild. Re-deploy only after calls are idle and local checks pass (`ruff`, `mypy`, `pytest`).
+Redeploying a prior image restores the last healthy release without a full rebuild. Ship a new build only after calls are idle and local checks pass (`ruff`, `mypy`, `pytest`).
 
 **CI/CD:** `.github/workflows/fly-deploy.yml` runs the locked test suite and deploys every push to `main`. It serializes production deployments, waits up to 10 minutes for active calls to finish via the authenticated `/internal/deployment-lock` lease, keeps `--ha=false`, and checks `/healthz` before reporting success. It needs the repository secrets `FLY_API_TOKEN` (app-scoped deploy token) and `DEPLOY_GUARD_TOKEN` — store the latter independently from the MCP and debug tokens; it can only touch the deployment lease. The lease is acquired atomically only when no call is active, blocks new calls while a deployment starts, expires after 15 minutes if canceled, and is cleared by a successful restart.
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,26 @@ flyctl status -a poke-call
 > [!IMPORTANT]
 > Keep exactly **one** Machine. SQLite state is volume-local; a second Machine would not share call state. `render.yaml` remains available as a paid Render alternative.
 
+
+### Rollback
+
+If a bad deploy reaches production, roll back first (do not redeploy while diagnosing):
+
+```bash
+# Confirm no active calls, or wait for them
+curl -sS -H "Authorization: Bearer $DEPLOY_GUARD_TOKEN" \
+  https://poke-call.fly.dev/internal/deployment-lock
+
+# List recent releases and restore the previous healthy image
+flyctl releases -a poke-call
+flyctl releases rollback -a poke-call
+
+# Verify
+curl -fsS https://poke-call.fly.dev/healthz
+```
+
+`flyctl releases rollback` restores the prior release image without a full rebuild. Re-deploy only after calls are idle and local checks pass (`ruff`, `mypy`, `pytest`).
+
 **CI/CD:** `.github/workflows/fly-deploy.yml` runs the locked test suite and deploys every push to `main`. It serializes production deployments, waits up to 10 minutes for active calls to finish via the authenticated `/internal/deployment-lock` lease, keeps `--ha=false`, and checks `/healthz` before reporting success. It needs the repository secrets `FLY_API_TOKEN` (app-scoped deploy token) and `DEPLOY_GUARD_TOKEN` — store the latter independently from the MCP and debug tokens; it can only touch the deployment lease. The lease is acquired atomically only when no call is active, blocks new calls while a deployment starts, expires after 15 minutes if canceled, and is cleared by a successful restart.
 
 ## 🔬 The fine print

--- a/app/call_activity.py
+++ b/app/call_activity.py
@@ -30,7 +30,7 @@ class CallActivityTracker:
         db: Database,
         *,
         is_audio_drain_active: Callable[[str], bool],
-        clear_audio_drain: Callable[[str], None],
+        clear_audio_drain: Callable[[str], object],
     ) -> None:
         self._db = db
         self._is_audio_drain_active = is_audio_drain_active

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -188,7 +188,13 @@ class CallService:
         self._undelivered_answers: dict[str, set[str]] = {}
         self._event_notifiers: dict[str, asyncio.Event] = {}
 
-    def _spawn(self, coroutine, *, name: str, must_finish: bool = False) -> asyncio.Task[Any]:
+    def _spawn(
+        self,
+        coroutine: Any,
+        *,
+        name: str,
+        must_finish: bool = False,
+    ) -> asyncio.Task[Any]:
         if self._stopping and not must_finish:
             # Reject new ordinary work once shutdown starts, but still register a
             # no-op task so callers holding the returned Task cannot outlive the
@@ -554,19 +560,23 @@ class CallService:
                     call_id = candidate["call_id"]
                     break
         call = await self.db.get_call(call_id) if call_id else None
-        if call is None or (plan_id and call["plan_id"] != plan_id):
+        if call is None or call_id is None or (plan_id and call["plan_id"] != plan_id):
             await self.realtime.reject(openai_call_id)
             raise LookupError("incoming SIP call could not be mapped to an approved plan")
         if call.get("openai_call_id") and call["openai_call_id"] != openai_call_id:
             await self.realtime.reject(openai_call_id)
             raise RuntimeError("call already mapped to a different OpenAI call")
-        await self.db.update_call(call_id, openai_call_id=openai_call_id)
+        mapped_call_id = call_id
+        await self.db.update_call(mapped_call_id, openai_call_id=openai_call_id)
         plan = await self.db.get_plan(call["plan_id"])
+        if plan is None:
+            await self.realtime.reject(openai_call_id)
+            raise LookupError("incoming SIP call plan is missing")
         packet = ContextPacket.model_validate(plan["context"])
         accept_status = await self._run_latency_marked_step(
-            call_id,
+            mapped_call_id,
             lambda: self.realtime.accept_and_connect(
-                call_id=call_id,
+                call_id=mapped_call_id,
                 openai_call_id=openai_call_id,
                 packet=packet,
             ),
@@ -576,12 +586,12 @@ class CallService:
             failure_reason="openai_accept_failed",
         )
         try:
-            await self.db.update_call(call_id, openai_accept_status=accept_status)
+            await self.db.update_call(mapped_call_id, openai_accept_status=accept_status)
         except Exception:
             logger.exception("failed to persist OpenAI accept status")
-            await self.terminate_call(call_id, "openai_accept_failed")
+            await self.terminate_call(mapped_call_id, "openai_accept_failed")
             raise
-        return call_id
+        return mapped_call_id
 
     async def handle_sideband_open(self, call_id: str) -> None:
         sideband_open = LatencyMark.now()
@@ -613,11 +623,14 @@ class CallService:
             return
         call = await self.db.get_call(call_id)
         if (
-            call
+            call is not None
             and CallState(call["state"]) not in TERMINAL_STATES
             and await self.db.set_flag_once(call_id, "callee_dialed")
         ):
             plan = await self.db.get_plan(call["plan_id"])
+            if plan is None:
+                await self.terminate_call(call_id, "plan_missing_after_sideband_open")
+                return
             packet = ContextPacket.model_validate(plan["context"])
             participant = await self._run_latency_marked_step(
                 call_id,
@@ -1343,7 +1356,7 @@ class CallService:
         try:
             advisory = AdvisoryOutcome.model_validate(arguments)
             advisory_outcome = advisory.model_dump(mode="json", by_alias=True)
-            output = {"accepted": True}
+            output: dict[str, Any] = {"accepted": True}
         except Exception as exc:
             output = {"accepted": False, "error": str(exc)}
         await self._send_nontransfer_tool_result(
@@ -2321,7 +2334,8 @@ class CallService:
         )
         # Once a termination claim may commit, caller cancellation must not strand
         # billing/media teardown behind an unreclaimable termination_claimed flag.
-        return await self._await_network_task(continuation)
+        result = await self._await_network_task(continuation)
+        return bool(result)
 
     async def _claim_and_finish_termination(
         self,
@@ -2565,6 +2579,8 @@ class CallService:
                     reason,
                 )
                 return False
+            if current is None:
+                return False
             call = current
             logger.warning(
                 "reconciled ambiguous terminal transition call_id=%s state=%s",
@@ -2757,12 +2773,15 @@ class CallService:
                 failure = "failed:owner_exit_unarmed"
                 failure_reason = "transfer_failed:owner_exit_unarmed"
                 try:
-                    failed_closed = await self.db.fail_promoted_transfer(
-                        call_id,
-                        transfer_outcome,
-                        failure,
-                        failure_reason,
-                    )
+                    if not isinstance(transfer_outcome, str):
+                        failed_closed = False
+                    else:
+                        failed_closed = await self.db.fail_promoted_transfer(
+                            call_id,
+                            transfer_outcome,
+                            failure,
+                            failure_reason,
+                        )
                 except Exception:
                     failed_closed = False
                     logger.warning(

--- a/app/db/calls.py
+++ b/app/db/calls.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.db.protocols import DatabaseAccess
+
 from collections.abc import Iterable
 from typing import Any
 
@@ -37,32 +42,36 @@ _UPDATE_CALL_ALLOWED_COLUMNS = frozenset(
 
 
 class CallsMixin:
-    async def get_call(self, call_id: str) -> dict[str, Any] | None:
+    async def get_call(self: DatabaseAccess, call_id: str) -> dict[str, Any] | None:
         return await self.fetch_one("SELECT * FROM calls WHERE call_id=?", (call_id,))
 
-    async def get_call_by_openai_id(self, openai_call_id: str) -> dict[str, Any] | None:
+    async def get_call_by_openai_id(
+        self: DatabaseAccess, openai_call_id: str
+    ) -> dict[str, Any] | None:
         return await self.fetch_one("SELECT * FROM calls WHERE openai_call_id=?", (openai_call_id,))
 
-    async def get_call_by_twilio_sid(self, sid: str) -> dict[str, Any] | None:
+    async def get_call_by_twilio_sid(self: DatabaseAccess, sid: str) -> dict[str, Any] | None:
         return await self.fetch_one(
             """SELECT * FROM calls
                WHERE twilio_ai_call_sid=? OR twilio_callee_call_sid=?""",
             (sid, sid),
         )
 
-    async def list_calls(self, limit: int = 100) -> list[dict[str, Any]]:
+    async def list_calls(self: DatabaseAccess, limit: int = 100) -> list[dict[str, Any]]:
         return await self.fetch_all(
             "SELECT * FROM calls ORDER BY created_at DESC LIMIT ?", (limit,)
         )
 
-    async def list_nonterminal_calls(self) -> list[dict[str, Any]]:
+    async def list_nonterminal_calls(self: DatabaseAccess) -> list[dict[str, Any]]:
         placeholders, params = self._in_clause(state.value for state in TERMINAL_STATES)
         return await self.fetch_all(
             f"SELECT * FROM calls WHERE state NOT IN ({placeholders})",  # noqa: S608
             params,
         )
 
-    async def list_terminal_calls_needing_finalization(self) -> list[dict[str, Any]]:
+    async def list_terminal_calls_needing_finalization(
+        self: DatabaseAccess,
+    ) -> list[dict[str, Any]]:
         placeholders, params = self._in_clause(state.value for state in TERMINAL_STATES)
         return await self.fetch_all(
             f"""SELECT calls.* FROM calls
@@ -76,21 +85,23 @@ class CallsMixin:
             params,
         )
 
-    async def set_conference_cleanup_pending(self, call_id: str, pending: bool) -> None:
+    async def set_conference_cleanup_pending(
+        self: DatabaseAccess, call_id: str, pending: bool
+    ) -> None:
         await self.execute(
             "UPDATE calls SET conference_cleanup_pending=? WHERE call_id=?",
             (1 if pending else 0, call_id),
         )
 
-    async def list_conference_cleanup_pending(self) -> list[dict[str, Any]]:
+    async def list_conference_cleanup_pending(self: DatabaseAccess) -> list[dict[str, Any]]:
         return await self.fetch_all("SELECT * FROM calls WHERE conference_cleanup_pending=1")
 
-    async def touch_call(self, call_id: str) -> None:
+    async def touch_call(self: DatabaseAccess, call_id: str) -> None:
         await self.execute(
             "UPDATE calls SET last_event_at=? WHERE call_id=?", (_iso_now(), call_id)
         )
 
-    async def touch_calls(self, activity: Iterable[tuple[str, str]]) -> None:
+    async def touch_calls(self: DatabaseAccess, activity: Iterable[tuple[str, str]]) -> None:
         """Persist latest observed activity for several calls in one durable transaction."""
         placeholders, terminal_states = self._in_clause(
             sorted(state.value for state in TERMINAL_STATES)
@@ -109,7 +120,7 @@ class CallsMixin:
                 rows,
             )
 
-    async def update_call(self, call_id: str, **values: Any) -> bool:
+    async def update_call(self: DatabaseAccess, call_id: str, **values: Any) -> bool:
         if not values:
             return True
         unknown = values.keys() - _UPDATE_CALL_ALLOWED_COLUMNS
@@ -125,7 +136,7 @@ class CallsMixin:
         return await self._execute_cas(f"UPDATE calls SET {columns} WHERE call_id=?", params)
 
     async def add_realtime_usage(
-        self,
+        self: DatabaseAccess,
         call_id: str,
         *,
         input_text_tokens: int,
@@ -156,7 +167,7 @@ class CallsMixin:
         )
 
     async def add_extractor_usage(
-        self, call_id: str, *, input_tokens: int, output_tokens: int
+        self: DatabaseAccess, call_id: str, *, input_tokens: int, output_tokens: int
     ) -> None:
         await self.execute(
             """UPDATE calls
@@ -166,7 +177,7 @@ class CallsMixin:
             (input_tokens, output_tokens, call_id),
         )
 
-    async def record_exa_search(self, call_id: str, *, cost_dollars: float) -> None:
+    async def record_exa_search(self: DatabaseAccess, call_id: str, *, cost_dollars: float) -> None:
         await self.execute(
             """UPDATE calls
                SET exa_search_count = exa_search_count + 1,
@@ -175,14 +186,16 @@ class CallsMixin:
             (cost_dollars, call_id),
         )
 
-    async def cas_state(self, call_id: str, expected: CallState, replacement: CallState) -> bool:
+    async def cas_state(
+        self: DatabaseAccess, call_id: str, expected: CallState, replacement: CallState
+    ) -> bool:
         return await self._execute_cas(
             """UPDATE calls SET state=?, last_event_at=?
                WHERE call_id=? AND state=?""",
             (replacement.value, _iso_now(), call_id, expected.value),
         )
 
-    async def set_flag_once(self, call_id: str, flag: str) -> bool:
+    async def set_flag_once(self: DatabaseAccess, call_id: str, flag: str) -> bool:
         allowed = {
             "sideband_open",
             "callee_joined",
@@ -198,7 +211,9 @@ class CallsMixin:
             (_iso_now(), call_id),
         )
 
-    async def set_amd_once(self, call_id: str, answered_by: str, handling: str) -> bool:
+    async def set_amd_once(
+        self: DatabaseAccess, call_id: str, answered_by: str, handling: str
+    ) -> bool:
         return await self._execute_cas(
             """UPDATE calls
                SET amd_result=?, answered_by=?, answer_handling=?, last_event_at=?
@@ -206,7 +221,7 @@ class CallsMixin:
             (answered_by, answered_by, handling, _iso_now(), call_id),
         )
 
-    async def claim_opening_if_not_voicemail(self, call_id: str) -> bool:
+    async def claim_opening_if_not_voicemail(self: DatabaseAccess, call_id: str) -> bool:
         """Atomically claim the opening unless AMD has already classified voicemail."""
         return await self._execute_cas(
             """UPDATE calls SET opening_sent=1, last_event_at=?

--- a/app/db/deployment.py
+++ b/app/db/deployment.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.db.protocols import DatabaseAccess
+
 from datetime import UTC, datetime, timedelta
 
 from app.db.engine import _iso_now
@@ -21,7 +26,7 @@ def _lock_is_active(locked_at: str | None) -> bool:
 
 
 class DeploymentMixin:
-    async def acquire_deployment_lock(self) -> int:
+    async def acquire_deployment_lock(self: DatabaseAccess) -> int:
         """Atomically block new calls if no call is currently nonterminal.
 
         Returns the number of active calls that prevented acquisition. Zero means
@@ -35,7 +40,8 @@ class DeploymentMixin:
                 f"SELECT COUNT(*) FROM calls WHERE state NOT IN ({placeholders})",  # noqa: S608
                 params,
             )
-            active_calls = int((await cursor.fetchone())[0])
+            count_row = await cursor.fetchone()
+            active_calls = int(count_row[0]) if count_row is not None else 0
             if active_calls:
                 await conn.rollback()
                 return active_calls
@@ -48,12 +54,12 @@ class DeploymentMixin:
             await conn.commit()
             return 0
 
-    async def release_deployment_lock(self) -> None:
+    async def release_deployment_lock(self: DatabaseAccess) -> None:
         await self.execute(
             "UPDATE deployment_control SET locked=0, locked_at=NULL WHERE singleton=1"
         )
 
-    async def deployment_lock_is_active(self) -> bool:
+    async def deployment_lock_is_active(self: DatabaseAccess) -> bool:
         row = await self.fetch_one(
             "SELECT locked, locked_at FROM deployment_control WHERE singleton=1"
         )

--- a/app/db/engine.py
+++ b/app/db/engine.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Iterable
+from collections.abc import AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
@@ -296,7 +296,7 @@ class DatabaseEngine:
         await conn.commit()
 
     @asynccontextmanager
-    async def _write_connection(self):
+    async def _write_connection(self) -> AsyncIterator[aiosqlite.Connection]:
         async with self._write_lock:
             conn = self._writer
             if conn is None:
@@ -332,7 +332,7 @@ class DatabaseEngine:
             raise asyncio.CancelledError
 
     @asynccontextmanager
-    async def _read_connection(self):
+    async def _read_connection(self) -> AsyncIterator[aiosqlite.Connection]:
         async with self._read_lock:
             conn = self._reader
             if conn is None:
@@ -366,7 +366,7 @@ class DatabaseEngine:
     async def execute(self, sql: str, params: Iterable[Any] = ()) -> int:
         async with self._write_connection() as conn:
             async with conn.execute(sql, tuple(params)) as cursor:
-                rowcount = cursor.rowcount
+                rowcount = int(cursor.rowcount)
             await conn.commit()
             return rowcount
 
@@ -395,7 +395,7 @@ class DatabaseEngine:
         return ",".join("?" for _ in values), values
 
     @asynccontextmanager
-    async def _immediate_transaction(self):
+    async def _immediate_transaction(self) -> AsyncIterator[aiosqlite.Connection]:
         """BEGIN IMMEDIATE, run the body, commit on normal exit.
 
         Only fits blocks that always commit once entered (no conditional early-return

--- a/app/db/plans.py
+++ b/app/db/plans.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.db.protocols import DatabaseAccess
+
 import json
 from datetime import datetime
 from typing import Any
@@ -11,7 +16,7 @@ from app.models import CallState
 
 class PlansMixin:
     async def create_plan(
-        self,
+        self: DatabaseAccess,
         plan_id: str,
         context: dict[str, Any],
         authority_basis: str | None,
@@ -25,11 +30,11 @@ class PlansMixin:
             (plan_id, json.dumps(context), authority_basis, now, expires_at.isoformat()),
         )
 
-    async def get_plan(self, plan_id: str) -> dict[str, Any] | None:
+    async def get_plan(self: DatabaseAccess, plan_id: str) -> dict[str, Any] | None:
         return await self.fetch_one("SELECT * FROM plans WHERE plan_id = ?", (plan_id,))
 
     async def claim_plan_and_create_call(
-        self,
+        self: DatabaseAccess,
         *,
         plan_id: str,
         call_id: str,

--- a/app/db/protocols.py
+++ b/app/db/protocols.py
@@ -1,0 +1,45 @@
+"""Typing protocol for the composed Database facade used by mixins.
+
+At runtime each concern mixin is composed onto ``DatabaseEngine`` via
+``app.db.Database``. Declaring the shared engine surface here lets mypy
+understand ``self.execute`` / ``self.fetch_one`` calls inside mixins without
+forcing mixins to inherit ``DatabaseEngine`` (which would break the MRO).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from contextlib import AbstractAsyncContextManager
+from typing import Any, Protocol
+
+import aiosqlite
+
+
+class DatabaseAccess(Protocol):
+    """Minimal engine surface mixins rely on."""
+
+    _latency_clock_id: str
+
+    async def execute(self, sql: str, params: Iterable[Any] = ()) -> int: ...
+
+    async def fetch_one(self, sql: str, params: Iterable[Any] = ()) -> dict[str, Any] | None: ...
+
+    async def fetch_all(self, sql: str, params: Iterable[Any] = ()) -> list[dict[str, Any]]: ...
+
+    async def _execute_cas(self, sql: str, params: Iterable[Any] = ()) -> bool: ...
+
+    def _in_clause(self, values: Iterable[Any]) -> tuple[str, tuple[Any, ...]]: ...
+
+    def _write_connection(self) -> AbstractAsyncContextManager[aiosqlite.Connection]: ...
+
+    def _read_connection(self) -> AbstractAsyncContextManager[aiosqlite.Connection]: ...
+
+    def _immediate_transaction(self) -> AbstractAsyncContextManager[aiosqlite.Connection]: ...
+
+    def _serialize_advisory_outcome(self, value: dict[str, Any] | None) -> Any: ...
+
+    async def record_latency_events(
+        self,
+        call_id: str,
+        events: Iterable[tuple[Any, Any, str]],
+    ) -> None: ...

--- a/app/db/questions.py
+++ b/app/db/questions.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.db.protocols import DatabaseAccess
+
 from typing import Any
 from uuid import uuid4
 
@@ -14,7 +19,7 @@ from app.models import CallState
 
 class QuestionsMixin:
     async def create_question(
-        self,
+        self: DatabaseAccess,
         call_id: str,
         *,
         tool_call_id: str,
@@ -65,14 +70,19 @@ class QuestionsMixin:
                 "SELECT COUNT(*) FROM call_questions WHERE call_id=?",
                 (call_id,),
             )
-            if (await cursor.fetchone())[0] >= max_questions:
+            count_row = await cursor.fetchone()
+            if count_row is not None and count_row[0] >= max_questions:
                 await conn.rollback()
                 return None, "question_limit_reached"
             cursor = await conn.execute(
                 "SELECT COALESCE(MAX(sequence_number), 0) + 1 FROM call_questions WHERE call_id=?",
                 (call_id,),
             )
-            sequence = (await cursor.fetchone())[0]
+            sequence_row = await cursor.fetchone()
+            if sequence_row is None:
+                await conn.rollback()
+                return None, "sequence_unavailable"
+            sequence = sequence_row[0]
             try:
                 cursor = await conn.execute(
                     """INSERT INTO call_questions
@@ -103,7 +113,7 @@ class QuestionsMixin:
         return dict(row) if row else None, None
 
     async def claim_question_answer(
-        self,
+        self: DatabaseAccess,
         call_id: str,
         question_id: str,
         answer: str,
@@ -133,7 +143,9 @@ class QuestionsMixin:
             await conn.commit()
         return dict(row)
 
-    async def claim_question_expiry(self, question_id: str) -> dict[str, Any] | None:
+    async def claim_question_expiry(
+        self: DatabaseAccess, question_id: str
+    ) -> dict[str, Any] | None:
         resolved_at = _iso_now()
         async with self._write_connection() as conn:
             await conn.execute("BEGIN IMMEDIATE")
@@ -164,7 +176,7 @@ class QuestionsMixin:
             await conn.commit()
         return dict(row)
 
-    async def cancel_pending_questions(self, call_id: str) -> list[dict[str, Any]]:
+    async def cancel_pending_questions(self: DatabaseAccess, call_id: str) -> list[dict[str, Any]]:
         async with self._immediate_transaction() as conn:
             resolved_at = _iso_now()
             cursor = await conn.execute(
@@ -177,7 +189,7 @@ class QuestionsMixin:
             rows = await cursor.fetchall()
         return [dict(row) for row in rows]
 
-    async def cancel_all_pending_questions(self) -> list[dict[str, Any]]:
+    async def cancel_all_pending_questions(self: DatabaseAccess) -> list[dict[str, Any]]:
         async with self._immediate_transaction() as conn:
             resolved_at = _iso_now()
             cursor = await conn.execute(
@@ -190,13 +202,15 @@ class QuestionsMixin:
             rows = await cursor.fetchall()
         return [dict(row) for row in rows]
 
-    async def get_question(self, question_id: str) -> dict[str, Any] | None:
+    async def get_question(self: DatabaseAccess, question_id: str) -> dict[str, Any] | None:
         return await self.fetch_one(
             "SELECT * FROM call_questions WHERE question_id=?",
             (question_id,),
         )
 
-    async def get_questions_after(self, call_id: str, after_sequence: int) -> list[dict[str, Any]]:
+    async def get_questions_after(
+        self: DatabaseAccess, call_id: str, after_sequence: int
+    ) -> list[dict[str, Any]]:
         return await self.fetch_all(
             """SELECT * FROM call_questions
                WHERE call_id=? AND sequence_number > ?
@@ -204,7 +218,7 @@ class QuestionsMixin:
             (call_id, after_sequence),
         )
 
-    async def count_call_questions(self, call_id: str) -> int:
+    async def count_call_questions(self: DatabaseAccess, call_id: str) -> int:
         row = await self.fetch_one(
             "SELECT COUNT(*) AS count FROM call_questions WHERE call_id=?",
             (call_id,),

--- a/app/db/telemetry.py
+++ b/app/db/telemetry.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.db.protocols import DatabaseAccess
+
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import StrEnum
@@ -62,7 +67,7 @@ class LatencyMark:
 
 class TelemetryMixin:
     async def record_latency_events(
-        self,
+        self: DatabaseAccess,
         call_id: str,
         events: Iterable[tuple[LatencyStage, LatencyMark, str]],
     ) -> None:
@@ -83,7 +88,7 @@ class TelemetryMixin:
             await conn.executemany(UPSERT_LATENCY_EVENT, rows)
 
     async def record_latency_event(
-        self,
+        self: DatabaseAccess,
         call_id: str,
         stage: LatencyStage,
         mark: LatencyMark | None = None,
@@ -95,7 +100,7 @@ class TelemetryMixin:
             [(stage, mark or LatencyMark.now(), event_key)],
         )
 
-    async def get_latency_events(self, call_id: str) -> list[dict[str, Any]]:
+    async def get_latency_events(self: DatabaseAccess, call_id: str) -> list[dict[str, Any]]:
         return await self.fetch_all(
             """SELECT stage, event_key, occurred_at, monotonic_ns, clock_id
                FROM call_latency_events WHERE call_id=? ORDER BY occurred_at, id""",
@@ -103,7 +108,7 @@ class TelemetryMixin:
         )
 
     async def record_tool_call(
-        self,
+        self: DatabaseAccess,
         call_id: str,
         *,
         latency_mark: LatencyMark,
@@ -141,7 +146,7 @@ class TelemetryMixin:
                 ),
             )
 
-    async def mark_tool_continuation_observed(self, call_id: str) -> bool:
+    async def mark_tool_continuation_observed(self: DatabaseAccess, call_id: str) -> bool:
         """Record a continuation only when at least one tool call was durably received."""
 
         return await self._execute_cas(

--- a/app/db/termination.py
+++ b/app/db/termination.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.db.protocols import DatabaseAccess
+
 from typing import Any
 
 from app.db.engine import _decode_json_columns, _iso_now
@@ -7,7 +12,9 @@ from app.models import TERMINAL_STATES, CallState
 
 
 class TerminationMixin:
-    async def claim_termination(self, call_id: str, reason: str) -> dict[str, Any] | None:
+    async def claim_termination(
+        self: DatabaseAccess, call_id: str, reason: str
+    ) -> dict[str, Any] | None:
         """Atomically claim and enter termination, returning the claimed current row."""
 
         placeholders, terminal_states = self._in_clause(state.value for state in TERMINAL_STATES)
@@ -35,7 +42,7 @@ class TerminationMixin:
         return _decode_json_columns(dict(row)) if row else None
 
     async def claim_startup_recovery(
-        self,
+        self: DatabaseAccess,
         call_id: str,
         *,
         expected_transfer_outcome: str | None,
@@ -89,7 +96,7 @@ class TerminationMixin:
         return _decode_json_columns(dict(row)) if row else None
 
     async def finish_claimed_termination(
-        self,
+        self: DatabaseAccess,
         call_id: str,
         *,
         expected_reason: str,
@@ -121,7 +128,7 @@ class TerminationMixin:
             params,
         )
 
-    async def reset_termination_claim(self, call_id: str) -> None:
+    async def reset_termination_claim(self: DatabaseAccess, call_id: str) -> None:
         placeholders, terminal_states = self._in_clause(state.value for state in TERMINAL_STATES)
         await self.execute(
             f"""UPDATE calls SET termination_claimed=0

--- a/app/db/transcripts.py
+++ b/app/db/transcripts.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from app.db.protocols import DatabaseAccess
+
 import json
 from datetime import datetime
 
@@ -11,11 +16,11 @@ from app.models import StoredCallResult, TranscriptTurn
 
 class TranscriptsMixin:
     async def add_transcript_turn(
-        self,
+        self: DatabaseAccess,
         *,
         call_id: str,
         turn_id: str,
-        speaker: str,
+        speaker: Literal["assistant", "callee", "owner", "system"],
         text: str,
         source_event_type: str,
         source_event_id: str,
@@ -26,7 +31,11 @@ class TranscriptsMixin:
                 "SELECT COALESCE(MAX(sequence_number), 0) + 1 FROM transcripts WHERE call_id=?",
                 (call_id,),
             )
-            sequence = (await cursor.fetchone())[0]
+            sequence_row = await cursor.fetchone()
+            if sequence_row is None:
+                await conn.rollback()
+                raise RuntimeError("failed to allocate transcript sequence")
+            sequence = sequence_row[0]
             created_at = _iso_now()
             try:
                 await conn.execute(
@@ -60,14 +69,14 @@ class TranscriptsMixin:
             created_at=datetime.fromisoformat(created_at),
         )
 
-    async def get_transcript(self, call_id: str) -> list[TranscriptTurn]:
+    async def get_transcript(self: DatabaseAccess, call_id: str) -> list[TranscriptTurn]:
         rows = await self.fetch_all(
             "SELECT * FROM transcripts WHERE call_id=? ORDER BY sequence_number", (call_id,)
         )
         return [TranscriptTurn.model_validate(row) for row in rows]
 
     async def save_result_with_transcript(
-        self,
+        self: DatabaseAccess,
         call_id: str,
         result: StoredCallResult,
         transcript: list[TranscriptTurn],
@@ -89,7 +98,7 @@ class TranscriptsMixin:
                 ),
             )
 
-    async def get_result(self, call_id: str) -> StoredCallResult | None:
+    async def get_result(self: DatabaseAccess, call_id: str) -> StoredCallResult | None:
         row = await self.fetch_one(
             "SELECT result_json FROM call_results WHERE call_id=?", (call_id,)
         )

--- a/app/db/transfers.py
+++ b/app/db/transfers.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.db.protocols import DatabaseAccess
+
 from typing import Any
 
 from app.db.engine import _decode_json_columns, _iso_now
@@ -12,7 +17,7 @@ TRANSFER_ELIGIBLE_STATES = ("prewarming", "ready_to_activate", "activating", "ac
 
 
 class TransfersMixin:
-    async def claim_transfer_joining(self, call_id: str, reason: str) -> bool:
+    async def claim_transfer_joining(self: DatabaseAccess, call_id: str, reason: str) -> bool:
         """Durably allow at most one owner-transfer attempt for a live call.
 
         Eligible once the callee has joined, even before activation completes.
@@ -30,7 +35,7 @@ class TransfersMixin:
         )
 
     async def record_transfer_owner_sid(
-        self, call_id: str, expected: str, owner_call_sid: str
+        self: DatabaseAccess, call_id: str, expected: str, owner_call_sid: str
     ) -> bool:
         """Persist the owner leg before transfer promotion can become recoverable."""
 
@@ -52,7 +57,9 @@ class TransfersMixin:
             ),
         )
 
-    async def promote_transfer(self, call_id: str, reason: str) -> dict[str, Any] | None:
+    async def promote_transfer(
+        self: DatabaseAccess, call_id: str, reason: str
+    ) -> dict[str, Any] | None:
         """Claim teardown ownership while promoting a joined owner transfer."""
 
         placeholders, states = self._in_clause(TRANSFER_ELIGIBLE_STATES)
@@ -81,7 +88,9 @@ class TransfersMixin:
             row = await cursor.fetchone()
         return _decode_json_columns(dict(row)) if row else None
 
-    async def fail_joining_transfer(self, call_id: str, expected: str, failure: str) -> bool:
+    async def fail_joining_transfer(
+        self: DatabaseAccess, call_id: str, expected: str, failure: str
+    ) -> bool:
         placeholders, states = self._in_clause(TRANSFER_ELIGIBLE_STATES)
         return await self._execute_cas(
             f"""UPDATE calls SET transfer_outcome=?, last_event_at=?
@@ -92,7 +101,9 @@ class TransfersMixin:
             (failure, _iso_now(), call_id, expected, *states),
         )
 
-    async def complete_promoted_transfer(self, call_id: str, expected: str, completed: str) -> bool:
+    async def complete_promoted_transfer(
+        self: DatabaseAccess, call_id: str, expected: str, completed: str
+    ) -> bool:
         return await self._execute_cas(
             """UPDATE calls SET transfer_outcome=?, last_event_at=?
                WHERE call_id=?
@@ -104,7 +115,7 @@ class TransfersMixin:
         )
 
     async def fail_promoted_transfer(
-        self,
+        self: DatabaseAccess,
         call_id: str,
         expected: str,
         failure: str,

--- a/app/db/webhooks.py
+++ b/app/db/webhooks.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.db.protocols import DatabaseAccess
+
 import aiosqlite
 
 from app.db.engine import _iso_now
 
 
 class WebhooksMixin:
-    async def record_webhook_once(self, webhook_id: str) -> bool:
+    async def record_webhook_once(self: DatabaseAccess, webhook_id: str) -> bool:
         try:
             return await self._execute_cas(
                 "INSERT INTO webhook_deliveries(webhook_id, received_at) VALUES (?, ?)",

--- a/app/finalizer.py
+++ b/app/finalizer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import Any
+from typing import Any, Literal
 
 from openai import (
     APIConnectionError,
@@ -81,9 +81,11 @@ class Finalizer:
         self._locks: dict[str, asyncio.Lock] = {}
 
     @staticmethod
-    def _call_status(state: str) -> str:
-        if state in {CallState.COMPLETED.value, CallState.TRANSFERRED.value}:
-            return state
+    def _call_status(state: str) -> Literal["completed", "transferred", "failed", "timed_out"]:
+        if state == CallState.COMPLETED.value:
+            return "completed"
+        if state == CallState.TRANSFERRED.value:
+            return "transferred"
         if state == CallState.TIMED_OUT.value:
             return "timed_out"
         return "failed"
@@ -134,7 +136,17 @@ class Finalizer:
         transcript_complete = any(turn.speaker != "system" for turn in transcript) and not any(
             reason.startswith(prefix) for prefix in fatal_reasons
         )
-        fallback_outcome = "failed" if call_status == "failed" else "unknown"
+        fallback_outcome: Literal[
+            "completed",
+            "partially_completed",
+            "needs_follow_up",
+            "declined",
+            "voicemail_left",
+            "wrong_number",
+            "transferred",
+            "failed",
+            "unknown",
+        ] = "failed" if call_status == "failed" else "unknown"
         if call.get("answer_handling") == "voicemail":
             fallback_outcome = "voicemail_left"
         fallback = StoredCallResult(

--- a/app/main.py
+++ b/app/main.py
@@ -39,7 +39,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         service = getattr(app.state, "call_service", None)
         if service is None:
             raise RuntimeError("service is not started")
-        return service
+        return service  # type: ignore[no-any-return]
 
     register_tools(mcp, get_service)
     mcp_http_app = mcp.http_app(

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable
+from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
@@ -36,7 +37,7 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
         context: ContextPacket,
         authority_basis: str | None = None,
         requested_by_owner: bool = False,
-    ) -> dict:
+    ) -> dict[str, Any]:
         try:
             output = await get_service().prepare(
                 PreparePhoneCallInput(
@@ -60,7 +61,7 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
     )
     async def start_phone_call(
         plan_id: str, explicit_confirmation: bool, confirmation_text: str
-    ) -> dict:
+    ) -> dict[str, Any]:
         try:
             result = await get_service().start(
                 plan_id,
@@ -79,7 +80,7 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
             + CONTEXT_GUIDANCE
         ),
     )
-    async def get_call_result(call_id: str) -> dict:
+    async def get_call_result(call_id: str) -> dict[str, Any]:
         try:
             return await get_service().get_result(call_id)
         except LookupError as exc:
@@ -89,7 +90,7 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
         name="end_phone_call",
         description="End an active call at the owner's request. " + CONTEXT_GUIDANCE,
     )
-    async def end_phone_call(call_id: str) -> dict:
+    async def end_phone_call(call_id: str) -> dict[str, Any]:
         ended = await get_service().terminate_call(call_id, "owner_request")
         return {"call_id": call_id, "termination_started": ended}
 
@@ -97,7 +98,7 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
         name="get_phone_call",
         description="Return lightweight call status and timing fields. " + CONTEXT_GUIDANCE,
     )
-    async def get_phone_call(call_id: str) -> dict:
+    async def get_phone_call(call_id: str) -> dict[str, Any]:
         try:
             snapshot = await get_service().get_snapshot(call_id)
         except LookupError as exc:
@@ -117,7 +118,7 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
         call_id: str,
         after_sequence: int = 0,
         timeout_seconds: float = 20.0,
-    ) -> dict:
+    ) -> dict[str, Any]:
         logger.info(
             "mcp tool wait_for_call_event call_id=%s after_sequence=%s timeout_seconds=%s",
             call_id,
@@ -164,7 +165,7 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
             + CONTEXT_GUIDANCE
         ),
     )
-    async def answer_call_question(call_id: str, question_id: str, answer: str) -> dict:
+    async def answer_call_question(call_id: str, question_id: str, answer: str) -> dict[str, Any]:
         logger.info(
             "mcp tool answer_call_question call_id=%s question_id=%s answer_chars=%s",
             call_id,

--- a/app/models.py
+++ b/app/models.py
@@ -250,6 +250,7 @@ class RealtimeFunctionTool(BaseModel):
         "search_web",
         "send_dtmf",
         "ask_poke",
+        "report_hold",
         "end_call",
     ]
     description: str = Field(min_length=1)
@@ -261,8 +262,12 @@ class AcceptPayload(BaseModel):
 
     type: Literal["realtime"] = "realtime"
     model: Literal["gpt-realtime-2.1"] = "gpt-realtime-2.1"
-    reasoning: dict[str, Literal["low"]] = Field(default_factory=lambda: {"effort": "low"})
-    output_modalities: list[Literal["audio"]] = Field(default_factory=lambda: ["audio"])
+    reasoning: dict[str, Literal["low"]] = Field(
+        default_factory=lambda: {"effort": "low"}  # type: ignore[arg-type]
+    )
+    output_modalities: list[Literal["audio"]] = Field(
+        default_factory=lambda: ["audio"]  # type: ignore[arg-type]
+    )
     max_output_tokens: Literal["inf"] = "inf"
     parallel_tool_calls: Literal[True] = True
     tool_choice: Literal["auto"] = "auto"

--- a/app/openai_client.py
+++ b/app/openai_client.py
@@ -17,14 +17,9 @@ def create_openai_client(settings: Settings) -> AsyncOpenAI:
         settings.openai_http_timeout_seconds,
         connect=settings.openai_connect_timeout_seconds,
     )
-    options: dict[str, object] = {
-        "api_key": Settings.reveal(settings.openai_api_key),
-        "webhook_secret": Settings.reveal(settings.openai_webhook_secret),
-        "timeout": timeout,
-        "max_retries": 0,
-    }
+    http_client: httpx.AsyncClient | None = None
     if settings.openai_keepalive_expiry_seconds is not None:
-        options["http_client"] = httpx.AsyncClient(
+        http_client = httpx.AsyncClient(
             timeout=timeout,
             follow_redirects=True,
             limits=httpx.Limits(
@@ -33,4 +28,17 @@ def create_openai_client(settings: Settings) -> AsyncOpenAI:
                 keepalive_expiry=settings.openai_keepalive_expiry_seconds,
             ),
         )
-    return AsyncOpenAI(**options)
+    if http_client is None:
+        return AsyncOpenAI(
+            api_key=Settings.reveal(settings.openai_api_key),
+            webhook_secret=Settings.reveal(settings.openai_webhook_secret),
+            timeout=timeout,
+            max_retries=0,
+        )
+    return AsyncOpenAI(
+        api_key=Settings.reveal(settings.openai_api_key),
+        webhook_secret=Settings.reveal(settings.openai_webhook_secret),
+        timeout=timeout,
+        max_retries=0,
+        http_client=http_client,
+    )

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -6,7 +6,7 @@ import json
 import logging
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any
 
 import websockets
 from openai import APIStatusError, AsyncOpenAI
@@ -25,7 +25,7 @@ from app.settings import Settings
 logger = logging.getLogger(__name__)
 
 EventHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
-OpenHandler = Callable[[str], Awaitable[None]]
+OpenHandler = Callable[[str], Coroutine[Any, Any, None]]
 FatalHandler = Callable[[str, str], Awaitable[None]]
 SendHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
 ActivityHandler = Callable[..., object]
@@ -338,7 +338,7 @@ class RealtimeBridge:
                 # Supervise on_open as well: it may be awaiting the session.updated readiness
                 # echo, while either event task may fail independently.
                 open_task = asyncio.create_task(
-                    cast(Coroutine[Any, Any, None], self.on_open(runtime.call_id)),
+                    self.on_open(runtime.call_id),
                     name=f"sideband-open:{runtime.call_id}",
                 )
                 runtime.open_task = open_task

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -4,14 +4,21 @@ import asyncio
 import contextlib
 import json
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import websockets
 from openai import APIStatusError, AsyncOpenAI
 
-from app.models import AcceptPayload, ContextPacket
+from app.models import (
+    AcceptPayload,
+    ContextPacket,
+    RealtimeAudio,
+    RealtimeAudioInput,
+    RealtimeAudioOutput,
+    RealtimeFunctionTool,
+)
 from app.prompts import realtime_instructions
 from app.settings import Settings
 
@@ -21,7 +28,7 @@ EventHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
 OpenHandler = Callable[[str], Awaitable[None]]
 FatalHandler = Callable[[str, str], Awaitable[None]]
 SendHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
-ActivityHandler = Callable[[str], None]
+ActivityHandler = Callable[..., object]
 
 # Realtime events are normally consumed as quickly as they arrive. A bounded queue protects a
 # call from unbounded memory growth if application handling stalls while still leaving ample room
@@ -245,14 +252,11 @@ class RealtimeBridge:
                 ask_poke_enabled=self.settings.ask_poke_enabled,
                 hold_detection_enabled=self.settings.hold_detection_enabled,
             ),
-            audio={
-                "input": self._input_audio_config(create_response=False, interrupt_response=False),
-                "output": {
-                    "voice": "cedar",
-                    "speed": 1.0,
-                },
-            },
-            tools=tools,
+            audio=RealtimeAudio(
+                input=self._input_audio_config(create_response=False, interrupt_response=False),
+                output=RealtimeAudioOutput(voice="cedar", speed=1.0),
+            ),
+            tools=[RealtimeFunctionTool.model_validate(tool) for tool in tools],
         )
 
     async def accept_and_connect(
@@ -334,7 +338,7 @@ class RealtimeBridge:
                 # Supervise on_open as well: it may be awaiting the session.updated readiness
                 # echo, while either event task may fail independently.
                 open_task = asyncio.create_task(
-                    self.on_open(runtime.call_id),
+                    cast(Coroutine[Any, Any, None], self.on_open(runtime.call_id)),
                     name=f"sideband-open:{runtime.call_id}",
                 )
                 runtime.open_task = open_task
@@ -543,10 +547,17 @@ class RealtimeBridge:
                     exc_info=True,
                 )
 
-    async def _update_session(self, call_id: str, audio_input: dict[str, Any]) -> dict[str, Any]:
+    async def _update_session(
+        self, call_id: str, audio_input: RealtimeAudioInput | dict[str, Any]
+    ) -> dict[str, Any]:
         runtime = self._runtime.get(call_id)
         if runtime is None:
             raise RuntimeError("sideband runtime missing")
+        payload = (
+            audio_input.model_dump(mode="json", exclude_none=True)
+            if isinstance(audio_input, RealtimeAudioInput)
+            else audio_input
+        )
         async with runtime.update_lock:
             loop = asyncio.get_running_loop()
             runtime.update_waiter = loop.create_future()
@@ -556,7 +567,7 @@ class RealtimeBridge:
                     "type": "session.update",
                     "session": {
                         "type": "realtime",
-                        "audio": {"input": audio_input},
+                        "audio": {"input": payload},
                     },
                 },
             )
@@ -574,20 +585,22 @@ class RealtimeBridge:
 
     def _input_audio_config(
         self, *, create_response: bool, interrupt_response: bool
-    ) -> dict[str, Any]:
+    ) -> RealtimeAudioInput:
         # Do not specify audio.format: SIP media negotiates G.711 with Twilio, and
         # explicitly overriding it can silence RTP. Always re-assert transcription
         # alongside turn_detection: session.update replaces the nested audio.input
         # object, so a turn_detection-only update would drop input transcription.
-        return {
-            "transcription": self._transcription_config(),
-            "turn_detection": {
-                "type": "semantic_vad",
-                "eagerness": self.settings.semantic_vad_eagerness,
-                "create_response": create_response,
-                "interrupt_response": interrupt_response,
-            },
-        }
+        return RealtimeAudioInput.model_validate(
+            {
+                "transcription": self._transcription_config(),
+                "turn_detection": {
+                    "type": "semantic_vad",
+                    "eagerness": self.settings.semantic_vad_eagerness,
+                    "create_response": create_response,
+                    "interrupt_response": interrupt_response,
+                },
+            }
+        )
 
     async def verify_initial_session(self, call_id: str) -> dict[str, Any]:
         return await self._update_session(

--- a/app/owner_transfer.py
+++ b/app/owner_transfer.py
@@ -181,7 +181,7 @@ class OwnerTransferCoordinator:
                         and not current.get("termination_claimed")
                         and current.get("transfer_outcome") == joining
                     )
-                    if not exact_joining:
+                    if not exact_joining or current is None:
                         if claim_error is not None:
                             raise claim_error
                         return None, "owner transfer already attempted or call is ending"
@@ -216,7 +216,8 @@ class OwnerTransferCoordinator:
             name=f"claim-owner-transfer:{call_id}",
             must_finish=True,
         )
-        return await self._await_network_task(claim)
+        result = await self._await_network_task(claim)
+        return result  # type: ignore[no-any-return]
 
 
 class OwnerTransferRun:

--- a/app/routes/debug.py
+++ b/app/routes/debug.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.security import require_debug_token
@@ -49,7 +51,7 @@ DEBUG_SAFE_CALL_FIELDS = {
 
 
 @router.get("/calls/{call_id}")
-async def get_call(call_id: str, request: Request):
+async def get_call(call_id: str, request: Request) -> dict[str, Any]:
     try:
         snapshot = await request.app.state.call_service.get_snapshot(call_id)
     except LookupError as exc:
@@ -68,6 +70,6 @@ async def get_call(call_id: str, request: Request):
 
 
 @router.get("/calls")
-async def list_calls(request: Request):
+async def list_calls(request: Request) -> list[dict[str, Any]]:
     rows = await request.app.state.call_service.list_call_records()
     return [{key: row.get(key) for key in DEBUG_SAFE_CALL_FIELDS} for row in rows]

--- a/app/twilio_bridge.py
+++ b/app/twilio_bridge.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from typing import Any
 from urllib.parse import urlencode
 
 from twilio.base.exceptions import TwilioRestException
@@ -42,7 +43,7 @@ class TwilioBridge:
         custom = urlencode({"X-Plan-Id": plan_id, "X-Bridge-Call-Id": call_id})
         sip_uri = f"sip:{self.settings.openai_project_id}@sip.api.openai.com;transport=tls?{custom}"
 
-        def create():
+        def create() -> Any:
             return self.client.conferences(conference_name).participants.create(
                 from_=self.settings.twilio_caller_id,
                 to=sip_uri,
@@ -83,7 +84,7 @@ class TwilioBridge:
         conference_sid_or_name: str,
         packet: ContextPacket,
     ) -> ParticipantInfo:
-        def create():
+        def create() -> Any:
             return self.client.conferences(conference_sid_or_name).participants.create(
                 from_=self.settings.twilio_caller_id,
                 to=packet.target.phone,
@@ -120,7 +121,7 @@ class TwilioBridge:
         conference_sid_or_name: str,
         owner_phone: str,
     ) -> ParticipantInfo:
-        def create():
+        def create() -> Any:
             return self.client.conferences(conference_sid_or_name).participants.create(
                 from_=self.settings.twilio_caller_id,
                 to=owner_phone,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,14 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "mypy>=1.17.0",
+    "pre-commit>=4.2.0",
     "pytest>=9.1.1",
     "pytest-asyncio>=1.4.0",
     "pytest-cov>=7.1.0",
     "respx>=0.23.1",
     "ruff>=0.15.21",
+    "types-protobuf>=6.30.2",
 ]
 
 [build-system]
@@ -45,3 +48,27 @@ line-length = 100
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "ASYNC"]
 ignore = ["B008", "E501"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+warn_unreachable = true
+show_error_codes = true
+packages = ["app"]
+exclude = [
+    "tests/",
+    "scripts/",
+    "dist/",
+]
+
+# Third-party packages without complete stubs.
+[[tool.mypy.overrides]]
+module = [
+    "twilio.*",
+    "phonenumbers.*",
+    "fastmcp.*",
+    "aiosqlite.*",
+]
+ignore_missing_imports = true

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
     "python_full_version < '3.14' and sys_platform == 'win32'",
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
@@ -195,6 +197,47 @@ wheels = [
 ]
 
 [[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/12/3e5f575f156555547c250a8b0d1347517a3a20fc7f4492e9703a69d4f45e/ast_serialize-0.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:a7520b672827885bafeae7501f684d14d47d17e5f45256f9df547686cca52264", size = 1177640, upload-time = "2026-06-30T20:02:06.708Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a4/921a9e27951627983b0f368859ea00f8330a551dc0bf4c2fdcb11855a98b/ast_serialize-0.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a14191beec7e0c078d2fc1f6edc0aee88bcd4db9f18e1bc9f8052b559c22dddc", size = 1168111, upload-time = "2026-06-30T20:02:08.366Z" },
+    { url = "https://files.pythonhosted.org/packages/00/69/950cf404de7b8782cf95e5c1237e25e2aa46177b287f39f9eeddf481fd6f/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32ef62ec34cf6be20ad77d4799556638fbdf187f3ae10698dfb20ef9f2c89516", size = 1227656, upload-time = "2026-06-30T20:02:09.843Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a8/46f8f6a6479d9d2273980957bb091a506c55f5b95d3c029ee58518a78407/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:13b7769970a39983b0adf2f38917b1cd3b8946f76df045756c3d741bc689f089", size = 1227706, upload-time = "2026-06-30T20:02:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/b9/9ac415bda0a40e49eab8fea3b2741c19c98bb84d57d62c4cfc6230eb67be/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6f7a408601bb3edaefb3bc67a4c01f5235e3253653b6a5729a2ee2382b35341c", size = 1431705, upload-time = "2026-06-30T20:02:12.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/8807115d441444879f7561b5eede5ac18fc80392f11826d61ccf31f503b1/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8670bfa51208a2c0c8d138928e40e998fab158f9200d53bb80c088b5b8eda7b8", size = 1249533, upload-time = "2026-06-30T20:02:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c0/c2ba82ef9618650357d9421a1fdb27ffec862a7f57e8e2de82a3ccd11e12/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4826809eb8597a8cd59fd924b6d7c285b8969a1e0007e2cb652cab62376270f", size = 1252619, upload-time = "2026-06-30T20:02:16.219Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a7/fa31d52dd4102cede29fb9634e98d214129b2783b4f95528c6dc6a8f6587/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:577a6c189068686869f5f1ddc38363f3ae1808a4753b577266f9202071a7bb66", size = 1242983, upload-time = "2026-06-30T20:02:17.813Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/20/ddf742b5ad3c4bafd3466f2265037cfd99bc1b9a5ee46a5d58c90d523242/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:085de7f62dc9cc247eb01e965a362707d1d90b1d89a82c5bf78301a60a3c417b", size = 1296148, upload-time = "2026-06-30T20:02:19.146Z" },
+    { url = "https://files.pythonhosted.org/packages/24/cb/9f6f217cce8b3b632c5568b478d195a35e79dce4dbe309438cb89ba6ea4f/ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9f8a8b78b13173de6a9ec22111d9be674874cd5bdccda04f14ae5ebc2bef403a", size = 1403826, upload-time = "2026-06-30T20:02:20.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f8/9d16d4f0107a183924425cc0e7618d8bf76f96b45afa9ff19f924ed1ad57/ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f2ff3baffc3a29c1f15bc9098aa0c09763410262d5e6cef42116f7356c184554", size = 1502943, upload-time = "2026-06-30T20:02:22.034Z" },
+    { url = "https://files.pythonhosted.org/packages/80/dd/bbc1c38756350dddf7e24acae1c9482ef42051c267417e019aecc1ed4075/ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0067b25fce104eaae5b88383de9ab803faeb671831e14ca698b771b356e2600f", size = 1497632, upload-time = "2026-06-30T20:02:23.517Z" },
+    { url = "https://files.pythonhosted.org/packages/42/7e/9daffefcf5b97e6bb4c3e0b3c024c1aee9722f23d3cf7cd2ff80d6fb4a40/ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c617417f9cbb0cb144f6283c3cbe0d2e0f01beaf9f608f662b21191058a626ec", size = 1448858, upload-time = "2026-06-30T20:02:24.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1f/f9baaab81a677ea0af7d2458cac2f94ebcc85958f8a3c15ba9d9e5dab653/ast_serialize-0.6.0-cp314-cp314t-win32.whl", hash = "sha256:5337cb256dcea3df9288205213d1601581536526b8f4da44b6974f1180f3252a", size = 1052600, upload-time = "2026-06-30T20:02:26.263Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1f/41b535866519512d8cf6669cb2cff7823b7672bb6279c0333b4ff89d7d9f/ast_serialize-0.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2d947e45cafc4b09bd7528917fa84c517654a43de173c79785574b7b3068ac24", size = 1095570, upload-time = "2026-06-30T20:02:27.639Z" },
+    { url = "https://files.pythonhosted.org/packages/50/64/e472fe3e3a2d33d874b987e8518aedf24562919e3b6161a4fa1797e89c0f/ast_serialize-0.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:6e15ec740436e1a0d62de848641abe5f3a2f89a7f94907d534795ac91bbacf14", size = 1067267, upload-time = "2026-06-30T20:02:28.949Z" },
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -347,6 +390,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
     { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
     { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
 ]
 
 [[package]]
@@ -566,6 +618,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -694,6 +755,15 @@ server = [
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.30.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/f7/2165ef325da22d854b8f81ca4799395f2eb6afa55cdb52c7710f028b5336/filelock-3.30.2.tar.gz", hash = "sha256:1ea7c857465c897a4a6e64c1aace28ff6b83f5bc66c1c06ea148efa65bc2ec5d", size = 176823, upload-time = "2026-07-16T19:50:42.724Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/df/05118016cad66cd0d7c9417b2d4fc245be35decc4c36810f3c8dbf729d88/filelock-3.30.2-py3-none-any.whl", hash = "sha256:a64b58f75048ec39589983e97f5117163f822261dcb6ba843e098f05aac9663f", size = 94092, upload-time = "2026-07-16T19:50:41.189Z" },
 ]
 
 [[package]]
@@ -838,6 +908,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -1049,6 +1128,68 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+    { url = "https://files.pythonhosted.org/packages/67/3b/18e7b63255297a2bdc9c25c8d6d4ca8eca9f63aceb1252c0f7427ac7099e/librt-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a468951af16155824e88bdd8326ebe5bdb371f3ec0ac04642994b98201d914f3", size = 151027, upload-time = "2026-07-08T12:25:19.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/68/e2248452c00d1a03b45fee1752cdc8f790a476efd2402b75181da88a9e61/librt-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ae01d8512cc17079e53425635327dbf3f7ff57a42c00dec348bf79791c56444c", size = 155152, upload-time = "2026-07-08T12:25:20.851Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/16/52b1c99bf19057a062aac39c900cbb81499f6f75d6c537c14463d247ba78/librt-0.13.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32c26893cd085c1efe83219e78d866da23fb20a066101b8f68210004361d224c", size = 502499, upload-time = "2026-07-08T12:25:22.055Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/54/b811151805c795f55e0dedee6ec687b75f9982a8105d240ea3910737a77b/librt-0.13.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5929da1981a46bcf4b28b1b9499905f0ff58e2419da402a048234e9783acbc4b", size = 496108, upload-time = "2026-07-08T12:25:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f8/094d6b2bd93f3fdaa54db54cc788c4a365333bddad65ab02e04da0b1d004/librt-0.13.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:94b85d664d777bab6c0d709416cb42938251fda9e221b79e3a2215d85df5f4f9", size = 531576, upload-time = "2026-07-08T12:25:24.648Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/40/541733d5755824f968f7ec39d78ffbd75d145964157ae5e69a09ec6d7326/librt-0.13.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:531b2df3e9fe96b1fcf73a6d165921e4656be5f58d631d384ebce344298368db", size = 524390, upload-time = "2026-07-08T12:25:25.898Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/b5/255673cfdbf5ba663339d36cd863c897289ab4337577e19f9405ce059f36/librt-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:109b84a9edf69ad89dc1f66358659e14a031baca95e3e5b0060bd903ede8efd6", size = 543053, upload-time = "2026-07-08T12:25:27.436Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/11/ab5005e9c9850710f21e354201bf090646349d3fabf5f951eaf70235729e/librt-0.13.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1304368a3e7ffc3e9db986796cc5326fdb5943a3567ecc137cff318e4240c0e7", size = 546387, upload-time = "2026-07-08T12:25:28.65Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/04/a5d7ce1d1df1afd15ca283dcdf7530ac073e12d69ae8c40879dda96f7868/librt-0.13.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e4f9b472e7d308d94b62c801982065661158c6ed02790d6c7ddb4337cea0f9c1", size = 535970, upload-time = "2026-07-08T12:25:30.171Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/76/927e267a6daa290174ac281b23c9804c8829b042ade9c6f24a065f540958/librt-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f836c37478f167a81200d8c8b2c920a22224564bed2c23d7aeec760965c367a", size = 573582, upload-time = "2026-07-08T12:25:31.507Z" },
+    { url = "https://files.pythonhosted.org/packages/10/24/b6c5213efe39c19f9e13605644d0cf063b4ddaa33ac2e45b088e23a70e2e/librt-0.13.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:4000d961ff9598ac6ea603c6c836a5ed49bc205ade5fc378b998dfe1e2c36628", size = 82189, upload-time = "2026-07-08T12:25:32.675Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/00/d29736be177a906ac0b84a5b04b4fbfa22c776dc2f366de4172b0f968c08/librt-0.13.0-cp313-cp313-win32.whl", hash = "sha256:79e44cff71750d299d61a678e49995b0d5935a9cda238c2574daeca3ba536927", size = 106193, upload-time = "2026-07-08T12:25:33.692Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ac/aff6fb45393cb8912f39dfb156ef6b2d1cadb207ff465fc8f66141054be8/librt-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:54dab44a847d5ad1acd05c8a83fe518ae685516ecf4d3f7cc6e3df2a66767650", size = 126962, upload-time = "2026-07-08T12:25:34.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3a/d68cb2b334d53fd30fac81d3a489ce4ba0d9506f4df43fcf676b68352b19/librt-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:d4cb6fbfdf874340ab5e51450753c0f817b6958a3621125ee695bbc3de866566", size = 112127, upload-time = "2026-07-08T12:25:35.981Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/66/f49ae0d592bd45b6941e9a8bafcb6a87cddcd501ee7874707e767f01b585/librt-0.13.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:25218d94b1d2cbc0ba1d8a3f9dc9af578d9646e5ed16443a70cde1dfdcce6d71", size = 149818, upload-time = "2026-07-08T12:25:37.203Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/50/51c76d74014d04fb95b6506d286808984b78a2f7a41039094e6b2194ac48/librt-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f26629539d4893c2957a16c41bb058e1e135c1f150f6a2e25ed047f64cf3f5c6", size = 154071, upload-time = "2026-07-08T12:25:39.399Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fe/f19b0f5f82d5a1f2da736586bc840abd00ce07d6388136ae80b7333883fc/librt-0.13.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4517d47b2b8af26975a406fba7d314de9696d864252e0257c6ea90238cfe27f", size = 494168, upload-time = "2026-07-08T12:25:40.641Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bc/b8550c75775127fd31a5f20e8775997f7b527ad661fc8ddccd7497c064f7/librt-0.13.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f19e181de5b3a1148bb3420b8c4b0b0ea0fce6950099724ad151d6cea5acc180", size = 491054, upload-time = "2026-07-08T12:25:41.905Z" },
+    { url = "https://files.pythonhosted.org/packages/30/14/4d0204867623df3f33f86efd3d3692ba5e01321443f4d6eab35a22697618/librt-0.13.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22034924f5b42d5a56371cf271771bfeaabf235a7a8b6264bef2d20013f786c6", size = 523006, upload-time = "2026-07-08T12:25:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0a/c45fc9a260934696bace1ac5df1e148ac92bd71767aee3bf7cd7a4534f4c/librt-0.13.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c7897db4e95e22468bdda33d8e012ceacd0182abf001e6389d763f0def6286b9", size = 515058, upload-time = "2026-07-08T12:25:44.541Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/50c5ce45b326854ef8fa6ae4c36cf5142e5c55315eaf9e51d0ae73ac4da3/librt-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ce61b3746545029d4f5c17d6bd74b676254ad98433086c846ffb5e8fa73f007", size = 534025, upload-time = "2026-07-08T12:25:45.825Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2d/08c413c8f93fc13b8103624fce38e5caa86cd08cbbc8465870ab287af54b/librt-0.13.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:46c330e82565962c761dbce7941be2cff7db674ee807455a8d0cadc5f9b759b0", size = 540557, upload-time = "2026-07-08T12:25:47.059Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/93af71fb4a364952210051811dd4e40174e79656b050c89cacac18af3330/librt-0.13.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:375f5af8f99cbaa99dd293af986e3d57caabc9ba81a5d3f021603764854197a1", size = 523201, upload-time = "2026-07-08T12:25:48.392Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/6e/9766f07b676a4889d9f8bc2864e9ba5fff165653143ef4dda7df6aa34d16/librt-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9320d34c3376ae204b2cd176e8d4883a013934e0aef822f1aed9c536490c275d", size = 565740, upload-time = "2026-07-08T12:25:49.678Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/1e/664e3472ce2b6e10e9b83f29d4a36eb982ff6b5a169ae7567bba3a4c4ff5/librt-0.13.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:9af313c66157a69dc69ea0059a66961692250e0dc95af9c385a48ffb770a0d16", size = 81611, upload-time = "2026-07-08T12:25:50.857Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d4/8582a4d65e2234673685e07309d02c230b28a85724eb0acbf13f019b7f6e/librt-0.13.0-cp314-cp314-win32.whl", hash = "sha256:f2a7253458e34f33543551394ae4fe104b497ec2a65ac266074de64c1df82e37", size = 100106, upload-time = "2026-07-08T12:25:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ce/0cb99efe6086b46cd985dc26672166fae312a239690e75871f7fafbd3fc5/librt-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:a3dfe4edf10e8ed7e55b026a8bfc2c2a8704218b659cd4bffdf604fab966dc39", size = 121209, upload-time = "2026-07-08T12:25:53.166Z" },
+    { url = "https://files.pythonhosted.org/packages/26/85/4f3ccb083a3c9b0d42e223acdb3c3f507953324a59cdcab4826e8e2e3b89/librt-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:68a5faee4bba381cb93b5961f684a514cf0053cb92308ff9c792c2fea0b174c6", size = 106404, upload-time = "2026-07-08T12:25:54.253Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/77/333191499538c8e8189de7a4cba8e6f49ee949fd6d6e6324b21fd1522466/librt-0.13.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a38fb81d8376dfa2f8963b265fec07637802b0d01e2a127c19c66cb070fb24f5", size = 159231, upload-time = "2026-07-08T12:25:55.432Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/9e/2aa83758f22c278b837a1d8025898434ce2b8bff36678d5330ecaef56dff/librt-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d4c8d9bd5abce34b2e75edb3bf37ab0f34e49b1f915a40ae8468eb7c85bc5b46", size = 161300, upload-time = "2026-07-08T12:25:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c0/86791e936553ca763d6b3c2fb4d31d596cd00e14fa631c283a40ba01559a/librt-0.13.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:387e2f1d27e89bffe0d3f520f0da0662c973fd607ca16c1808f8a5085419485e", size = 582056, upload-time = "2026-07-08T12:25:58.144Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d3/a9ec15984a185e000c4d2a16ba28bd623124ad4c38a10974c7ff78e3a893/librt-0.13.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:4f6db193d2e5e0ed60359b9a5a682cd67205d0d3b1e459a867dd4b5c4e7eaa7a", size = 562758, upload-time = "2026-07-08T12:25:59.544Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/af/dbe36b78b19c06a55097f99305e4ea9458e2273e6ae16a3cbecaad7ee978/librt-0.13.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d38604854e8d22faadf683ec6c02bb0f886e2ba56ef981a1c36ee275f21ea22", size = 602095, upload-time = "2026-07-08T12:26:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a8/2966891b4dd2830f5203fbee92ac2c4947653a2390ba73dfa44244fad025/librt-0.13.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:371f7ce73026815dafd51c50ce38416e91428b28c4b2ec97cd39271164b0045c", size = 593452, upload-time = "2026-07-08T12:26:02.352Z" },
+    { url = "https://files.pythonhosted.org/packages/61/f5/4df8bfc8405ecf8c0d525b4d69636f694bdd8620b313ec8b76e54a5926cc/librt-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3aaedf52171bee90860704c560bc798fe83b76247df47568e0197e9b13c735a0", size = 623729, upload-time = "2026-07-08T12:26:04.294Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/13/9ac202dffc8db06f75d06c08c2f9f6ff054be67d21272dcc078fa1cc0c57/librt-0.13.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:96bad8725a4f196a798366c25ce075d1f7543a4ec045ffc13e6a7ec095cdab04", size = 617077, upload-time = "2026-07-08T12:26:05.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f0/ebe38610716aee5cb28efd95089bb90192096179802779381e1c5dcf239c/librt-0.13.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6bf6a559ffe4a93bbea6cf31ddf01a7fd9ba342ef51f27beb178e318b74acd61", size = 599561, upload-time = "2026-07-08T12:26:07.21Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5c/c2e72e236fff7abc716d5b1753b8b8cd3ea85ac46fe17d2e7c51d4e1c723/librt-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:301067672387902c55f94b51d5022304b36c966ea9fe1f21caab99a9bef487c9", size = 645511, upload-time = "2026-07-08T12:26:08.562Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/99/6203ce619dee940d6bfbe099ec3fe4be00a68e9d60f70abf906cf124fe66/librt-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:5fdcf34f86de8fb66d7dc7589f96ba91c4aa46671200d400e6fd6f109a483f18", size = 104357, upload-time = "2026-07-08T12:26:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/52/dd/843b6314087c41657c7036d7914d8f294bdf9b580aa8513ea0588c8e9a3d/librt-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:260c33e92263fa629b4f6d3c51967a1c2158fe6c33237aaa3ebeac586b085259", size = 126998, upload-time = "2026-07-08T12:26:10.975Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/3dcec2884ba1b0806d1408612555c38dd5d68e90156b59f75f6e36435c3a/librt-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2f281549a4c52ac7bb97997f14353f8bd0e53a34ca0dad1c905cfd0b4a58ae99", size = 110771, upload-time = "2026-07-08T12:26:12.303Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1203,6 +1344,69 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ae/f7d056eb0294586a572d0d0d89580ec633c064db520f11d37d5a2fb833bd/mypy-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:91ad22a52ae2c7e621c2f67c94d5a17f66b3209a4cff5cf8a573579835c69e97", size = 14947298, upload-time = "2026-07-13T11:27:47.734Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d5/db3e7af01e7844d21662c6ddc1f7825ec7cb4053f0391ac02faf3638396f/mypy-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:99ac767cc5d3b64c8d0ae226ead10c96694f94e4e7da1668642225dcd4e75aac", size = 13950768, upload-time = "2026-07-13T11:27:57.726Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/fb/43c031f0190513d1ec248ed037eceb742ddd2a4d74bbf406658a28173837/mypy-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de6d2c484742a4d7b0ed6d07b143375624d3b899c5749c7b3c947f56261f48a6", size = 14151586, upload-time = "2026-07-13T11:29:18.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c3/f8b2ffc60883084da91be51af58e88a7ffd4ff9795acb7d902ff88d31eb1/mypy-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7da939dd335cfd2ad788bdfd081c9f4e47634ab995e5a45eb15fd1e5bc052f8b", size = 15227411, upload-time = "2026-07-13T11:30:29.904Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2e/16b917fc7adcf03f1aadddfc93aab804ffb234b1ab09c0ffd6d92a5d34a2/mypy-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7247eb2824f996722a949530183394921ca71deb9680052a338cf53cff7925c2", size = 15478790, upload-time = "2026-07-13T11:33:14.686Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/88/aaa65a93c73d0cdae7e42f8adb302bf6885bb281302084f99d0290a35347/mypy-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:75b0984bb3cbd76bb5c9291a8671f7ae66ca3b51c7584c358fc2e923259f0757", size = 11234919, upload-time = "2026-07-13T11:33:39.28Z" },
+    { url = "https://files.pythonhosted.org/packages/35/19/b40de63f1a80e63bc2d40f0679a6a8dbd34e95176c8122119bdf406aa552/mypy-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:d78fcf900b59cb7e82cb7e3a235e31b462d9333d92285bd1e4952d355b8ffba1", size = 10201510, upload-time = "2026-07-13T11:31:52.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/58/fa0ae047da911f540284009b4f44b96fe09d83c076d7c103e9d645f46303/mypy-2.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ea317b060ce83e26050f8f9e4d7d6bf44ed7597c8ff9990bccffbb9d1d8522db", size = 14941909, upload-time = "2026-07-13T11:32:34.332Z" },
+    { url = "https://files.pythonhosted.org/packages/15/14/2ba1d61452d7c2a7fe12741e8d374e52b183476b07aa7f9e2a0d02b0720a/mypy-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:094af99f92638aa92852326188b85a89e50f4a472f44827c03362228482f0762", size = 13967581, upload-time = "2026-07-13T11:30:00.587Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/5a/483fb9e5ffbbb1a28dccc7b0a13d141b17ac769b6c9f488c0a0c63698962/mypy-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de121747278144fc9ae7caa2e978cf5df12aebc82933182f5b3b86081a30baef", size = 14168807, upload-time = "2026-07-13T11:28:48.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/77/70d7a10732063beb74ad713682cf871e88f5c5fa39bfc8beff8a524bf9cb/mypy-2.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:37fa4de896a84e2dc9200d91e614c22563b43d1a266789d4bbac7b22ebe6192b", size = 15200144, upload-time = "2026-07-13T11:31:25.283Z" },
+    { url = "https://files.pythonhosted.org/packages/56/72/766218ac783be4fdfcd699b90037b63017348a3e86fb2c1fbfb18302637d/mypy-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f1b3a98dfd21058bc759bb3337d5d1f61d0fdf9f3cf9c00f4291790fb5427bff", size = 15460389, upload-time = "2026-07-13T11:29:29.077Z" },
+    { url = "https://files.pythonhosted.org/packages/38/4e/8a9db7411ecb8ec0cb1fd05dba432f28bafffcd38b4e887714a4a0506689/mypy-2.3.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:944c665d984157cb96a679dfb7a4a81dd1d36b24b9c284b699514e6e626b82d4", size = 7753664, upload-time = "2026-07-13T11:29:08.147Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4c/c3f8bfd6ed0e5e38b5a244403b27f821d433443df5a15a278417c10a3a3c/mypy-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:4359424140d985192c778c1ce2c114a10c1ca58a381ed79cfa70d37df94b299f", size = 11417237, upload-time = "2026-07-13T11:33:47.467Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/00/89a32eaf5ccf174bc4f90db0eaea5d70636c01b8d49f384bdab2e8834390/mypy-2.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:3dd0bed92c4bdec57c42505b96416fb9e6a5aa7be84d2809bcd5f2ecec2860d7", size = 10389252, upload-time = "2026-07-13T11:31:43.81Z" },
+    { url = "https://files.pythonhosted.org/packages/31/56/104f93d69aa9f339b6b9d3b0a7faa699b8b466c942cf3ae86cc2a2ec0915/mypy-2.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:691fdc37132b1ae628d834f672e74de83462d9fb4aff621835767fb43a8dd373", size = 16385495, upload-time = "2026-07-13T11:29:49.818Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/03/f1d2123313f55efafdd27706960f43a771c62f1b68426c76043f3ab9ebf3/mypy-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:aec15d465d477558fd842757b487849007311cf3897849cdda0e3162ac0ac556", size = 15098155, upload-time = "2026-07-13T11:30:40.301Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/5d/d5f9200399b445e81726c4f23becee33f233aee81c72680b1ef3a258b641/mypy-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b352b7e49f5e6576009e8df730e1ff4f915cb565b851b396d2ffe2f5a6f5da88", size = 15514155, upload-time = "2026-07-13T11:34:38.569Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ce/69977c555f08faa3190cfde44189b89dbd56861b1ab97aa18fc5f3a2e4a3/mypy-2.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c6c6bf687b17f90dbfcad95b960d32eaa0154c00da45f03ab50bf8952e047fe", size = 16766351, upload-time = "2026-07-13T11:33:29.195Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/92/6648b6caa3ab9e00f9ac0c2a78307805f873dd48139b24a6f6f7c3667bbf/mypy-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f4ed18f111bfe2d599bca7468e7f9251042c1c2118f762c8de2766a56d773c60", size = 17043490, upload-time = "2026-07-13T11:30:53.927Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ab/0dc91d80f3f016634c68d451f294a97320fe903a9b6f90b9e57b3f7f1717/mypy-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0b025a93cffb9781d231f232be07a17912f35f10a313c24f301c81e842870654", size = 12146869, upload-time = "2026-07-13T11:29:38.874Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b5/4c964d02634ba81f4d1c84838e5c5b18ab06d13ed568960f5d6318495ccc/mypy-2.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:adebc76aab4f3495a88b41d48aa4aff0c03f2822501da76625afcca5975f19e5", size = 10965113, upload-time = "2026-07-13T11:28:07.056Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.45.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1264,6 +1468,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
 name = "phonenumbers"
 version = "9.0.34"
 source = { registry = "https://pypi.org/simple" }
@@ -1310,11 +1523,14 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "types-protobuf" },
 ]
 
 [package.metadata]
@@ -1334,11 +1550,30 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mypy", specifier = ">=1.17.0" },
+    { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "respx", specifier = ">=0.23.1" },
     { name = "ruff", specifier = ">=0.15.21" },
+    { name = "types-protobuf", specifier = ">=6.30.2" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -1651,6 +1886,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/81/58c70036dffeccb7fe7d79d6260c69f7a28272bbd3909c29a01ea9422744/python_discovery-1.4.4.tar.gz", hash = "sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3", size = 72212, upload-time = "2026-07-08T23:06:50.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/ae/84bc0d2440c95772272bb6f4b3d09ccf08b2898fce89b3d4f969a9fc74e9/python_discovery-1.4.4-py3-none-any.whl", hash = "sha256:abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe", size = 34181, upload-time = "2026-07-08T23:06:49.402Z" },
 ]
 
 [[package]]
@@ -2009,6 +2257,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-protobuf"
+version = "7.34.1.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/59/e2b13b499d15e6720150c4b1a8d91e31fcacf716b432397475b3151ff7e4/types_protobuf-7.34.1.20260518.tar.gz", hash = "sha256:28cfaded25889cb83ebfb63cfb0a43628f0b6f3785767bec17287dc6468795f2", size = 68936, upload-time = "2026-05-18T06:01:47.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/1f/ec5caf72c2e3b688ca3927e0979a04ddad19e1afc4bf1c199bd743e0f419/types_protobuf-7.34.1.20260518-py3-none-any.whl", hash = "sha256:a0a5337413347166439c0e07cbc26c6164d091401c6f01b1dfd8cdb966c4dd8f", size = 85992, upload-time = "2026-05-18T06:01:45.696Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2058,6 +2315,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/ec/dbb7e5a6b91f86bfb9eb7d2988a2730907b6a729875b949c7f022e8b88fa/uvicorn-0.51.0-py3-none-any.whl", hash = "sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b", size = 73219, upload-time = "2026-07-08T10:59:04.44Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/d9/b477fddb68840b570af8b22afe9b035cbc277b5fb7b33dea390617a8b10f/virtualenv-21.6.1.tar.gz", hash = "sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128", size = 5526620, upload-time = "2026-07-10T19:33:53.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/7c/4e7225d46d634a0d8d534dd8a6ce0c319d09b4d0cf0337eb314ca4789d8c/virtualenv-21.6.1-py3-none-any.whl", hash = "sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b", size = 5506392, upload-time = "2026-07-10T19:33:51.629Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Enable strict mypy (`[tool.mypy] strict = true`) with `DatabaseAccess` protocol typing for DB mixins, safer null handling in call mapping/teardown paths, and CI gate via `uv run mypy app`.
- Add local/pre-commit quality gates (ruff, large-file check, gitleaks, mypy), Dependabot for uv + GitHub Actions, and a Gitleaks secret-scan workflow.
- Document one-command Fly rollback (`flyctl releases rollback`) in README/AGENTS and expand `.gitignore` for IDE/OS/cache artifacts.

## Risks
- Low runtime risk: mostly typing annotations, tooling, and docs. Session update payload construction now uses typed models serialized with `exclude_none=True` (behavior preserved for existing Realtime payload expectations).
- Deploy path now runs mypy before pytest; type regressions will block production deploys.

## Validation
- `uv run mypy app` (clean under strict)
- `uv run ruff check app tests scripts`
- `uv run ruff format --check app tests scripts`
- `uv run pytest -q` (326 passed)
- `uv run pre-commit run --all-files` (all hooks pass)

## Test plan
- [x] Local mypy/ruff/pytest all green
- [ ] Confirm Dependabot PR creation after merge
- [ ] Confirm secret-scan workflow runs on PR/main
- [ ] Smoke one Fly rollback command against a non-prod release if available

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict typing and secret scanning, and documents a safe Fly rollback using a deployment lock and pinned image. CI now blocks on `mypy`, with local `pre-commit` gates for `ruff`, `mypy`, and `gitleaks`.

- New Features
  - Enforce strict `mypy` with a `DatabaseAccess` protocol; tighter types across DB, realtime, and tooling paths.
  - CI: run `uv run mypy app` in deploy workflow; add `gitleaks` scan pinned to a SHA with `pull-requests` read; enable Dependabot for `uv` and GitHub Actions.
  - Dev UX: add `pre-commit` hooks (`ruff`, `mypy`, `gitleaks`, large-file check) and expand `.gitignore`.
  - Docs: clarify that rolling back to a prior image does not restore Fly config, env vars, or secrets.

- Migration
  - Run `uv run pre-commit install`.
  - Before pushing: `uv run ruff check`, `uv run mypy app`, `uv run pytest -q`.
  - For rollback: acquire `/internal/deployment-lock`, list images with `flyctl releases --image`, redeploy with `flyctl deploy --image <ref>`; Fly config/env/secrets remain unchanged.

<sup>Written for commit f14ac1b340c053b2dd96b9db456cf6733b5f5111. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/XiyaoWang0519/poke-call/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

