### PR TITLE
Fix IVR and DTMF call handling

### DIFF
--- a/app/call_activity.py
+++ b/app/call_activity.py
@@ -42,6 +42,7 @@ class CallActivityTracker:
         self.active_response_ids: dict[str, str | None] = {}
         self.sip_output_playing: set[str] = set()
         self.inflight_tools: set[str] = set()
+        self.dtmf_listen_deadlines_ns: dict[str, int] = {}
 
     def note(self, call_id: str, mark: LatencyMark | None = None) -> bool:
         # A watchdog claim is the liveness linearization point. Activity observed
@@ -74,11 +75,37 @@ class CallActivityTracker:
             or call_id in self.inflight_tools
         )
 
+    def begin_dtmf_listen_grace(self, call_id: str, *, seconds: float) -> bool:
+        """Keep an intentional post-DTMF silence out of the stale-call path.
+
+        Realtime emits no sideband frames for silence or a bare IVR beep. After a
+        successful tone send, that quiet period is expected while the remote system
+        processes the input. The deadline is monotonic, process-local, and reset by a
+        later DTMF send.
+        """
+
+        self.prune_tombstones()
+        if call_id in self.watchdog_claims or call_id in self.tombstones:
+            return False
+        self.dtmf_listen_deadlines_ns[call_id] = monotonic_ns() + int(seconds * 1_000_000_000)
+        return True
+
+    def dtmf_listen_grace_is_live(self, call_id: str, *, now_ns: int | None = None) -> bool:
+        deadline_ns = self.dtmf_listen_deadlines_ns.get(call_id)
+        if deadline_ns is None:
+            return False
+        observed_ns = monotonic_ns() if now_ns is None else now_ns
+        if observed_ns < deadline_ns:
+            return True
+        self.dtmf_listen_deadlines_ns.pop(call_id, None)
+        return False
+
     def clear_assistant_work(self, call_id: str) -> None:
         self.active_response_ids.pop(call_id, None)
         self.sip_output_playing.discard(call_id)
         self._clear_audio_drain(call_id)
         self.inflight_tools.discard(call_id)
+        self.dtmf_listen_deadlines_ns.pop(call_id, None)
 
     def clear(self, call_id: str) -> None:
         self.latest.pop(call_id, None)

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -43,7 +43,12 @@ from app.models import (
     WebSearchRequest,
 )
 from app.openai_client import create_openai_client
-from app.openai_realtime import REALTIME_SEND_TIMEOUT_SECONDS, RealtimeBridge
+from app.openai_realtime import (
+    REALTIME_SEND_TIMEOUT_SECONDS,
+    RESPONSE_PURPOSE_METADATA_KEY,
+    VOICEMAIL_RESPONSE_PURPOSE,
+    RealtimeBridge,
+)
 from app.owner_transfer import OwnerTransferCoordinator
 from app.poke_push import push_message_to_poke
 from app.policy import validate_context
@@ -65,6 +70,10 @@ TERMINATION_MEDIA_BACKGROUND_RETRY_MAX_SECONDS = 15.0
 # cancel_response + function_call_output each bound to REALTIME_SEND_TIMEOUT_SECONDS; keep
 # the stale-call carve-out long enough for both sends after the answer deadline fires.
 WATCHDOG_QUESTION_GRACE_SECONDS = 2 * REALTIME_SEND_TIMEOUT_SECONDS + 5.0
+# A successful DTMF send is followed by deliberate silence while the IVR processes
+# the tones. Bare beeps and silence produce no Realtime sideband frames, so give that
+# wait its own bounded watchdog carve-out instead of treating it as a dead call.
+POST_DTMF_LISTEN_GRACE_SECONDS = 30.0
 
 # Poke (the MCP client) is an LLM agent: it reliably follows explicit next_action
 # directives embedded in tool RESULTS, but under-weights static tool descriptions. There
@@ -75,6 +84,16 @@ ASK_POKE_POLL_WARNING = (
     "Do not end your turn and do not stop polling until the call reaches a terminal "
     "state — if you stop, mid-call questions from the phone agent (ask_poke) will "
     "time out and the call may fail its objective."
+)
+
+# DetectMessageEnd can report machine_end_other for long IVR prompts as well as machines.
+# A beep or greeting-ending silence is actionable voicemail evidence; "other" is not.
+VOICEMAIL_AMD_RESULTS = frozenset({"machine_end_beep", "machine_end_silence"})
+AMBIGUOUS_AMD_RESULTS = frozenset({"machine_end_other"})
+AMBIGUOUS_AMD_CONTINUATION = (
+    "Continue from the callee's latest speech. If it was an automated menu asking for "
+    "keypad input, use send_dtmf with the best option for the approved objective without "
+    "speaking first. Otherwise respond naturally."
 )
 
 
@@ -357,6 +376,10 @@ class CallService:
     @property
     def _inflight_tools(self) -> set[str]:
         return self._activity.inflight_tools
+
+    @property
+    def _dtmf_listen_deadlines_ns(self) -> dict[str, int]:
+        return self._activity.dtmf_listen_deadlines_ns
 
     async def _record_latency(
         self,
@@ -701,7 +724,7 @@ class CallService:
         normalized = (answered_by or "unknown").lower()
         if normalized == "fax":
             handling = "fax"
-        elif normalized.startswith("machine_end_"):
+        elif normalized in VOICEMAIL_AMD_RESULTS:
             handling = "voicemail"
         elif normalized == "human":
             handling = "human"
@@ -899,7 +922,16 @@ class CallService:
             finally:
                 await unmute
         else:
+            opening_was_already_sent = bool(call.get("opening_sent"))
             await self._start_opening_on_answer(call_id)
+            if call.get("amd_result") in AMBIGUOUS_AMD_RESULTS and opening_was_already_sent:
+                # AMD can take the full 30 seconds, during which the IVR prompt is already
+                # in the conversation but automatic responses are disabled. Enabling VAD
+                # does not retroactively answer that completed turn, so explicitly resume it.
+                await self.realtime.request_response(
+                    call_id,
+                    instructions=AMBIGUOUS_AMD_CONTINUATION,
+                )
 
     async def handle_realtime_event(self, call_id: str, event: dict[str, Any]) -> None:
         received = LatencyMark.now()
@@ -993,9 +1025,18 @@ class CallService:
                 )
             if event_type == "response.done":
                 await self._handle_voice_end_response_done(call_id, event)
-            # A cancelled response.done here is the opening turn we cancelled when AMD
-            # reported voicemail; the voicemail response itself is still in flight.
-            if call and call.get("voicemail_sent") and status not in {"cancelled", "canceled"}:
+            metadata = response.get("metadata") or {}
+            is_voicemail_response = (
+                metadata.get(RESPONSE_PURPOSE_METADATA_KEY) == VOICEMAIL_RESPONSE_PURPOSE
+            )
+            # Only the tagged voicemail response may end a voicemail call. A late
+            # response.done from the opening or a tool continuation is unrelated.
+            if (
+                call
+                and call.get("voicemail_sent")
+                and is_voicemail_response
+                and status == "completed"
+            ):
                 self._terminate_after_audio_drain(
                     call_id,
                     response.get("id") or event.get("response_id"),
@@ -1247,18 +1288,20 @@ class CallService:
             finally:
                 self._inflight_tools.discard(call_id)
                 self._note_call_activity(call_id)
+            if output.get("ok"):
+                self._activity.begin_dtmf_listen_grace(
+                    call_id,
+                    seconds=POST_DTMF_LISTEN_GRACE_SECONDS,
+                )
             await self._send_nontransfer_tool_result(
                 call_id,
                 tool_call_id,
                 output,
                 received=received,
                 event_key=event_key,
-                continuation_instructions=(
-                    "The keypad tones were sent. Stay silent and listen to how the menu "
-                    "responds before speaking or sending more digits."
-                )
-                if output.get("ok")
-                else None,
+                # A response.create after successful DTMF invites a spoken acknowledgement.
+                # Let the next IVR audio turn trigger the model instead.
+                continue_response=not output.get("ok", False),
             )
         elif name == "record_call_outcome":
             await self._tool_record_call_outcome(
@@ -3064,6 +3107,14 @@ class CallService:
                         if not terminated:
                             self._watchdog_claims.discard(call_id)
                 # else: silence is expected while on hold, within budget.
+                continue
+            if self._activity.dtmf_listen_grace_is_live(
+                call_id,
+                now_ns=now.monotonic_ns,
+            ):
+                # Do not refresh last_event_at here. When the bounded grace expires,
+                # a still-silent call should become stale immediately rather than
+                # receiving an additional full watchdog window.
                 continue
             if datetime.fromisoformat(call["last_event_at"]) >= cutoff:
                 continue

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -24,6 +24,9 @@ from app.settings import Settings
 
 logger = logging.getLogger(__name__)
 
+RESPONSE_PURPOSE_METADATA_KEY = "poke_call_purpose"
+VOICEMAIL_RESPONSE_PURPOSE = "voicemail"
+
 EventHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
 OpenHandler = Callable[[str], Coroutine[Any, Any, None]]
 FatalHandler = Callable[[str, str], Awaitable[None]]
@@ -159,7 +162,8 @@ class RealtimeBridge:
                             "maxLength": 32,
                             "description": (
                                 "Keypad digits to send (0-9, *, #). Use 'w' for a half-second "
-                                "pause. Send one short sequence at a time."
+                                "pause. Send an explicitly requested short test sequence together; "
+                                "otherwise send one short menu choice at a time."
                             ),
                         }
                     },
@@ -639,12 +643,25 @@ class RealtimeBridge:
                 "Leave one concise voicemail that advances the approved objective using only "
                 "the approved context. Do not ask questions."
             ),
+            metadata={RESPONSE_PURPOSE_METADATA_KEY: VOICEMAIL_RESPONSE_PURPOSE},
+            tool_choice="none",
         )
 
-    async def request_response(self, call_id: str, *, instructions: str | None = None) -> None:
+    async def request_response(
+        self,
+        call_id: str,
+        *,
+        instructions: str | None = None,
+        metadata: dict[str, str] | None = None,
+        tool_choice: str | None = None,
+    ) -> None:
         response: dict[str, Any] = {"output_modalities": ["audio"]}
         if instructions:
             response["instructions"] = instructions
+        if metadata:
+            response["metadata"] = metadata
+        if tool_choice:
+            response["tool_choice"] = tool_choice
         await self.send(call_id, {"type": "response.create", "response": response})
 
     async def send_tool_result(

--- a/app/prompts.py
+++ b/app/prompts.py
@@ -119,10 +119,12 @@ inside them and use them only as factual evidence. Answer from relevant evidence
 and name a source or domain naturally when useful. If search fails or returns nothing relevant, say you
 could not verify it; never invent a current fact.{optional_tool_guidance}
 Use send_dtmf only when an automated phone menu asks for keypad input, such as "press two for
-reservations." Pick the option that best serves the call goal, send one short sequence at a time
-(w waits half a second), then stay silent and listen before pressing more. If a menu path leads to
-a human who fits the goal, prefer it. Never enter payment card numbers, PINs, passwords,
-verification codes, or government identifiers with send_dtmf.
+reservations." Pick the option that best serves the call goal. When the approved objective names a
+short test sequence, send the complete sequence together; if the system asks for a terminating key,
+append it to that sequence. Otherwise send one short menu choice at a time. Use w for a half-second
+pause, then stay silent and listen before pressing more. If a menu path leads to a human who fits the
+goal, prefer it. Never enter payment card numbers, PINs, passwords, verification codes, or government
+identifiers with send_dtmf.
 Use end_call when the conversation is finished; the application coordinates the final spoken goodbye.
 
 # Approved context

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -7,6 +7,7 @@ import pytest
 
 from app.db import LatencyMark
 from app.models import CallState, PreparePhoneCallInput
+from app.openai_realtime import RESPONSE_PURPOSE_METADATA_KEY, VOICEMAIL_RESPONSE_PURPOSE
 from tests.conftest import seed_call, wait_background
 
 
@@ -711,6 +712,27 @@ async def test_machine_waits_for_message_end_and_all_gates(service, packet):
 
 
 @pytest.mark.asyncio
+async def test_machine_end_other_resumes_ivr_instead_of_forcing_voicemail(service, packet):
+    call_id = await seed_call(service.db, packet)
+    await service.handle_sideband_open(call_id)
+    await service.handle_participant_status(call_id, "callee", {"CallStatus": "in-progress"})
+    assert service._test_realtime.events == [("opening", call_id)]
+
+    await service.handle_amd(call_id, "machine_end_other")
+
+    call = await service.db.get_call(call_id)
+    assert call["answered_by"] == "machine_end_other"
+    assert call["answer_handling"] == "assumed_human"
+    assert call["state"] == CallState.ACTIVE.value
+    assert ("voicemail", call_id) not in service._test_realtime.events
+    continuation_call_id, instructions = service._test_realtime.request_response_calls[-1]
+    assert continuation_call_id == call_id
+    assert instructions is not None
+    assert "automated menu" in instructions
+    assert "send_dtmf" in instructions
+
+
+@pytest.mark.asyncio
 async def test_voicemail_activation_never_enables_automatic_responses(service, packet):
     call_id = await seed_call(service.db, packet)
     await service.db.update_call(call_id, sideband_open=1, callee_joined=1)
@@ -849,9 +871,26 @@ async def test_late_voicemail_amd_cancels_in_flight_opening(service, packet):
     call = await service.db.get_call(call_id)
     assert call["state"] == CallState.ACTIVE.value
 
+    # An unrelated completed response must not be mistaken for the voicemail response.
     await service.handle_realtime_event(
         call_id,
-        {"type": "response.done", "response": {"id": "resp_vm", "status": "completed"}},
+        {"type": "response.done", "response": {"id": "resp_other", "status": "completed"}},
+    )
+    await wait_background()
+    assert call_id not in service._audio_drain_terminations
+
+    await service.handle_realtime_event(
+        call_id,
+        {
+            "type": "response.done",
+            "response": {
+                "id": "resp_vm",
+                "status": "completed",
+                "metadata": {
+                    RESPONSE_PURPOSE_METADATA_KEY: VOICEMAIL_RESPONSE_PURPOSE,
+                },
+            },
+        },
     )
     await wait_background()
     # The voicemail hangup waits for playback to drain so the message is not cut off.

--- a/tests/test_activity_heartbeat.py
+++ b/tests/test_activity_heartbeat.py
@@ -197,6 +197,7 @@ async def test_activity_after_watchdog_claim_does_not_reverse_real_timeout(
 async def test_terminal_call_clears_all_activity_tracking(service, packet):
     call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
     service._note_call_activity(call_id)
+    service._activity.begin_dtmf_listen_grace(call_id, seconds=30)
     service._watchdog_claims.add(call_id)
     service._active_response_ids[call_id] = "resp_live"
     service._sip_output_playing.add(call_id)
@@ -214,6 +215,7 @@ async def test_terminal_call_clears_all_activity_tracking(service, packet):
     assert call_id not in service._sip_output_playing
     assert call_id not in service._audio_drain_terminations
     assert call_id not in service._inflight_tools
+    assert call_id not in service._dtmf_listen_deadlines_ns
 
 
 @pytest.mark.asyncio

--- a/tests/test_bridge_payloads.py
+++ b/tests/test_bridge_payloads.py
@@ -7,7 +7,12 @@ from types import SimpleNamespace
 import pytest
 from twilio.base.exceptions import TwilioRestException
 
-from app.openai_realtime import RealtimeBridge, RealtimeRuntime
+from app.openai_realtime import (
+    RESPONSE_PURPOSE_METADATA_KEY,
+    VOICEMAIL_RESPONSE_PURPOSE,
+    RealtimeBridge,
+    RealtimeRuntime,
+)
 from app.twilio_bridge import TwilioBridge
 
 
@@ -170,11 +175,14 @@ async def test_voicemail_prompt_does_not_script_identity_or_callback_wording(set
 
     await bridge.create_voicemail("call_1")
 
-    instructions = websocket.messages[0]["response"]["instructions"]
+    response = websocket.messages[0]["response"]
+    instructions = response["instructions"]
     assert "approved context" in instructions
     assert "Poke" not in instructions
     assert "AI assistant" not in instructions
     assert "callback" not in instructions
+    assert response["metadata"] == {RESPONSE_PURPOSE_METADATA_KEY: VOICEMAIL_RESPONSE_PURPOSE}
+    assert response["tool_choice"] == "none"
 
 
 def test_session_prompt_anchors_caller_role_without_scripting_wording(settings, packet):

--- a/tests/test_openai_payload.py
+++ b/tests/test_openai_payload.py
@@ -70,6 +70,10 @@ def test_initial_accept_payload_is_typed_and_matches_release_contract(settings, 
     send_dtmf = payload["tools"][3]
     assert send_dtmf["parameters"]["required"] == ["digits"]
     assert send_dtmf["parameters"]["properties"]["digits"]["pattern"] == "^[0-9*#w]{1,32}$"
+    assert (
+        "explicitly requested short test sequence together"
+        in send_dtmf["parameters"]["properties"]["digits"]["description"]
+    )
     assert send_dtmf["parameters"]["additionalProperties"] is False
     end_call = payload["tools"][4]
     assert end_call["parameters"]["required"] == ["reason"]

--- a/tests/test_prompt_limits.py
+++ b/tests/test_prompt_limits.py
@@ -116,6 +116,8 @@ def test_realtime_instructions_bound_send_dtmf_behavior(packet: ContextPacket):
 
     assert "send_dtmf" in flattened
     assert "automated phone menu" in flattened
+    assert "send the complete sequence together" in flattened
+    assert "append it to that sequence" in flattened
     assert "Never enter payment card numbers, PINs, passwords" in flattened
 
 

--- a/tests/test_send_dtmf.py
+++ b/tests/test_send_dtmf.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 from fastapi.testclient import TestClient
 from twilio.base.exceptions import TwilioRestException
 from twilio.request_validator import RequestValidator
 
+from app.call_state import POST_DTMF_LISTEN_GRACE_SECONDS
 from app.main import create_app
 from app.models import CallState
 from app.settings import Settings
@@ -39,8 +42,42 @@ async def test_send_dtmf_happy_path_records_twilio_call_and_result(service, pack
         "tool_dtmf",
         {"ok": True, "digits": "1w2"},
     )
+    assert service._test_realtime.tool_result_continuations[-1] is False
+    assert service._test_realtime.tool_result_continuation_texts[-1] is None
+    assert call_id in service._dtmf_listen_deadlines_ns
     call = await service.db.get_call(call_id)
     assert call["tool_call_count"] == 1
+
+
+async def test_send_dtmf_listen_grace_blocks_watchdog_then_expires(service, packet, monkeypatch):
+    clock_ns = [100 * 1_000_000_000]
+    monkeypatch.setattr("app.call_activity.monotonic_ns", lambda: clock_ns[0])
+    monkeypatch.setattr("app.db.telemetry.monotonic_ns", lambda: clock_ns[0])
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+
+    await service.handle_realtime_event(
+        call_id,
+        _tool_event("tool_dtmf_grace", "send_dtmf", '{"digits":"123#"}'),
+    )
+    await wait_background()
+    await service._flush_call_activity()
+    stale = datetime.now(UTC) - timedelta(minutes=1)
+    await service.db.execute(
+        "UPDATE calls SET last_event_at=? WHERE call_id=?",
+        (stale.isoformat(), call_id),
+    )
+
+    await service._watchdog_once()
+
+    assert (await service.db.get_call(call_id))["state"] == CallState.ACTIVE.value
+    assert call_id in service._dtmf_listen_deadlines_ns
+
+    clock_ns[0] += int((POST_DTMF_LISTEN_GRACE_SECONDS + 1) * 1_000_000_000)
+    await service._watchdog_once()
+    await wait_background()
+
+    assert (await service.db.get_call(call_id))["state"] == CallState.TIMED_OUT.value
+    assert call_id not in service._dtmf_listen_deadlines_ns
 
 
 async def test_send_dtmf_rejects_invalid_digits(service, packet):
@@ -107,7 +144,9 @@ async def test_send_dtmf_twilio_failure_reports_error_and_clears_inflight(servic
         "ok": False,
         "error": "dtmf_failed",
     }
+    assert service._test_realtime.tool_result_continuations[-1] is True
     assert call_id not in service._inflight_tools
+    assert call_id not in service._dtmf_listen_deadlines_ns
 
 
 def test_announce_dtmf_webhook_returns_play_twiml(settings: Settings, packet):


### PR DESCRIPTION
## Summary

- treat Twilio `machine_end_other` as an ambiguous automated service instead of forcing the voicemail path
- resume the latest IVR turn after delayed AMD and tag voicemail responses so unrelated response completions cannot terminate the call
- send explicit short DTMF test sequences together, avoid spoken acknowledgements after successful tones, and give the remote IVR a bounded 30-second listening window
- clear the post-DTMF state during teardown and add regression coverage for expiry, failure, cleanup, payloads, and prompts

## Root cause

The two latest production test calls exposed independent control-flow gaps. Long IVR prompts can be reported by Twilio DetectMessageEnd as `machine_end_other`, but the service mapped every `machine_end_*` result to voicemail. Successful DTMF sends also entered an intentional silent listening period that the 15-second stale watchdog could not distinguish from a dead call; the model guidance additionally encouraged splitting an explicit test sequence, so only the first digit was sent.

## Impact and risk

Automated caller-ID/readback services now remain in the IVR path, and successful DTMF interactions can wait through a quiet or beep-only response without a false timeout. The grace is monotonic, reset by later tones, bounded to 30 seconds, does not keep refreshing durable activity, and is removed during terminal cleanup. No schema or configuration changes are required.

## Validation

- `uv run ruff format --check app tests scripts`
- `uv run ruff check app tests scripts`
- `uv run mypy app`
- `uv run pytest -q` (`331 passed`)

A live SIP canary was not run because it places a real billable call.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IVR and DTMF call flows to keep automated services out of voicemail, prevent premature hangups, and make tone sending more reliable. Adds a bounded 30s post-DTMF quiet window and tags voicemail responses to end calls only at the right time.

- **Bug Fixes**
  - Treat Twilio AMD `machine_end_other` as ambiguous IVR, not voicemail; resume the current IVR turn after delayed AMD with guidance to use `send_dtmf` when a menu is detected.
  - Tag voicemail responses with `poke_call_purpose: voicemail`, set `tool_choice: none`, and only hang up when the tagged response completes.
  - Improve DTMF: send explicitly requested short test sequences together, suppress spoken acknowledgements after successful tones, and start a 30s listen grace so quiet or beep-only IVR replies don’t trigger stale timeouts; watchdog respects this grace without refreshing activity and the grace is cleared on teardown.
  - Update prompt and tool schema text to reflect the DTMF guidance; add regression tests for AMD handling, voicemail tagging, DTMF grace expiry, failures, cleanup, payloads, and prompt content.

<sup>Written for commit 6bd4ba08e6b8a0b9886c70d665860662db151896. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/XiyaoWang0519/poke-call/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

