### PR TITLE
Keep Poke polling during calls so ask_poke questions get answered

### DIFF
--- a/app/call_state.py
+++ b/app/call_state.py
@@ -67,11 +67,32 @@ TERMINATION_MEDIA_BACKGROUND_RETRY_MAX_SECONDS = 15.0
 WATCHDOG_QUESTION_GRACE_SECONDS = 2 * REALTIME_SEND_TIMEOUT_SECONDS + 5.0
 ASK_POKE_LOG_TEXT_LIMIT = 200
 
+# Poke (the MCP client) is an LLM agent: it reliably follows explicit next_action
+# directives embedded in tool RESULTS, but under-weights static tool descriptions. There
+# is no reliable out-of-band push to wake a Poke turn that has already ended, so every
+# response for a non-terminal call must repeat this warning to keep Poke long-polling —
+# otherwise a mid-call ask_poke question can arrive with nobody listening and time out.
+ASK_POKE_POLL_WARNING = (
+    "Do not end your turn and do not stop polling until the call reaches a terminal "
+    "state — if you stop, mid-call questions from the phone agent (ask_poke) will "
+    "time out and the call may fail its objective."
+)
+
 
 def _truncate_for_log(text: str, *, limit: int = ASK_POKE_LOG_TEXT_LIMIT) -> str:
     if len(text) <= limit:
         return text
     return text[:limit] + "…"
+
+
+def _seconds_until(iso_timestamp: str | None) -> float | None:
+    if not iso_timestamp:
+        return None
+    try:
+        target = datetime.fromisoformat(iso_timestamp)
+    except ValueError:
+        return None
+    return (target - datetime.now(UTC)).total_seconds()
 
 
 @dataclass(slots=True)
@@ -1400,7 +1421,13 @@ class CallService:
         # turn; resolve the question now so both delivery paths lose their claims.
         self._clear_pending_question(call_id)
         try:
-            await self.db.cancel_pending_questions(call_id)
+            cancelled = await self.db.cancel_pending_questions(call_id)
+            for cancelled_row in cancelled:
+                logger.info(
+                    "ask_poke question cancelled call_id=%s question_id=%s reason=voice_end_call",
+                    call_id,
+                    cancelled_row["question_id"],
+                )
         except Exception:
             logger.warning(
                 "pending question cancellation failed at end_call call_id=%s",
@@ -1813,6 +1840,12 @@ class CallService:
         await asyncio.sleep(self.settings.ask_poke_answer_timeout_seconds)
         if call_id in self._voice_end_pending:
             # end_call already cancels pending questions; the goodbye owns the sideband.
+            logger.info(
+                "ask_poke question cancelled call_id=%s question_id=%s "
+                "reason=voice_end_pending_owns_cancellation",
+                call_id,
+                question_id,
+            )
             return
         self._mark_question_delivering(call_id, question_id)
         try:
@@ -1828,6 +1861,12 @@ class CallService:
             # Lost the claim (answered, cancelled, or termination owns the call and
             # will cancel it); drop a stale watchdog carve-out entry left behind if
             # resolution raced our registration.
+            logger.info(
+                "ask_poke question cancelled call_id=%s question_id=%s "
+                "reason=expiry_claim_lost_race",
+                call_id,
+                question_id,
+            )
             self._clear_pending_question(call_id, question_id)
             return
         await self._cancel_active_response(call_id)
@@ -1916,16 +1955,33 @@ class CallService:
                     (event["sequence"] for event in events),
                     default=after,
                 )
+                pending_events = [event for event in events if event["status"] == "pending"]
                 if terminal:
-                    next_action = "Call is terminal; call get_call_result."
+                    next_action = (
+                        f"Call is terminal (state={state.value}). The call is over; stop "
+                        "polling and call get_call_result to retrieve the result."
+                    )
+                elif pending_events:
+                    question_event = pending_events[-1]
+                    answer_remaining = _seconds_until(question_event["deadline_at"])
+                    if answer_remaining is None:
+                        answer_remaining = self.settings.ask_poke_answer_timeout_seconds
+                    next_action = (
+                        "Answer immediately via answer_call_question with "
+                        f"question_id={question_event['question_id']}; you have "
+                        f"~{max(0, round(answer_remaining))}s. " + ASK_POKE_POLL_WARNING
+                    )
                 elif events:
                     next_action = (
-                        "New call events are available. Answer pending questions with "
-                        "answer_call_question, then wait again with next_after_sequence."
+                        "New call events are available but none are pending questions. Call "
+                        f"wait_for_call_event again NOW with after_sequence={next_after}. "
+                        + ASK_POKE_POLL_WARNING
                     )
                 else:
                     next_action = (
-                        "No new events; re-enter wait_for_call_event with the same after_sequence."
+                        "No new events. Call wait_for_call_event again NOW with "
+                        f"after_sequence={next_after}. The call is still in progress. "
+                        + ASK_POKE_POLL_WARNING
                     )
                 if events or terminal:
                     logger.info(
@@ -1985,7 +2041,14 @@ class CallService:
                 call_id,
                 question_id,
             )
-            return {"status": "accepted", "question_id": question_id}
+            return {
+                "status": "accepted",
+                "question_id": question_id,
+                "next_action": (
+                    "Answer accepted. Resume polling: call wait_for_call_event with "
+                    f"after_sequence={row['sequence_number']}. " + ASK_POKE_POLL_WARNING
+                ),
+            }
 
         existing = await self.db.get_question(question_id)
         if existing is None or existing.get("call_id") != call_id:
@@ -2030,7 +2093,14 @@ class CallService:
                     call_id,
                     question_id,
                 )
-                return {"status": "accepted", "question_id": question_id}
+                return {
+                    "status": "accepted",
+                    "question_id": question_id,
+                    "next_action": (
+                        "Answer accepted. Resume polling: call wait_for_call_event with "
+                        f"after_sequence={existing['sequence_number']}. " + ASK_POKE_POLL_WARNING
+                    ),
+                }
             logger.info(
                 "answer_call_question already_answered call_id=%s question_id=%s",
                 call_id,
@@ -2372,7 +2442,15 @@ class CallService:
                 # teardown and mark a question answered after the call left ACTIVE.
                 self._pending_questions.pop(call_id, None)
                 try:
-                    await self.db.cancel_pending_questions(call_id)
+                    cancelled = await self.db.cancel_pending_questions(call_id)
+                    for cancelled_row in cancelled:
+                        logger.info(
+                            "ask_poke question cancelled call_id=%s question_id=%s "
+                            "reason=termination_claim reason_code=%s",
+                            call_id,
+                            cancelled_row["question_id"],
+                            reason,
+                        )
                 except Exception:
                     logger.warning(
                         "pending question cancellation failed at termination claim call_id=%s",
@@ -2589,7 +2667,15 @@ class CallService:
             )
         self._clear_call_runtime_state(call_id)
         try:
-            await self.db.cancel_pending_questions(call_id)
+            cancelled = await self.db.cancel_pending_questions(call_id)
+            for cancelled_row in cancelled:
+                logger.info(
+                    "ask_poke question cancelled call_id=%s question_id=%s "
+                    "reason=termination_finished reason_code=%s",
+                    call_id,
+                    cancelled_row["question_id"],
+                    reason,
+                )
         except Exception:
             logger.warning(
                 "pending question cancellation failed call_id=%s", call_id, exc_info=True
@@ -2850,7 +2936,13 @@ class CallService:
 
     async def recover_startup(self) -> None:
         try:
-            await self.db.cancel_all_pending_questions()
+            cancelled = await self.db.cancel_all_pending_questions()
+            for cancelled_row in cancelled:
+                logger.info(
+                    "ask_poke question cancelled call_id=%s question_id=%s reason=startup_recovery",
+                    cancelled_row["call_id"],
+                    cancelled_row["question_id"],
+                )
         except Exception:
             logger.warning("startup could not cancel pending questions", exc_info=True)
         recovered: set[str] = set()

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -1860,9 +1860,10 @@ class CallService:
         if row is None:
             # Lost the claim (answered, cancelled, or termination owns the call and
             # will cancel it); drop a stale watchdog carve-out entry left behind if
-            # resolution raced our registration.
+            # resolution raced our registration. Not a cancellation — the winner
+            # already owns the final status.
             logger.info(
-                "ask_poke question cancelled call_id=%s question_id=%s "
+                "ask_poke question expiry claim lost call_id=%s question_id=%s "
                 "reason=expiry_claim_lost_race",
                 call_id,
                 question_id,
@@ -2106,7 +2107,13 @@ class CallService:
                 call_id,
                 question_id,
             )
-            return {"status": "already_answered"}
+            return {
+                "status": "already_answered",
+                "next_action": (
+                    "Question already answered. Resume polling: call wait_for_call_event "
+                    f"with after_sequence={existing['sequence_number']}. " + ASK_POKE_POLL_WARNING
+                ),
+            }
         if status == "expired":
             logger.info(
                 "answer_call_question expired call_id=%s question_id=%s",
@@ -2116,6 +2123,10 @@ class CallService:
             return {
                 "status": "expired",
                 "detail": "timeout already sent to the agent",
+                "next_action": (
+                    "Answer window already expired. Resume polling: call wait_for_call_event "
+                    f"with after_sequence={existing['sequence_number']}. " + ASK_POKE_POLL_WARNING
+                ),
             }
         if status == "cancelled":
             logger.info(
@@ -2141,7 +2152,13 @@ class CallService:
             call_id,
             question_id,
         )
-        return {"status": "already_answered"}
+        return {
+            "status": "already_answered",
+            "next_action": (
+                "Question already handled. Resume polling: call wait_for_call_event "
+                f"with after_sequence={existing['sequence_number']}. " + ASK_POKE_POLL_WARNING
+            ),
+        }
 
     async def _handle_voice_end_response_done(self, call_id: str, event: dict[str, Any]) -> None:
         pending = self._voice_end_pending.get(call_id)

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -54,9 +54,15 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
         name="start_phone_call",
         description=(
             "Start only a valid, unexpired prepared plan after explicit owner confirmation. "
-            "Pass the confirmation text that was read back. Then call wait_for_call_event; answer "
-            "pending questions with answer_call_question, continue waiting with the returned cursor, "
-            "and call get_call_result once the call is terminal. " + CONTEXT_GUIDANCE
+            "Pass the confirmation text that was read back. Then IMMEDIATELY begin calling "
+            "wait_for_call_event in a loop, calling it again right after every response, "
+            "until the call reaches a terminal state; answer pending questions with "
+            "answer_call_question, continue waiting with the returned cursor, and call "
+            "get_call_result once the call is terminal. Do not end your turn between calls: "
+            "this tool starts a live phone call, and the phone agent on the call may ask a "
+            "question (via ask_poke) at any moment that only YOU can answer by staying in the "
+            "wait_for_call_event loop — if you stop polling, that question times out and the "
+            "call can fail its objective. " + CONTEXT_GUIDANCE
         ),
     )
     async def start_phone_call(
@@ -111,7 +117,14 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
         description=(
             "Long-poll for mid-call questions or terminal state after a sequence cursor. "
             "Returns immediately when events exist; on idle timeout returns an empty events list "
-            "(never an error). Re-enter with next_after_sequence. " + CONTEXT_GUIDANCE
+            "(never an error) — this is NOT a stopping condition. Re-enter with "
+            "next_after_sequence immediately, in a loop, for as long as the call is "
+            "non-terminal; read and follow the response's next_action field every time, which "
+            "tells you exactly what to do next. Never end your turn while the call is "
+            "non-terminal: the phone agent can raise a mid-call question (ask_poke) at any "
+            "moment, and if nothing is polling, that question times out and the call can fail "
+            "its objective. Only stop once a response reports terminal=true, then call "
+            "get_call_result. " + CONTEXT_GUIDANCE
         ),
     )
     async def wait_for_call_event(
@@ -160,9 +173,11 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
     @mcp.tool(
         name="answer_call_question",
         description=(
-            "Answer one pending mid-call question from the voice agent. Exactly-once: a second "
-            "answer returns already_answered; late answers after timeout return expired. "
-            + CONTEXT_GUIDANCE
+            "Answer one pending mid-call question from the voice agent, as soon as it arrives "
+            "from wait_for_call_event — the callee is waiting live on the phone. Exactly-once: "
+            "a second answer returns already_answered; late answers after timeout return "
+            "expired. After answering, immediately resume the wait_for_call_event loop until "
+            "the call is terminal; do not end your turn. " + CONTEXT_GUIDANCE
         ),
     )
     async def answer_call_question(call_id: str, question_id: str, answer: str) -> dict[str, Any]:

--- a/app/models.py
+++ b/app/models.py
@@ -112,8 +112,13 @@ class StartPhoneCallOutput(BaseModel):
     state: CallState
     poll_after_seconds: int = 2
     next_action: str = (
-        "Call wait_for_call_event. Answer pending questions with answer_call_question and continue "
-        "waiting with next_after_sequence; when terminal, call get_call_result."
+        "The call has started. Immediately begin calling wait_for_call_event in a loop "
+        "with the returned next_after_sequence, and keep calling it again NOW after every "
+        "response until the call reaches a terminal state. Answer pending questions with "
+        "answer_call_question, then resume the wait_for_call_event loop. Do not end your "
+        "turn and do not stop polling until the call is terminal — if you stop, mid-call "
+        "questions from the phone agent (ask_poke) will time out and the call may fail its "
+        "objective. When terminal, call get_call_result."
     )
 
 

--- a/scripts/ask_poke_latency_probe.py
+++ b/scripts/ask_poke_latency_probe.py
@@ -197,7 +197,5 @@ async def probe_results(request: Request) -> dict:
     if not secrets.compare_digest(supplied, f"Bearer {BEARER_TOKEN}"):
         raise HTTPException(status_code=401, detail="unauthorized")
     return {
-        "probes": [
-            {"probe": asdict(probe), "timing": timing(probe)} for probe in PROBES.values()
-        ]
+        "probes": [{"probe": asdict(probe), "timing": timing(probe)} for probe in PROBES.values()]
     }

--- a/scripts/ask_poke_latency_probe.py
+++ b/scripts/ask_poke_latency_probe.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import asdict, dataclass
+from os import environ
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException, Request
+from fastmcp import FastMCP
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+@dataclass
+class Probe:
+    probe_id: str
+    question: str
+    delay_seconds: float
+    started_at: float
+    wait_entered_at: float | None = None
+    question_returned_at: float | None = None
+    answer_received_at: float | None = None
+    answer: str | None = None
+
+
+PROBES: dict[str, Probe] = {}
+BEARER_TOKEN = environ["PROBE_BEARER_TOKEN"]
+mcp = FastMCP("Ask Poke No-Call Probe")
+
+
+class BearerAuthMiddleware:
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        headers = {key.lower(): value for key, value in scope.get("headers", [])}
+        supplied = headers.get(b"authorization", b"").decode("latin-1")
+        if secrets.compare_digest(supplied, f"Bearer {BEARER_TOKEN}"):
+            await self.app(scope, receive, send)
+            return
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b'{"detail":"unauthorized"}'})
+
+
+def require_probe(probe_id: str) -> Probe:
+    probe = PROBES.get(probe_id)
+    if probe is None:
+        raise ValueError("unknown probe_id")
+    return probe
+
+
+def timing(probe: Probe) -> dict[str, float | None]:
+    def elapsed(end: float | None, start: float | None) -> float | None:
+        if end is None or start is None:
+            return None
+        return round(end - start, 3)
+
+    return {
+        "start_to_wait_seconds": elapsed(probe.wait_entered_at, probe.started_at),
+        "wait_to_question_seconds": elapsed(probe.question_returned_at, probe.wait_entered_at),
+        "poke_answer_seconds": elapsed(probe.answer_received_at, probe.question_returned_at),
+        "total_seconds": elapsed(probe.answer_received_at, probe.started_at),
+    }
+
+
+@mcp.tool(
+    name="start_ask_poke_probe",
+    description=(
+        "Start a no-phone-call test of Poke's ability to remain in an MCP tool chain, long-poll "
+        "for a question, and submit an answer. Always follow the returned next_action."
+    ),
+)
+async def start_ask_poke_probe(question: str, delay_seconds: float = 5.0) -> dict:
+    if not question.strip() or len(question) > 500:
+        raise ValueError("question must contain 1-500 characters")
+    if not 1 <= delay_seconds <= 25:
+        raise ValueError("delay_seconds must be between 1 and 25")
+    probe_id = uuid4().hex
+    PROBES[probe_id] = Probe(
+        probe_id=probe_id,
+        question=" ".join(question.split()),
+        delay_seconds=delay_seconds,
+        started_at=time.time(),
+    )
+    return {
+        "status": "started",
+        "probe_id": probe_id,
+        "next_action": (
+            "Immediately call wait_for_ask_poke_probe with this probe_id and "
+            "timeout_seconds=20. If it returns status=idle, call it again. When it returns a "
+            "question, answer it using submit_ask_poke_probe_answer. Do not answer only in chat."
+        ),
+    }
+
+
+@mcp.tool(
+    name="wait_for_ask_poke_probe",
+    description=(
+        "Long-poll for a no-call probe question. On status=idle, call this tool again. On "
+        "status=question, use submit_ask_poke_probe_answer with the same probe_id."
+    ),
+)
+async def wait_for_ask_poke_probe(probe_id: str, timeout_seconds: float = 20.0) -> dict:
+    probe = require_probe(probe_id)
+    if probe.answer_received_at is not None:
+        return {"status": "answered", "probe_id": probe_id, "timing": timing(probe)}
+    if probe.wait_entered_at is None:
+        probe.wait_entered_at = time.time()
+    timeout_seconds = min(max(timeout_seconds, 0.0), 25.0)
+    ready_at = probe.started_at + probe.delay_seconds
+    remaining = max(0.0, ready_at - time.time())
+    await asyncio.sleep(min(remaining, timeout_seconds))
+    if time.time() < ready_at:
+        return {
+            "status": "idle",
+            "probe_id": probe_id,
+            "next_action": "Call wait_for_ask_poke_probe again with the same probe_id.",
+        }
+    if probe.question_returned_at is None:
+        probe.question_returned_at = time.time()
+    return {
+        "status": "question",
+        "probe_id": probe_id,
+        "question": probe.question,
+        "next_action": (
+            "Answer this question now using submit_ask_poke_probe_answer. Pass the same probe_id "
+            "and your answer. Do not answer only in chat."
+        ),
+    }
+
+
+@mcp.tool(
+    name="submit_ask_poke_probe_answer",
+    description="Submit Poke's answer to a no-call probe and return exact end-to-end timing.",
+)
+async def submit_ask_poke_probe_answer(probe_id: str, answer: str) -> dict:
+    probe = require_probe(probe_id)
+    if probe.question_returned_at is None:
+        raise ValueError("question has not been returned to Poke yet")
+    if not answer.strip() or len(answer) > 4096:
+        raise ValueError("answer must contain 1-4096 characters")
+    if probe.answer_received_at is None:
+        probe.answer_received_at = time.time()
+        probe.answer = " ".join(answer.split())
+    return {
+        "status": "completed",
+        "probe_id": probe_id,
+        "answer": probe.answer,
+        "timing": timing(probe),
+    }
+
+
+@mcp.tool(name="get_ask_poke_probe_result")
+async def get_ask_poke_probe_result(probe_id: str) -> dict:
+    probe = require_probe(probe_id)
+    return {"probe": asdict(probe), "timing": timing(probe)}
+
+
+mcp_http_app = mcp.http_app(
+    path="/",
+    transport="streamable-http",
+    stateless_http=True,
+    json_response=True,
+)
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+    async with mcp_http_app.lifespan(_):
+        yield
+
+
+app = FastAPI(lifespan=lifespan)
+app.mount("/mcp", BearerAuthMiddleware(mcp_http_app))
+
+
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/probe-results")
+async def probe_results(request: Request) -> dict:
+    supplied = request.headers.get("authorization", "")
+    if not secrets.compare_digest(supplied, f"Bearer {BEARER_TOKEN}"):
+        raise HTTPException(status_code=401, detail="unauthorized")
+    return {
+        "probes": [
+            {"probe": asdict(probe), "timing": timing(probe)} for probe in PROBES.values()
+        ]
+    }

--- a/scripts/ask_poke_latency_probe.py
+++ b/scripts/ask_poke_latency_probe.py
@@ -13,6 +13,10 @@ from fastapi import FastAPI, HTTPException, Request
 from fastmcp import FastMCP
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+# Bound in-memory probe retention so a long-running process cannot grow without limit.
+MAX_PROBES = 50
+PROBE_TTL_SECONDS = 3600.0
+
 
 @dataclass
 class Probe:
@@ -54,7 +58,31 @@ class BearerAuthMiddleware:
         await send({"type": "http.response.body", "body": b'{"detail":"unauthorized"}'})
 
 
+def _prune_probes(now: float | None = None) -> None:
+    """Drop stale/completed probes and enforce a hard cap on retained entries."""
+    clock = time.monotonic() if now is None else now
+    stale = [
+        probe_id
+        for probe_id, probe in PROBES.items()
+        if clock - probe.started_at > PROBE_TTL_SECONDS
+        or (
+            probe.answer_received_at is not None
+            and clock - probe.answer_received_at > PROBE_TTL_SECONDS
+        )
+    ]
+    for probe_id in stale:
+        PROBES.pop(probe_id, None)
+    if len(PROBES) <= MAX_PROBES:
+        return
+    overflow = sorted(PROBES.values(), key=lambda probe: probe.started_at)[
+        : len(PROBES) - MAX_PROBES
+    ]
+    for probe in overflow:
+        PROBES.pop(probe.probe_id, None)
+
+
 def require_probe(probe_id: str) -> Probe:
+    _prune_probes()
     probe = PROBES.get(probe_id)
     if probe is None:
         raise ValueError("unknown probe_id")
@@ -87,12 +115,13 @@ async def start_ask_poke_probe(question: str, delay_seconds: float = 5.0) -> dic
         raise ValueError("question must contain 1-500 characters")
     if not 1 <= delay_seconds <= 25:
         raise ValueError("delay_seconds must be between 1 and 25")
+    _prune_probes()
     probe_id = uuid4().hex
     PROBES[probe_id] = Probe(
         probe_id=probe_id,
         question=" ".join(question.split()),
         delay_seconds=delay_seconds,
-        started_at=time.time(),
+        started_at=time.monotonic(),
     )
     return {
         "status": "started",
@@ -117,19 +146,19 @@ async def wait_for_ask_poke_probe(probe_id: str, timeout_seconds: float = 20.0) 
     if probe.answer_received_at is not None:
         return {"status": "answered", "probe_id": probe_id, "timing": timing(probe)}
     if probe.wait_entered_at is None:
-        probe.wait_entered_at = time.time()
+        probe.wait_entered_at = time.monotonic()
     timeout_seconds = min(max(timeout_seconds, 0.0), 25.0)
     ready_at = probe.started_at + probe.delay_seconds
-    remaining = max(0.0, ready_at - time.time())
+    remaining = max(0.0, ready_at - time.monotonic())
     await asyncio.sleep(min(remaining, timeout_seconds))
-    if time.time() < ready_at:
+    if time.monotonic() < ready_at:
         return {
             "status": "idle",
             "probe_id": probe_id,
             "next_action": "Call wait_for_ask_poke_probe again with the same probe_id.",
         }
     if probe.question_returned_at is None:
-        probe.question_returned_at = time.time()
+        probe.question_returned_at = time.monotonic()
     return {
         "status": "question",
         "probe_id": probe_id,
@@ -152,7 +181,7 @@ async def submit_ask_poke_probe_answer(probe_id: str, answer: str) -> dict:
     if not answer.strip() or len(answer) > 4096:
         raise ValueError("answer must contain 1-4096 characters")
     if probe.answer_received_at is None:
-        probe.answer_received_at = time.time()
+        probe.answer_received_at = time.monotonic()
         probe.answer = " ".join(answer.split())
     return {
         "status": "completed",
@@ -196,6 +225,7 @@ async def probe_results(request: Request) -> dict:
     supplied = request.headers.get("authorization", "")
     if not secrets.compare_digest(supplied, f"Bearer {BEARER_TOKEN}"):
         raise HTTPException(status_code=401, detail="unauthorized")
+    _prune_probes()
     return {
         "probes": [{"probe": asdict(probe), "timing": timing(probe)} for probe in PROBES.values()]
     }

--- a/scripts/ask_poke_latency_probe.py
+++ b/scripts/ask_poke_latency_probe.py
@@ -58,8 +58,16 @@ class BearerAuthMiddleware:
         await send({"type": "http.response.body", "body": b'{"detail":"unauthorized"}'})
 
 
+def _probe_is_complete(probe: Probe) -> bool:
+    return probe.answer_received_at is not None
+
+
 def _prune_probes(now: float | None = None) -> None:
-    """Drop stale/completed probes and enforce a hard cap on retained entries."""
+    """Drop TTL-expired probes, then evict oldest completed ones down to MAX_PROBES.
+
+    In-flight probes are never evicted by the capacity cap — a new start must fail
+    instead when every retained slot is still active.
+    """
     clock = time.monotonic() if now is None else now
     stale = [
         probe_id
@@ -72,12 +80,14 @@ def _prune_probes(now: float | None = None) -> None:
     ]
     for probe_id in stale:
         PROBES.pop(probe_id, None)
-    if len(PROBES) <= MAX_PROBES:
+    overflow = len(PROBES) - MAX_PROBES
+    if overflow <= 0:
         return
-    overflow = sorted(PROBES.values(), key=lambda probe: probe.started_at)[
-        : len(PROBES) - MAX_PROBES
-    ]
-    for probe in overflow:
+    completed = sorted(
+        (probe for probe in PROBES.values() if _probe_is_complete(probe)),
+        key=lambda probe: probe.started_at,
+    )
+    for probe in completed[:overflow]:
         PROBES.pop(probe.probe_id, None)
 
 
@@ -116,6 +126,18 @@ async def start_ask_poke_probe(question: str, delay_seconds: float = 5.0) -> dic
     if not 1 <= delay_seconds <= 25:
         raise ValueError("delay_seconds must be between 1 and 25")
     _prune_probes()
+    if len(PROBES) >= MAX_PROBES:
+        completed = sorted(
+            (probe for probe in PROBES.values() if _probe_is_complete(probe)),
+            key=lambda probe: probe.started_at,
+        )
+        needed = len(PROBES) - MAX_PROBES + 1
+        if len(completed) < needed:
+            raise ValueError(
+                f"too many active probes (max {MAX_PROBES}); wait for one to finish or expire"
+            )
+        for probe in completed[:needed]:
+            PROBES.pop(probe.probe_id, None)
     probe_id = uuid4().hex
     PROBES[probe_id] = Probe(
         probe_id=probe_id,

--- a/tests/test_ask_poke.py
+++ b/tests/test_ask_poke.py
@@ -87,7 +87,9 @@ async def test_answer_delivers_correlated_output_and_continuation(ask_service, p
     result = await ask_service.answer_call_question(call_id, question_id, "CVS on Market Street")
     await wait_background()
 
-    assert result == {"status": "accepted", "question_id": question_id}
+    assert result["status"] == "accepted"
+    assert result["question_id"] == question_id
+    assert "wait_for_call_event" in result["next_action"]
     assert ask_service._test_realtime.tool_results[-1] == (
         call_id,
         "tc_1",
@@ -389,7 +391,9 @@ async def test_wait_for_call_event_terminating_is_not_terminal(ask_service, pack
     assert result["terminal"] is False
     assert result["state"] == CallState.TERMINATING.value
     assert "get_call_result" not in result["next_action"]
-    assert "re-enter wait_for_call_event" in result["next_action"]
+    assert "Call wait_for_call_event again NOW" in result["next_action"]
+    assert "do not stop polling" in result["next_action"]
+    assert "ask_poke" in result["next_action"]
 
 
 @pytest.mark.asyncio
@@ -423,6 +427,12 @@ async def test_wait_for_call_event_timeout_returns_empty_events(ask_service, pac
     assert result["events"] == []
     assert result["terminal"] is False
     assert result["state"] == CallState.ACTIVE.value
+    # The idle-timeout response must still drive Poke to keep polling — an empty
+    # events list is not a stopping condition (see the ask_poke keep-polling incident).
+    assert "Call wait_for_call_event again NOW" in result["next_action"]
+    assert "after_sequence=0" in result["next_action"]
+    assert "do not stop polling" in result["next_action"]
+    assert "ask_poke" in result["next_action"]
 
 
 @pytest.mark.asyncio
@@ -634,7 +644,9 @@ async def test_failed_answer_delivery_is_retryable(ask_service, packet):
     retry = await ask_service.answer_call_question(call_id, question_id, "ignored retry text")
     await wait_background()
 
-    assert retry == {"status": "accepted", "question_id": question_id}
+    assert retry["status"] == "accepted"
+    assert retry["question_id"] == question_id
+    assert "wait_for_call_event" in retry["next_action"]
     delivered = [r for r in ask_service._test_realtime.tool_results if r[1] == "tc_retry"]
     assert len(delivered) == 1
     # The originally claimed answer wins; the retry only re-attempts delivery.

--- a/tests/test_ask_poke.py
+++ b/tests/test_ask_poke.py
@@ -124,6 +124,8 @@ async def test_timeout_exactly_once_then_answer_is_expired(ask_service, packet):
     late = await ask_service.answer_call_question(call_id, question_id, "too late")
     await wait_background()
     assert late["status"] == "expired"
+    assert "wait_for_call_event" in late["next_action"]
+    assert f"after_sequence={row['sequence_number']}" in late["next_action"]
     assert len([r for r in ask_service._test_realtime.tool_results if r[1] == "tc_timeout"]) == 1
 
 
@@ -161,6 +163,8 @@ async def test_duplicate_answer_idempotent_and_unknown_question_errors(ask_servi
     await wait_background()
     assert first["status"] == "accepted"
     assert second["status"] == "already_answered"
+    assert "wait_for_call_event" in second["next_action"]
+    assert f"after_sequence={rows[0]['sequence_number']}" in second["next_action"]
     assert len([r for r in ask_service._test_realtime.tool_results if r[1] == "tc_1"]) == 1
 
     with pytest.raises(LookupError, match="unknown question"):
@@ -656,6 +660,7 @@ async def test_failed_answer_delivery_is_retryable(ask_service, packet):
     third = await ask_service.answer_call_question(call_id, question_id, "again")
     await wait_background()
     assert third["status"] == "already_answered"
+    assert "wait_for_call_event" in third["next_action"]
     assert len([r for r in ask_service._test_realtime.tool_results if r[1] == "tc_retry"]) == 1
 
 


### PR DESCRIPTION
## Problem

A live `ask_poke` test call failed: the voice agent's question was registered server-side (`ask_poke asked` at 13:16:46) but timed out with no answer. Root cause from the fly logs: Poke did exactly one empty `wait_for_call_event` long-poll right after `start_phone_call` (13:16:00–13:16:20), then ended its agent turn — nobody was listening when the question arrived 26 seconds later.

The Poke inbound-API push (the intended wake-up nudge, `POKE_PUSH_ENABLED`) was verified non-functional: messages are acknowledged with HTTP 200 but never delivered to the assistant (4/4 attempts across two days, both endpoints, two API keys — likely related to the iMessage→business-channel migration). So the only reliable delivery mechanism is keeping Poke parked in the long-poll.

## Fix

- **Every MCP tool response now drives the polling loop.** `wait_for_call_event`, `start_phone_call`, and `answer_call_question` results carry explicit `next_action` directives — computed from the actual response (after_sequence, question_id, remaining answer window) — telling Poke to immediately re-poll until the call is terminal, answer pending questions right away, and never end its turn mid-call. A prior latency probe showed Poke follows response-level `next_action` directives faithfully, while static descriptions are cached and under-weighted.
- **Tool descriptions restate the same contract** as a backup channel.
- **Silent question-cancellation paths now log.** Six paths (deadline races, termination claim/finish, startup recovery, voice `end_call`) killed pending questions with zero output — which is why the original incident showed no timeout log. All now emit `ask_poke question cancelled ... reason=...`.
- `scripts/ask_poke_latency_probe.py`: recovered synthetic MCP probe from a prior Codex session for measuring the ask_poke round trip without a billable call.

## Testing

- `uv run pytest -q`: 326 passed (includes new regression assertions on the idle-timeout `next_action` directive)
- `ruff check`, `ruff format --check`, `mypy app`: clean
- Follow-up after deploy: live test call watching for repeated `wait_for_call_event` polls and an `ask_poke answer delivered` log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep Poke long-polling during live calls so mid-call `ask_poke` questions are received and answered instead of timing out. Adds explicit `next_action` guidance on all call-tool responses, richer cancellation/race logs, and a bearer-protected no-call latency probe.

- **Bug Fixes**
  - All call tools now return `next_action` that drives an immediate re-poll loop until terminal; `wait_for_call_event` tells you to answer pending questions now (with ~seconds remaining) or poll again NOW with the right `after_sequence`; terminal responses say to stop and call `get_call_result`.
  - `answer_call_question` always returns a “resume polling” directive for `accepted`, `already_answered`, and `expired`; `StartPhoneCallOutput.next_action` instructs an immediate polling loop.
  - Added logs for previously silent question cancellations and expiry-claim races (voice `end_call`, termination claim/finish with reason codes, watchdog expiry, startup recovery) with call/question IDs and reasons.

- **New Features**
  - Added `scripts/ask_poke_latency_probe.py`: a bearer-protected `FastAPI` app exposing `fastmcp` tools (`start_ask_poke_probe`, `wait_for_ask_poke_probe`, `submit_ask_poke_probe_answer`, `get_ask_poke_probe_result`) to measure `ask_poke` latency without a phone call; uses monotonic timing and bounded in-memory retention that never evicts in-flight probes (evicts oldest completed ones; rejects new starts when all slots are active).

<sup>Written for commit b8985139b9e9d2b860b934e85c1e68b87f61873a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/XiyaoWang0519/poke-call/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

