### PR TITLE
Add Cloud Agent dev environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-call",
-  "install": "command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/0.9.27/install.sh | sh; export PATH=\"$HOME/.local/bin:$PATH\"; uv sync --all-groups --frozen --python 3.13",
+  "install": "set -eu; export PATH=\"$HOME/.local/bin:$PATH\"; if [ \"$(uv --version 2>/dev/null || true)\" != \"uv 0.9.27\" ]; then curl -LsSf https://astral.sh/uv/0.9.27/install.sh | sh; fi; [ \"$(uv --version)\" = \"uv 0.9.27\" ]; uv sync --all-groups --frozen --python 3.13",
   "terminals": [
     {
       "name": "server",

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,11 @@
+{
+  "name": "agent-call",
+  "install": "command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/0.9.27/install.sh | sh; export PATH=\"$HOME/.local/bin:$PATH\"; uv sync --all-groups --frozen --python 3.13",
+  "terminals": [
+    {
+      "name": "server",
+      "command": "scripts/dev_server.sh 8000"
+    }
+  ],
+  "ports": [8000]
+}

--- a/scripts/dev_server.sh
+++ b/scripts/dev_server.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Boot the app locally with dummy credentials and a temp SQLite DB so the HTTP
+# and MCP endpoints are reachable without real Twilio/OpenAI credentials. The
+# server can answer /healthz and prepare_phone_call, but cannot place a real
+# call (that needs real credentials + a public HTTPS tunnel). For a scripted
+# end-to-end check that exits, use scripts/live_smoke.sh instead.
+#
+# Usage: scripts/dev_server.sh [port]   (default port 8000)
+set -euo pipefail
+
+PORT="${1:-8000}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# uv is installed to ~/.local/bin by the environment install step.
+export PATH="$HOME/.local/bin:$PATH"
+
+# Dummy dev credentials (same fakes as scripts/live_smoke.sh). Real values are
+# only needed to place a live call; these satisfy Settings.require_runtime_configuration.
+: "${OPENAI_API_KEY:=sk-dummy}"
+: "${OPENAI_WEBHOOK_SECRET:=whsec_dummy}"
+: "${OPENAI_PROJECT_ID:=proj_dummy}"
+: "${EXA_API_KEY:=exa-dummy}"
+: "${TWILIO_ACCOUNT_SID:=ACdummy}"
+: "${TWILIO_AUTH_TOKEN:=dummy}"
+: "${TWILIO_CALLER_ID:=+15550000000}"
+: "${OWNER_PHONE_E164:=+15550000001}"
+: "${ALLOWED_AGENT_USER_ID:=local-dev-user}"
+: "${MCP_BEARER_TOKEN:=local-dev-bearer}"
+: "${DEBUG_API_TOKEN:=local-dev-debug}"
+: "${DEPLOY_GUARD_TOKEN:=local-dev-deploy}"
+: "${PUBLIC_BASE_URL:=https://local-dev.example.com}"
+: "${DATABASE_URL:=sqlite:///${ROOT}/agent_call.db}"
+export OPENAI_API_KEY OPENAI_WEBHOOK_SECRET OPENAI_PROJECT_ID EXA_API_KEY
+export TWILIO_ACCOUNT_SID TWILIO_AUTH_TOKEN TWILIO_CALLER_ID
+export OWNER_PHONE_E164 ALLOWED_AGENT_USER_ID MCP_BEARER_TOKEN DEBUG_API_TOKEN DEPLOY_GUARD_TOKEN
+export PUBLIC_BASE_URL DATABASE_URL
+
+cd "$ROOT"
+exec uv run uvicorn app.main:app --host 0.0.0.0 --port "$PORT"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a reproducible Cloud Agent development environment for this repo and adds a convenience dev-server script. No application code changes.

- `​.cursor/environment.json` (repository-managed, highest-precedence env source):
  - `install`: installs `uv` pinned to `0.9.27` (matching CI and the production `Dockerfile`) if absent, then runs `uv sync --all-groups --frozen --python 3.13` — the same locked install CI uses.
  - `terminals`: a visible `server` terminal running `scripts/dev_server.sh 8000`.
  - `ports`: exposes `8000`.
- `scripts/dev_server.sh`: boots the app with dummy dev credentials and a local SQLite DB so `/healthz` and the MCP endpoint (`/mcp/`) are reachable out of the box. Real Twilio/OpenAI credentials + a public HTTPS tunnel are only needed to place a live call (same fakes already used by `scripts/live_smoke.sh`).

## Why repository-managed

This repo is PR/CI-driven and already ships a committed `Dockerfile`, so a versioned `.cursor/environment.json` that follows branches fits the existing workflow and is reviewable here.

## Validation

Run on this VM against the locked toolchain (`uv` 0.9.27, Python 3.13.11):

- `uv sync --all-groups --frozen` — succeeds; second run is a no-op (idempotent).
- `uv run ruff format --check app tests scripts` — 59 files already formatted.
- `uv run ruff check app tests scripts` — all checks passed.
- `uv run mypy app` — no issues in 35 source files.
- `uv run pytest -q --cov=app` — 347 passed, 87.67% coverage (floor 85%).
- `scripts/live_smoke.sh` — SMOKE PASS (healthz, MCP initialize, tools/list, prepare_phone_call, auth rejection).
- `scripts/dev_server.sh` (with `.env.local` removed, proving self-sufficiency) — `/healthz` → `{"status":"ok"}`; `prepare_phone_call` persisted a real `plan_id` with `missing_fields: []`.
- `pre-commit run --files …` on the new files — all hooks pass, including gitleaks.

### Clean-image build + fresh-agent verification

A draft environment build (`bld-20260813-5476339d`) ran the `install` script on a clean image: `uv 0.9.27` + `CPython 3.13.11` + all 112 locked packages installed, exit 0. A fresh Cloud Agent booted from that exact build then independently confirmed:

- `uv 0.9.27`, `Python 3.13.11`, `/workspace/.venv` present.
- `uv sync --all-groups --frozen` → `Audited 112 packages` (no re-download).
- `uv run pytest -q` → 347 passed.
- `scripts/dev_server.sh 8000` boots and `/healthz` → `{"status":"ok"}`.
- MCP `prepare_phone_call` → `plan_id = plan_…`, `missing_fields = []`.

## Risk

Environment/tooling only; no changes to live-call teardown, billing, or webhook handling. `.env.local` remains gitignored and is not committed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24c91ba3-a9a9-4bd3-8d8f-f98ccd1e2869?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24c91ba3-a9a9-4bd3-8d8f-f98ccd1e2869&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

