### PR TITLE
Recover once from post-DTMF silence before watchdog

### DIFF
--- a/app/call_activity.py
+++ b/app/call_activity.py
@@ -41,6 +41,7 @@ class CallActivityTracker:
         self.tombstones: OrderedDict[str, int] = OrderedDict()
         self.active_response_ids: dict[str, str | None] = {}
         self.sip_output_playing: set[str] = set()
+        self.input_speech_active: set[str] = set()
         self.inflight_tools: set[str] = set()
         self.dtmf_listen_deadlines_ns: dict[str, int] = {}
 
@@ -62,15 +63,16 @@ class CallActivityTracker:
         return True
 
     def assistant_work_is_live(self, call_id: str) -> bool:
-        """True when the assistant is generating, playing SIP audio, or awaiting a tool.
+        """True while either party or an assistant tool is actively doing call work.
 
         The 15s stale watchdog only sees sideband/Twilio heartbeats. SIP media and
-        in-flight tool waits can leave that clock idle while the callee still hears
-        (or is about to hear) the assistant, so those states must count as live.
+        in-flight tool waits can leave that clock idle while either party is speaking
+        or the callee is about to hear the assistant, so those states must count as live.
         """
         return (
             call_id in self.active_response_ids
             or call_id in self.sip_output_playing
+            or call_id in self.input_speech_active
             or self._is_audio_drain_active(call_id)
             or call_id in self.inflight_tools
         )
@@ -95,17 +97,35 @@ class CallActivityTracker:
         if deadline_ns is None:
             return False
         observed_ns = monotonic_ns() if now_ns is None else now_ns
+        return observed_ns < deadline_ns
+
+    def consume_expired_dtmf_listen_grace(
+        self,
+        call_id: str,
+        *,
+        now_ns: int | None = None,
+    ) -> bool:
+        """Consume one expired post-DTMF wait so recovery can run exactly once."""
+
+        deadline_ns = self.dtmf_listen_deadlines_ns.get(call_id)
+        if deadline_ns is None:
+            return False
+        observed_ns = monotonic_ns() if now_ns is None else now_ns
         if observed_ns < deadline_ns:
-            return True
+            return False
         self.dtmf_listen_deadlines_ns.pop(call_id, None)
-        return False
+        return True
+
+    def clear_dtmf_listen_grace(self, call_id: str) -> None:
+        self.dtmf_listen_deadlines_ns.pop(call_id, None)
 
     def clear_assistant_work(self, call_id: str) -> None:
         self.active_response_ids.pop(call_id, None)
         self.sip_output_playing.discard(call_id)
+        self.input_speech_active.discard(call_id)
         self._clear_audio_drain(call_id)
         self.inflight_tools.discard(call_id)
-        self.dtmf_listen_deadlines_ns.pop(call_id, None)
+        self.clear_dtmf_listen_grace(call_id)
 
     def clear(self, call_id: str) -> None:
         self.latest.pop(call_id, None)

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -74,6 +74,12 @@ WATCHDOG_QUESTION_GRACE_SECONDS = 2 * REALTIME_SEND_TIMEOUT_SECONDS + 5.0
 # the tones. Bare beeps and silence produce no Realtime sideband frames, so give that
 # wait its own bounded watchdog carve-out instead of treating it as a dead call.
 POST_DTMF_LISTEN_GRACE_SECONDS = 30.0
+POST_DTMF_RECOVERY_INSTRUCTIONS = (
+    "The keypad tones were sent successfully, but no new IVR speech turn followed. "
+    "Continue the approved objective from the latest menu state. Do not verbally acknowledge "
+    "the prior keypress. If the system is waiting for more keypad input, use send_dtmf; "
+    "otherwise listen, respond briefly if speech is required, or end the call when complete."
+)
 
 # Poke (the MCP client) is an LLM agent: it reliably follows explicit next_action
 # directives embedded in tool RESULTS, but under-weights static tool descriptions. There
@@ -372,6 +378,10 @@ class CallService:
     @property
     def _sip_output_playing(self) -> set[str]:
         return self._activity.sip_output_playing
+
+    @property
+    def _input_speech_active(self) -> set[str]:
+        return self._activity.input_speech_active
 
     @property
     def _inflight_tools(self) -> set[str]:
@@ -941,6 +951,15 @@ class CallService:
         # so dispatcher-only paths (and sparse SIP sidebands) still refresh the watchdog.
         if event_type in ASSISTANT_SPEECH_EVENT_TYPES:
             self._activity.note(call_id, received)
+        if event_type == "input_audio_buffer.speech_started":
+            self._activity.note(call_id, received)
+            self._activity.input_speech_active.add(call_id)
+            # The expected post-DTMF IVR turn arrived. Semantic VAD will trigger the
+            # next model response when the turn ends, so a timeout recovery would race it.
+            self._activity.clear_dtmf_listen_grace(call_id)
+        elif event_type == "input_audio_buffer.speech_stopped":
+            self._activity.note(call_id, received)
+            self._activity.input_speech_active.discard(call_id)
         if event_type in {
             "response.output_audio_transcript.delta",
             "response.output_audio_transcript.done",
@@ -956,6 +975,7 @@ class CallService:
             # session.update/session.updated handshake in handle_sideband_open.
             logger.debug("observed session.created call_id=%s", call_id)
         elif event_type == "conversation.item.input_audio_transcription.completed":
+            self._activity.input_speech_active.discard(call_id)
             text = event.get("transcript", "").strip()
             if text:
                 await self.db.add_transcript_turn(
@@ -998,6 +1018,8 @@ class CallService:
                 event_key=str(event.get("call_id") or event_id),
             )
         elif event_type == "response.created":
+            # Any model turn proves the post-DTMF deadlock has resolved.
+            self._activity.clear_dtmf_listen_grace(call_id)
             if call_id in self._tool_seen_calls:
                 self._tool_seen_calls.discard(call_id)
                 await self.db.mark_tool_continuation_observed(call_id)
@@ -1161,7 +1183,7 @@ class CallService:
         advisory_outcome: dict[str, Any] | None = None,
         continue_response: bool = True,
         continuation_instructions: str | None = None,
-    ) -> None:
+    ) -> bool:
         # Begin the one durable tool write before yielding to the WebSocket, but do not
         # put SQLite on the response path. Await it before returning so the FIFO dispatcher
         # cannot process response.created before tool_call_count is committed.
@@ -1191,16 +1213,15 @@ class CallService:
                     {"accepted": False, "error": "outcome could not be persisted"},
                 )
                 raise
-            await self._guarded_send_tool_result(
+            return await self._guarded_send_tool_result(
                 call_id,
                 tool_call_id,
                 output,
                 continue_response=continue_response,
                 continuation_instructions=continuation_instructions,
             )
-            return
         try:
-            await self._guarded_send_tool_result(
+            return await self._guarded_send_tool_result(
                 call_id,
                 tool_call_id,
                 output,
@@ -1266,7 +1287,22 @@ class CallService:
                 )
                 return
 
+            if call_id in self._activity.input_speech_active:
+                # Do not inject tones into a prompt that is still playing. Returning the
+                # tool result without response.create lets semantic VAD resume the model
+                # after the callee's current speech turn finishes.
+                await self._send_nontransfer_tool_result(
+                    call_id,
+                    tool_call_id,
+                    {"ok": False, "error": "callee_speaking", "retryable": True},
+                    received=received,
+                    event_key=event_key,
+                    continue_response=False,
+                )
+                return
+
             self._note_call_activity(call_id)
+            self._activity.clear_dtmf_listen_grace(call_id)
             self._inflight_tools.add(call_id)
             try:
                 await self.twilio.send_dtmf(
@@ -1288,21 +1324,24 @@ class CallService:
             finally:
                 self._inflight_tools.discard(call_id)
                 self._note_call_activity(call_id)
-            if output.get("ok"):
-                self._activity.begin_dtmf_listen_grace(
-                    call_id,
-                    seconds=POST_DTMF_LISTEN_GRACE_SECONDS,
-                )
-            await self._send_nontransfer_tool_result(
+            delivered = await self._send_nontransfer_tool_result(
                 call_id,
                 tool_call_id,
                 output,
                 received=received,
                 event_key=event_key,
-                # A response.create after successful DTMF invites a spoken acknowledgement.
-                # Let the next IVR audio turn trigger the model instead.
+                # A response.create immediately after successful DTMF invites a spoken
+                # acknowledgement. Wait for the IVR, then recover once if it stays silent.
                 continue_response=not output.get("ok", False),
             )
+            if output.get("ok") and delivered:
+                # Start the grace only after the model has received function_call_output.
+                # If the sideband write failed, normal teardown must handle the unresolved
+                # tool call instead of hiding it behind an in-memory silence exemption.
+                self._activity.begin_dtmf_listen_grace(
+                    call_id,
+                    seconds=POST_DTMF_LISTEN_GRACE_SECONDS,
+                )
         elif name == "record_call_outcome":
             await self._tool_record_call_outcome(
                 call_id, tool_call_id, arguments, received=received, event_key=event_key
@@ -3112,10 +3151,37 @@ class CallService:
                 call_id,
                 now_ns=now.monotonic_ns,
             ):
-                # Do not refresh last_event_at here. When the bounded grace expires,
-                # a still-silent call should become stale immediately rather than
-                # receiving an additional full watchdog window.
+                # Successful DTMF intentionally waits for the next IVR turn without
+                # inviting an immediate spoken acknowledgement from the model.
                 continue
+            if call_id in self._activity.dtmf_listen_deadlines_ns:
+                if self._activity.assistant_work_is_live(call_id):
+                    # A long IVR prompt or a response already in progress wins over the
+                    # silence deadline. Keep the expired marker so recovery remains
+                    # available if that work later ends without producing a model turn.
+                    self._activity.note(call_id, now)
+                    continue
+                if self._activity.consume_expired_dtmf_listen_grace(
+                    call_id,
+                    now_ns=now.monotonic_ns,
+                ):
+                    try:
+                        await self.realtime.request_response(
+                            call_id,
+                            instructions=POST_DTMF_RECOVERY_INSTRUCTIONS,
+                        )
+                    except Exception:
+                        # A broken sideband cannot recover the unresolved conversation;
+                        # fall through so the ordinary stale path can terminate it.
+                        logger.warning(
+                            "post-DTMF recovery could not be delivered call_id=%s",
+                            call_id,
+                            exc_info=True,
+                        )
+                    else:
+                        logger.info("requested post-DTMF recovery call_id=%s", call_id)
+                        self._activity.note(call_id, now)
+                        continue
             if datetime.fromisoformat(call["last_event_at"]) >= cutoff:
                 continue
             if self._activity.assistant_work_is_live(call_id):

--- a/app/prompts.py
+++ b/app/prompts.py
@@ -120,11 +120,13 @@ and name a source or domain naturally when useful. If search fails or returns no
 could not verify it; never invent a current fact.{optional_tool_guidance}
 Use send_dtmf only when an automated phone menu asks for keypad input, such as "press two for
 reservations." Pick the option that best serves the call goal. When the approved objective names a
-short test sequence, send the complete sequence together; if the system asks for a terminating key,
-append it to that sequence. Otherwise send one short menu choice at a time. Use w for a half-second
-pause, then stay silent and listen before pressing more. If a menu path leads to a human who fits the
-goal, prefer it. Never enter payment card numbers, PINs, passwords, verification codes, or government
-identifiers with send_dtmf.
+short test sequence, treat it as payload, not as an initial menu choice: complete any prerequisite
+recording or menu navigation first, wait until the system explicitly asks for the test tones, then
+send the complete sequence together. If the system asks for a terminating key, append it to that
+sequence. Otherwise send one short menu choice at a time. Never send tones while the automated prompt
+is still speaking. Use w for a half-second pause, then stay silent and listen before pressing more.
+If a menu path leads to a human who fits the goal, prefer it. Never enter payment card numbers, PINs,
+passwords, verification codes, or government identifiers with send_dtmf.
 Use end_call when the conversation is finished; the application coordinates the final spoken goodbye.
 
 # Approved context

--- a/app/twilio_bridge.py
+++ b/app/twilio_bridge.py
@@ -70,7 +70,14 @@ class TwilioBridge:
                     call_id=call_id,
                     plan_id=plan_id,
                 ),
-                conference_status_callback_event=["start", "end", "join", "leave", "mute"],
+                conference_status_callback_event=[
+                    "start",
+                    "end",
+                    "join",
+                    "leave",
+                    "mute",
+                    "announcement",
+                ],
             )
 
         participant = await asyncio.to_thread(create)

--- a/tests/test_bridge_payloads.py
+++ b/tests/test_bridge_payloads.py
@@ -652,6 +652,7 @@ async def test_twilio_participant_options_match_bridge_contract(settings, packet
         "join",
         "leave",
         "mute",
+        "announcement",
     ]
 
     await bridge.create_callee_participant(**common, conference_sid_or_name="CF1", packet=packet)

--- a/tests/test_prompt_limits.py
+++ b/tests/test_prompt_limits.py
@@ -116,8 +116,10 @@ def test_realtime_instructions_bound_send_dtmf_behavior(packet: ContextPacket):
 
     assert "send_dtmf" in flattened
     assert "automated phone menu" in flattened
+    assert "treat it as payload, not as an initial menu choice" in flattened
     assert "send the complete sequence together" in flattened
     assert "append it to that sequence" in flattened
+    assert "Never send tones while the automated prompt is still speaking" in flattened
     assert "Never enter payment card numbers, PINs, passwords" in flattened
 
 

--- a/tests/test_send_dtmf.py
+++ b/tests/test_send_dtmf.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from twilio.base.exceptions import TwilioRestException
 from twilio.request_validator import RequestValidator
 
-from app.call_state import POST_DTMF_LISTEN_GRACE_SECONDS
+from app.call_state import POST_DTMF_LISTEN_GRACE_SECONDS, POST_DTMF_RECOVERY_INSTRUCTIONS
 from app.main import create_app
 from app.models import CallState
 from app.settings import Settings
@@ -49,7 +49,7 @@ async def test_send_dtmf_happy_path_records_twilio_call_and_result(service, pack
     assert call["tool_call_count"] == 1
 
 
-async def test_send_dtmf_listen_grace_blocks_watchdog_then_expires(service, packet, monkeypatch):
+async def test_send_dtmf_listen_grace_recovers_once_before_watchdog(service, packet, monkeypatch):
     clock_ns = [100 * 1_000_000_000]
     monkeypatch.setattr("app.call_activity.monotonic_ns", lambda: clock_ns[0])
     monkeypatch.setattr("app.db.telemetry.monotonic_ns", lambda: clock_ns[0])
@@ -76,7 +76,105 @@ async def test_send_dtmf_listen_grace_blocks_watchdog_then_expires(service, pack
     await service._watchdog_once()
     await wait_background()
 
+    assert (await service.db.get_call(call_id))["state"] == CallState.ACTIVE.value
+    assert call_id not in service._dtmf_listen_deadlines_ns
+    assert service._test_realtime.request_response_calls[-1] == (
+        call_id,
+        POST_DTMF_RECOVERY_INSTRUCTIONS,
+    )
+
+    # Recovery is one-shot. If it produces no response or inbound turn, the ordinary
+    # watchdog still terminates the call after its normal stale window.
+    await service._flush_call_activity()
+    await service.db.execute(
+        "UPDATE calls SET last_event_at=? WHERE call_id=?",
+        (stale.isoformat(), call_id),
+    )
+    clock_ns[0] += int((service.settings.watchdog_stale_seconds + 1) * 1_000_000_000)
+    await service._watchdog_once()
+    await wait_background()
+
     assert (await service.db.get_call(call_id))["state"] == CallState.TIMED_OUT.value
+    assert (
+        service._test_realtime.request_response_calls.count(
+            (call_id, POST_DTMF_RECOVERY_INSTRUCTIONS)
+        )
+        == 1
+    )
+
+
+async def test_send_dtmf_waits_until_active_callee_speech_finishes(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    await service.handle_realtime_event(call_id, {"type": "input_audio_buffer.speech_started"})
+
+    await service.handle_realtime_event(
+        call_id,
+        _tool_event("tool_dtmf_speaking", "send_dtmf", '{"digits":"123#"}'),
+    )
+    await wait_background()
+
+    assert service._test_twilio.dtmf == []
+    assert service._test_realtime.tool_results[-1][2] == {
+        "ok": False,
+        "error": "callee_speaking",
+        "retryable": True,
+    }
+    assert service._test_realtime.tool_result_continuations[-1] is False
+    assert call_id in service._input_speech_active
+
+    await service.handle_realtime_event(call_id, {"type": "input_audio_buffer.speech_stopped"})
+    assert call_id not in service._input_speech_active
+
+
+async def test_long_callee_prompt_stays_live_past_watchdog_window(service, packet, monkeypatch):
+    clock_ns = [100 * 1_000_000_000]
+    monkeypatch.setattr("app.call_activity.monotonic_ns", lambda: clock_ns[0])
+    monkeypatch.setattr("app.db.telemetry.monotonic_ns", lambda: clock_ns[0])
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+
+    await service.handle_realtime_event(call_id, {"type": "input_audio_buffer.speech_started"})
+    await service._flush_call_activity()
+    stale = datetime.now(UTC) - timedelta(minutes=1)
+    await service.db.execute(
+        "UPDATE calls SET last_event_at=? WHERE call_id=?",
+        (stale.isoformat(), call_id),
+    )
+    clock_ns[0] += int((service.settings.watchdog_stale_seconds + 1) * 1_000_000_000)
+
+    await service._watchdog_once()
+
+    assert (await service.db.get_call(call_id))["state"] == CallState.ACTIVE.value
+    assert call_id in service._input_speech_active
+    assert call_id not in service._watchdog_claims
+
+
+async def test_new_ivr_speech_cancels_post_dtmf_silence_recovery(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+
+    await service.handle_realtime_event(
+        call_id,
+        _tool_event("tool_dtmf_ivr", "send_dtmf", '{"digits":"2"}'),
+    )
+    await wait_background()
+    assert call_id in service._dtmf_listen_deadlines_ns
+
+    await service.handle_realtime_event(call_id, {"type": "input_audio_buffer.speech_started"})
+
+    assert call_id not in service._dtmf_listen_deadlines_ns
+    assert call_id in service._input_speech_active
+
+
+async def test_send_dtmf_does_not_hide_failed_tool_result_delivery(service, packet):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    service._test_realtime.tool_result_failures_remaining = 1
+
+    await service.handle_realtime_event(
+        call_id,
+        _tool_event("tool_dtmf_delivery_fail", "send_dtmf", '{"digits":"1"}'),
+    )
+    await wait_background()
+
+    assert service._test_twilio.dtmf == [("CF" + "a" * 32, "CA" + "b" * 32, "1")]
     assert call_id not in service._dtmf_listen_deadlines_ns
 
 


### PR DESCRIPTION
## Summary
- After a successful `send_dtmf`, the model received no `response.create` and no IVR turn could arrive, leaving the call silent until the watchdog terminated it. Add a one-shot post-DTMF recovery: when the 30s listen grace expires with no inbound speech or model turn, request one response with explicit recovery instructions (`POST_DTMF_RECOVERY_INSTRUCTIONS`) before falling back to the ordinary stale path.
- New IVR speech (`input_audio_buffer.speech_started`), a model `response.created`, or a fresh DTMF send cancels the pending recovery so it never races a real turn. The recovery is one-shot via `consume_expired_dtmf_listen_grace`, which pops the deadline atomically.
- Gate `send_dtmf` on active callee speech: return `callee_speaking` / `retryable` with `continue_response=False` instead of injecting tones into a playing prompt, letting semantic VAD resume the model naturally.
- Start the listen grace only after the tool result is actually delivered, so a failed sideband write cannot hide an unresolved tool call behind the silence exemption.
- Track `input_speech_active` as assistant work so long IVR prompts stay live past the watchdog window; clear it on `speech_stopped` and `transcription.completed`.
- Subscribe to the Twilio `announcement` conference callback event (falls through to the `touch_call` liveness refresh).
- Clarify the `send_dtmf` prompt: treat a named test sequence as payload (complete prerequisite menu navigation first, wait for the system to ask for tones), and never send tones while the automated prompt is still speaking.

### Risks to live-call teardown / billing
- The post-DTMF recovery issues one extra `response.create` per successful DTMF that goes silent. This is bounded (exactly once per grace window) and falls through to normal stale termination if the sideband is broken, so no call can hang indefinitely.
- `input_speech_active` extending `assistant_work_is_live` has the same stickiness hazard as the existing `sip_output_playing` / `inflight_tools` flags (all cleared by `clear_assistant_work` on termination); no new indefinite-liveness class is introduced.
- Benign known race: if the watchdog fires recovery in the narrow window between grace expiry and an IVR `speech_started` arriving, both the recovery response and semantic-VAD auto response could trigger. Realtime interruption handling manages the overlap, and the recovery instructions direct the model to listen/respond briefly.

### Configuration changes
- None. No new env vars; `POST_DTMF_RECOVERY_INSTRUCTIONS` is a module constant.

### Validation performed
- `uv run ruff format --check app tests scripts`: 59 files already formatted
- `uv run ruff check app tests scripts`: all checks passed
- `uv run mypy app`: no issues in 35 files
- `uv run pytest -q`: 335 passed
- New/updated tests in `tests/test_send_dtmf.py`:
  - `test_send_dtmf_listen_grace_recovers_once_before_watchdog` (renamed): proves recovery fires once, then the ordinary watchdog terminates on the next tick.
  - `test_send_dtmf_waits_until_active_callee_speech_finishes`: callee-speech gate.
  - `test_long_callee_prompt_stays_live_past_watchdog_window`: `input_speech_active` liveness.
  - `test_new_ivr_speech_cancels_post_dtmf_silence_recovery`: grace cleared on inbound speech.
  - `test_send_dtmf_does_not_hide_failed_tool_result_delivery`: grace only after successful delivery.
- `tests/test_bridge_payloads.py` and `tests/test_prompt_limits.py` updated for the new callback event and prompt text.

#### Test plan
- [x] ruff format + ruff check + mypy clean
- [x] full pytest suite green (335 passed)
- [ ] live SIP canary (`scripts/run_sip_canary.py --mode full`) against an IVR that goes silent after a keypress, to confirm the recovery turn fires once and the call proceeds or terminates cleanly — not run here (requires real credentials + a human with a phone)

Generated with [Devin](https://devin.ai)
