### PR TITLE
Require AskPoke source checks before not_found answers

### DIFF
--- a/app/call_state.py
+++ b/app/call_state.py
@@ -1959,11 +1959,16 @@ class CallService:
                     if answer_remaining is None:
                         answer_remaining = self.settings.ask_poke_answer_timeout_seconds
                     next_action = (
-                        "Answer immediately via answer_call_question with "
+                        "Begin the required retrieval now for "
                         f"question_id={question_event['question_id']}; you have "
-                        f"~{max(0, round(answer_remaining))}s. Finish all relevant checks "
-                        "first, then answer once with only the final, ready-to-relay result "
-                        "and no progress update such as 'I'm still checking'. "
+                        f"~{max(0, round(answer_remaining))}s. Accuracy is more important than "
+                        "speed within that window. For owner-specific facts, search poke_memory "
+                        "and conversation_history first, then relevant integrations. A miss in one "
+                        "source is not a not_found result, and call context such as 'this is a test' "
+                        "does not make the question optional. Call answer_call_question once with "
+                        "only the final, ready-to-relay result, its resolution, and the sources "
+                        "actually checked. resolution=not_found requires both poke_memory and "
+                        "conversation_history in sources_checked. Do not send a progress update. "
                         + ASK_POKE_POLL_WARNING
                     )
                 elif events:

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -10,7 +10,13 @@ from fastmcp.exceptions import ToolError
 from pydantic import ValidationError
 
 from app.call_state import CallService
-from app.models import AnswerCallQuestionRequest, ContextPacket, PreparePhoneCallInput
+from app.models import (
+    AnswerCallQuestionRequest,
+    ContextPacket,
+    PreparePhoneCallInput,
+    QuestionResolution,
+    QuestionSource,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -174,30 +180,44 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
         name="answer_call_question",
         description=(
             "Submit the final answer to one pending mid-call question from the voice agent — "
-            "the callee is waiting live on the phone. Finish all relevant checks in Poke "
-            "memory and integrations before calling this tool: the answer is relayed to the "
-            "callee immediately and accepted exactly once. The answer must contain only the "
-            "final, ready-to-relay result. Never submit a progress update, partial result, or "
-            "promise to keep checking (for example, 'one sec', 'I'm still looking', or 'let "
-            "me check further'). If the requested fact cannot be found after checking, submit "
-            "a conclusive final answer saying that and include only useful confirmed facts. "
-            "A second answer returns already_answered; late answers after timeout return "
-            "expired. After answering, immediately resume the wait_for_call_event loop until "
-            "the call is terminal; do not end your turn. " + CONTEXT_GUIDANCE
+            "the callee is waiting live on the phone. Begin retrieval immediately, but prioritize "
+            "accuracy over speed within the remaining deadline. For owner-specific facts, search "
+            "Poke memory and conversation history first, then relevant integrations such as "
+            "email. A miss in one source does not mean the answer is unavailable, and call context "
+            "such as 'this is a test' does not make the requested fact optional. The answer is "
+            "relayed to the callee immediately and accepted exactly once, so it must contain only "
+            "the final, ready-to-relay result. Never submit a progress update, partial result, or "
+            "promise to keep checking. Set resolution=not_found only after checking both "
+            "poke_memory and conversation_history and include them in sources_checked; otherwise "
+            "the submission is rejected and the question remains pending. A second accepted answer "
+            "returns already_answered; late answers after timeout return expired. After answering, "
+            "immediately resume the wait_for_call_event loop until the call is terminal; do not end "
+            "your turn. " + CONTEXT_GUIDANCE
         ),
     )
-    async def answer_call_question(call_id: str, question_id: str, answer: str) -> dict[str, Any]:
+    async def answer_call_question(
+        call_id: str,
+        question_id: str,
+        answer: str,
+        resolution: QuestionResolution,
+        sources_checked: list[QuestionSource],
+    ) -> dict[str, Any]:
         logger.info(
-            "mcp tool answer_call_question call_id=%s question_id=%s answer_chars=%s",
+            "mcp tool answer_call_question call_id=%s question_id=%s answer_chars=%s "
+            "resolution=%s sources_checked=%s",
             call_id,
             question_id,
             len(answer),
+            resolution.value,
+            ",".join(source.value for source in sources_checked),
         )
         try:
             request = AnswerCallQuestionRequest(
                 call_id=call_id,
                 question_id=question_id,
                 answer=answer,
+                resolution=resolution,
+                sources_checked=sources_checked,
             )
         except ValidationError as exc:
             logger.info(
@@ -205,7 +225,26 @@ def register_tools(mcp: FastMCP, get_service: Callable[[], CallService]) -> None
                 call_id,
                 question_id,
             )
-            raise ToolError(str(exc)) from exc
+            issues = [
+                {
+                    "field": ".".join(str(part) for part in error["loc"]) or "request",
+                    "message": error["msg"],
+                }
+                for error in exc.errors(include_input=False, include_url=False)
+            ]
+            raise ToolError(
+                json.dumps(
+                    {
+                        "code": "invalid_answer_submission",
+                        "message": "Answer rejected; the question remains pending.",
+                        "issues": issues,
+                        "next_action": (
+                            "Complete the missing source checks and retry "
+                            "answer_call_question before the original deadline."
+                        ),
+                    }
+                )
+            ) from exc
         try:
             result = await get_service().answer_call_question(
                 request.call_id,

--- a/app/models.py
+++ b/app/models.py
@@ -114,9 +114,10 @@ class StartPhoneCallOutput(BaseModel):
     next_action: str = (
         "The call has started. Immediately begin calling wait_for_call_event in a loop "
         "with the returned next_after_sequence, and keep calling it again NOW after every "
-        "response until the call reaches a terminal state. For each pending question, finish "
-        "all relevant checks and use answer_call_question once with only the final, "
-        "ready-to-relay result, never an intermediate 'I'm checking' update, then resume the "
+        "response until the call reaches a terminal state. For each pending question, follow the "
+        "returned source-check instructions, prioritize accuracy within the answer deadline, and "
+        "use answer_call_question once with only the final, ready-to-relay result and source "
+        "attestation, never an intermediate 'I'm checking' update, then resume the "
         "wait_for_call_event loop. Do not end your turn and do not stop polling until the "
         "call is terminal — if you stop, mid-call questions from the phone agent (ask_poke) "
         "will time out and the call may fail its objective. When terminal, call "
@@ -334,6 +335,20 @@ class QuestionStatus(StrEnum):
     CANCELLED = "cancelled"
 
 
+class QuestionResolution(StrEnum):
+    FOUND = "found"
+    NOT_FOUND = "not_found"
+
+
+class QuestionSource(StrEnum):
+    POKE_MEMORY = "poke_memory"
+    CONVERSATION_HISTORY = "conversation_history"
+    EMAIL = "email"
+    CALENDAR = "calendar"
+    DRIVE = "drive"
+    OTHER = "other"
+
+
 class AskPokeRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -363,6 +378,20 @@ class AnswerCallQuestionRequest(BaseModel):
     call_id: str = Field(min_length=1, max_length=120)
     question_id: str = Field(min_length=1, max_length=120)
     answer: str = Field(min_length=1, max_length=4096)
+    resolution: QuestionResolution = Field(
+        description=(
+            "Use found only for a confirmed answer. Use not_found only after the required "
+            "owner-specific sources were searched."
+        )
+    )
+    sources_checked: list[QuestionSource] = Field(
+        min_length=1,
+        max_length=len(QuestionSource),
+        description=(
+            "Sources actually checked before submitting. For owner-specific facts, search "
+            "poke_memory and conversation_history before relevant integrations."
+        ),
+    )
 
     @field_validator("answer")
     @classmethod
@@ -373,6 +402,21 @@ class AnswerCallQuestionRequest(BaseModel):
         if len(stripped.encode("utf-8")) > 4096:
             raise ValueError("answer exceeds 4096 UTF-8 bytes")
         return stripped
+
+    @model_validator(mode="after")
+    def validate_sources_checked(self) -> AnswerCallQuestionRequest:
+        if len(set(self.sources_checked)) != len(self.sources_checked):
+            raise ValueError("sources_checked must not contain duplicates")
+        if self.resolution is QuestionResolution.NOT_FOUND:
+            required = {
+                QuestionSource.POKE_MEMORY,
+                QuestionSource.CONVERSATION_HISTORY,
+            }
+            missing = required.difference(self.sources_checked)
+            if missing:
+                names = ", ".join(sorted(source.value for source in missing))
+                raise ValueError("not_found answers require sources_checked to include " + names)
+        return self
 
 
 class AdvisoryOutcome(BaseModel):

--- a/tests/test_ask_poke.py
+++ b/tests/test_ask_poke.py
@@ -9,10 +9,17 @@ from types import SimpleNamespace
 
 import pytest
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 
 from app.call_state import WATCHDOG_QUESTION_GRACE_SECONDS, PendingQuestion
 from app.mcp_tools import register_tools
-from app.models import CallState, StartPhoneCallOutput
+from app.models import (
+    AnswerCallQuestionRequest,
+    CallState,
+    QuestionResolution,
+    QuestionSource,
+    StartPhoneCallOutput,
+)
 from app.openai_realtime import RealtimeBridge
 from tests.conftest import seed_call, wait_background
 
@@ -50,6 +57,7 @@ def test_start_phone_call_output_routes_monitoring_through_event_poll():
     assert "wait_for_call_event" in output.next_action
     assert "answer_call_question" in output.next_action
     assert "only the final, ready-to-relay result" in output.next_action
+    assert "source attestation" in output.next_action
     assert "I'm checking" in output.next_action
     assert "get_call_result" in output.next_action
 
@@ -80,7 +88,7 @@ async def test_ask_persists_without_immediate_tool_output(ask_service, packet):
 
 
 @pytest.mark.asyncio
-async def test_question_event_requires_final_answer_after_checks(ask_service, packet):
+async def test_question_event_prioritizes_required_sources_over_speed(ask_service, packet):
     call_id = await seed_call(ask_service.db, packet, state=CallState.ACTIVE)
     await _ask(ask_service, call_id, tool_call_id="tc_final_guidance")
 
@@ -91,9 +99,68 @@ async def test_question_event_requires_final_answer_after_checks(ask_service, pa
     )
 
     assert len(result["events"]) == 1
-    assert "finish all relevant checks first" in result["next_action"].lower()
+    assert "accuracy is more important than speed" in result["next_action"].lower()
+    assert "search poke_memory and conversation_history first" in result["next_action"]
+    assert "this is a test" in result["next_action"]
     assert "only the final, ready-to-relay result" in result["next_action"]
-    assert "I'm still checking" in result["next_action"]
+    assert "resolution=not_found requires both" in result["next_action"]
+
+
+def test_not_found_answer_requires_memory_and_conversation_history():
+    with pytest.raises(ValueError, match="not_found answers require sources_checked"):
+        AnswerCallQuestionRequest(
+            call_id="call_1",
+            question_id="question_1",
+            answer="I could not find the building.",
+            resolution=QuestionResolution.NOT_FOUND,
+            sources_checked=[QuestionSource.EMAIL],
+        )
+
+    request = AnswerCallQuestionRequest(
+        call_id="call_1",
+        question_id="question_1",
+        answer="I could not find the building after checking the available records.",
+        resolution=QuestionResolution.NOT_FOUND,
+        sources_checked=[
+            QuestionSource.POKE_MEMORY,
+            QuestionSource.CONVERSATION_HISTORY,
+            QuestionSource.EMAIL,
+        ],
+    )
+
+    assert request.resolution is QuestionResolution.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_mcp_rejects_unsupported_not_found_without_claiming_question(ask_service, packet):
+    call_id = await seed_call(ask_service.db, packet, state=CallState.ACTIVE)
+    await _ask(ask_service, call_id, tool_call_id="tc_unsupported_not_found")
+    await wait_background()
+    rows = await ask_service.db.get_questions_after(call_id, 0)
+    question_id = rows[0]["question_id"]
+    mcp = FastMCP("test-ask-poke-source-validation")
+    register_tools(mcp, lambda: ask_service)
+
+    with pytest.raises(ToolError, match="question remains pending"):
+        await mcp.call_tool(
+            "answer_call_question",
+            {
+                "call_id": call_id,
+                "question_id": question_id,
+                "answer": "I could not find the building in email.",
+                "resolution": "not_found",
+                "sources_checked": ["email"],
+            },
+        )
+    await wait_background()
+
+    question = await ask_service.db.get_question(question_id)
+    assert question is not None
+    assert question["status"] == "pending"
+    assert not any(
+        tool_call_id == "tc_unsupported_not_found"
+        for _, tool_call_id, _ in ask_service._test_realtime.tool_results
+    )
 
 
 @pytest.mark.asyncio
@@ -770,6 +837,8 @@ async def test_mcp_ask_poke_tools_emit_invocation_logs(ask_service, packet, capl
                 "call_id": call_id,
                 "question_id": question_id,
                 "answer": "CVS on Market Street",
+                "resolution": "found",
+                "sources_checked": ["poke_memory"],
             },
         )
         await wait_background()
@@ -784,7 +853,12 @@ async def test_mcp_ask_poke_tools_emit_invocation_logs(ask_service, packet, capl
     messages = _messages(caplog, logger_name="app.mcp_tools")
     assert any("mcp tool wait_for_call_event call_id=" in message for message in messages)
     assert any("mcp tool wait_for_call_event completed" in message for message in messages)
-    assert any("mcp tool answer_call_question call_id=" in message for message in messages)
+    assert any(
+        "mcp tool answer_call_question call_id=" in message
+        and "resolution=found" in message
+        and "sources_checked=poke_memory" in message
+        for message in messages
+    )
     assert any(
         "mcp tool answer_call_question completed" in message and "status=accepted" in message
         for message in messages

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -297,4 +297,14 @@ async def test_exactly_seven_mcp_tools(settings):
     description = answer_tool.description.lower()
     assert "only the final, ready-to-relay result" in description
     assert "never submit a progress update" in description
-    assert "cannot be found after checking" in description
+    assert "prioritize accuracy over speed" in description
+    assert "search poke memory and conversation history first" in description
+    assert "resolution=not_found" in description
+    assert "question remains pending" in description
+
+    required = set(answer_tool.parameters["required"])
+    assert {"resolution", "sources_checked"}.issubset(required)
+    assert answer_tool.parameters["properties"]["resolution"]["enum"] == [
+        "found",
+        "not_found",
+    ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens mid-call `ask_poke` answers so Poke cannot claim `not_found` without attesting that it searched the required owner-specific sources.

- `answer_call_question` now requires `resolution` (`found` | `not_found`) and `sources_checked`.
- `resolution=not_found` is rejected unless both `poke_memory` and `conversation_history` are included; invalid submissions keep the question pending.
- Event/`next_action` guidance prioritizes accuracy within the deadline and tells the agent to search memory and conversation history before integrations.
- MCP tool description and validation error payload steer retries with structured `invalid_answer_submission` details.

## Test plan

- [x] `uv run pytest -q` — 329 passed
- [x] `uv run ruff check app tests scripts` — clean
- [x] `uv run ruff format --check app tests scripts` — clean
- [x] Added/updated tests for required sources, MCP rejection without claiming the question, and schema/logging coverage

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7b3a-de15-7fee-b881-fc1410463482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7b3a-de15-7fee-b881-fc1410463482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require source attestation for mid-call AskPoke answers to prevent unsupported `not_found` claims and improve accuracy. `answer_call_question` now requires a `resolution` and `sources_checked`, and rejects `not_found` unless both `poke_memory` and `conversation_history` were searched.

- **New Features**
  - Added `resolution` (`found` | `not_found`) and `sources_checked` to `answer_call_question`; `not_found` requires `poke_memory` and `conversation_history`.
  - Introduced `QuestionResolution` and `QuestionSource` enums with validation (no duplicates; enforce required sources).
  - Updated MCP tool description and errors to return a structured `invalid_answer_submission` with `next_action`; invalid submissions keep the question pending.
  - Refined `next_action` guidance: prioritize accuracy within the deadline, search memory and conversation history first, then integrations; submit only one final answer (no progress updates).
  - Expanded tests for validation, MCP rejection without claiming the question, guidance text, and logging.

- **Migration**
  - Update callers of `answer_call_question` to pass `resolution` and `sources_checked`.
  - For `resolution=not_found`, include both `poke_memory` and `conversation_history` in `sources_checked`, or the submission is rejected and the question remains pending.

<sup>Written for commit 01331e00055ea1ed459551154cac71fc07764380. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/XiyaoWang0519/poke-call/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

