### PR TITLE
Harden open-source release security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-RUN groupadd --system --gid 10001 app \
+RUN apt-get update \
+    && apt-get install --no-install-recommends --yes gosu \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system --gid 10001 app \
     && useradd --system --uid 10001 --gid app --home-dir /app --shell /usr/sbin/nologin app \
     && mkdir -p /data /var/data \
     && chown app:app /data /var/data
@@ -15,11 +18,14 @@ RUN groupadd --system --gid 10001 app \
 COPY --from=ghcr.io/astral-sh/uv:0.9.27 /uv /usr/local/bin/uv
 COPY --chown=app:app pyproject.toml uv.lock README.md ./
 COPY --chown=app:app app ./app
-RUN uv sync --frozen --no-dev && chown -R app:app /app
+COPY --chown=root:root scripts/container-entrypoint.sh /usr/local/bin/container-entrypoint
+RUN uv sync --frozen --no-dev \
+    && chown -R app:app /app \
+    && chmod 755 /usr/local/bin/container-entrypoint
 
 ENV PATH="/app/.venv/bin:$PATH"
 EXPOSE 8000
 
-USER app
+ENTRYPOINT ["/usr/local/bin/container-entrypoint"]
 
 CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --proxy-headers --forwarded-allow-ips='*'"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,19 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+RUN groupadd --system --gid 10001 app \
+    && useradd --system --uid 10001 --gid app --home-dir /app --shell /usr/sbin/nologin app \
+    && mkdir -p /data /var/data \
+    && chown app:app /data /var/data
+
 COPY --from=ghcr.io/astral-sh/uv:0.9.27 /uv /usr/local/bin/uv
-COPY pyproject.toml uv.lock README.md ./
-COPY app ./app
-RUN uv sync --frozen --no-dev
+COPY --chown=app:app pyproject.toml uv.lock README.md ./
+COPY --chown=app:app app ./app
+RUN uv sync --frozen --no-dev && chown -R app:app /app
 
 ENV PATH="/app/.venv/bin:$PATH"
 EXPOSE 8000
+
+USER app
 
 CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --proxy-headers --forwarded-allow-ips='*'"]

--- a/app/call_state.py
+++ b/app/call_state.py
@@ -28,6 +28,7 @@ from app.db import (
 )
 from app.exa_search import ExaSearchClient, ExaSearchError
 from app.finalizer import Finalizer
+from app.logging_safety import provider_error_fields
 from app.models import (
     TERMINAL_STATES,
     AdvisoryOutcome,
@@ -56,6 +57,9 @@ from app.settings import Settings
 from app.twilio_bridge import TwilioBridge
 
 logger = logging.getLogger(__name__)
+
+_CALL_ID_PATTERN = re.compile(r"^call_[A-Za-z0-9_-]{1,128}$")
+_PLAN_ID_PATTERN = re.compile(r"^plan_[A-Za-z0-9_-]{1,128}$")
 
 # Over SIP, response.done marks the end of audio *generation*; playback to the phone lags
 # behind because OpenAI drains a server-side output buffer in real time. Termination after a
@@ -589,24 +593,41 @@ class CallService:
     async def handle_openai_incoming(
         self, openai_call_id: str, sip_headers: list[dict[str, str]]
     ) -> str:
-        headers = {item.get("name", "").lower(): item.get("value", "") for item in sip_headers}
-        call_id = headers.get("x-bridge-call-id") or headers.get("x_bridge_call_id")
-        plan_id = headers.get("x-plan-id") or headers.get("x_plan_id")
-        if call_id is None:
-            joined = " ".join(headers.values())
-            for candidate in await self.db.list_nonterminal_calls():
-                if candidate["call_id"] in joined or candidate["plan_id"] in joined:
-                    call_id = candidate["call_id"]
-                    break
-        call = await self.db.get_call(call_id) if call_id else None
-        if call is None or call_id is None or (plan_id and call["plan_id"] != plan_id):
+        def exact_header(name: str) -> str | None:
+            values = [
+                item.get("value", "").strip()
+                for item in sip_headers
+                if item.get("name", "").strip().lower() == name
+            ]
+            return values[0] if len(values) == 1 else None
+
+        call_id = exact_header("x-bridge-call-id")
+        plan_id = exact_header("x-plan-id")
+        if (
+            call_id is None
+            or plan_id is None
+            or not _CALL_ID_PATTERN.fullmatch(call_id)
+            or not _PLAN_ID_PATTERN.fullmatch(plan_id)
+        ):
             await self.realtime.reject(openai_call_id)
             raise LookupError("incoming SIP call could not be mapped to an approved plan")
-        if call.get("openai_call_id") and call["openai_call_id"] != openai_call_id:
+
+        if not await self.db.bind_openai_call(
+            call_id=call_id,
+            plan_id=plan_id,
+            openai_call_id=openai_call_id,
+        ):
+            call = await self.db.get_call(call_id)
             await self.realtime.reject(openai_call_id)
-            raise RuntimeError("call already mapped to a different OpenAI call")
+            if call is not None and call.get("openai_call_id"):
+                raise RuntimeError("call already mapped to an OpenAI call")
+            raise LookupError("incoming SIP call could not be mapped to an approved plan")
+
+        call = await self.db.get_call(call_id)
+        if call is None:
+            await self.realtime.reject(openai_call_id)
+            raise LookupError("incoming SIP call could not be mapped to an approved plan")
         mapped_call_id = call_id
-        await self.db.update_call(mapped_call_id, openai_call_id=openai_call_id)
         plan = await self.db.get_plan(call["plan_id"])
         if plan is None:
             await self.realtime.reject(openai_call_id)
@@ -1019,11 +1040,15 @@ class CallService:
             if status in {"cancelled", "canceled"}:
                 await self.db.update_call(call_id, interruption_observed=1)
             elif status == "failed":
+                error_code, error_type, error_message = provider_error_fields(
+                    response.get("status_details")
+                )
                 logger.error(
-                    "realtime response failed call_id=%s status_details=%s event=%s",
+                    "realtime response failed call_id=%s error_code=%s error_type=%s message=%s",
                     call_id,
-                    response.get("status_details"),
-                    event,
+                    error_code,
+                    error_type,
+                    error_message,
                 )
             if event_type == "response.done":
                 await self._handle_voice_end_response_done(call_id, event)
@@ -1058,9 +1083,16 @@ class CallService:
             error = event.get("error") or {}
             if error.get("code") == "response_cancel_not_active":
                 # Benign race: the response we tried to cancel finished on its own.
-                logger.info("stale response.cancel ignored call_id=%s event=%s", call_id, event)
+                logger.info("stale response.cancel ignored call_id=%s", call_id)
                 return
-            logger.error("realtime error event call_id=%s event=%s", call_id, event)
+            error_code, error_type, error_message = provider_error_fields(error)
+            logger.error(
+                "realtime error call_id=%s error_code=%s error_type=%s message=%s",
+                call_id,
+                error_code,
+                error_type,
+                error_message,
+            )
             self._spawn(
                 self.terminate_call(call_id, "openai_fatal_error"),
                 name=f"terminate:{call_id}:openai-error",

--- a/app/db/calls.py
+++ b/app/db/calls.py
@@ -135,6 +135,16 @@ class CallsMixin:
         params.append(call_id)
         return await self._execute_cas(f"UPDATE calls SET {columns} WHERE call_id=?", params)
 
+    async def bind_openai_call(
+        self: DatabaseAccess, *, call_id: str, plan_id: str, openai_call_id: str
+    ) -> bool:
+        """Atomically bind one expected prewarming call to one OpenAI SIP call."""
+        return await self._execute_cas(
+            """UPDATE calls SET openai_call_id=?, last_event_at=?
+               WHERE call_id=? AND plan_id=? AND state=? AND openai_call_id IS NULL""",
+            (openai_call_id, _iso_now(), call_id, plan_id, CallState.PREWARMING.value),
+        )
+
     async def add_realtime_usage(
         self: DatabaseAccess,
         call_id: str,

--- a/app/logging_safety.py
+++ b/app/logging_safety.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+_CONTROL_CHARACTERS = re.compile(r"[\x00-\x1f\x7f]+")
+_NAMED_SECRET = re.compile(r"(?i)\b(authorization|api[_ -]?key|token|secret)\s*[:=]\s*\S+")
+_TOKEN_LIKE_VALUE = re.compile(r"\b(?:sk|whsec)[-_A-Za-z0-9]{12,}\b", re.IGNORECASE)
+
+
+def sanitize_log_text(value: object, *, max_length: int = 240) -> str | None:
+    if value is None:
+        return None
+    text = _CONTROL_CHARACTERS.sub(" ", str(value)).strip()
+    text = _NAMED_SECRET.sub(r"\1=[redacted]", text)
+    text = _TOKEN_LIKE_VALUE.sub("[redacted]", text)
+    if len(text) > max_length:
+        return f"{text[: max_length - 3]}..."
+    return text
+
+
+def provider_error_fields(value: object) -> tuple[str | None, str | None, str | None]:
+    if not isinstance(value, Mapping):
+        return None, None, None
+    nested: Any = value.get("error")
+    error = nested if isinstance(nested, Mapping) else value
+    return (
+        sanitize_log_text(error.get("code"), max_length=80),
+        sanitize_log_text(error.get("type"), max_length=80),
+        sanitize_log_text(error.get("message")),
+    )
+
+
+def request_id_from_headers(headers: object) -> str | None:
+    getter = getattr(headers, "get", None)
+    if not callable(getter):
+        return None
+    for name in ("x-request-id", "request-id", "openai-request-id"):
+        value = getter(name)
+        if value:
+            return sanitize_log_text(value, max_length=100)
+    return None

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ from app.db import Database
 from app.mcp_tools import register_tools
 from app.openai_client import create_openai_client
 from app.routes import debug, deployment, openai_webhooks, twilio_webhooks
-from app.security import MCPAuthMiddleware
+from app.security import MCPAuthMiddleware, WebhookBodyLimitMiddleware
 from app.settings import Settings
 
 logging.basicConfig(
@@ -122,6 +122,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             raise BaseExceptionGroup("application lifespan cleanup failed", cleanup_errors)
 
     app = FastAPI(title="Agent Phone-Call Bridge", version="1.0.0", lifespan=lifespan)
+    app.add_middleware(WebhookBodyLimitMiddleware)
     app.state.settings = settings
     app.state.mcp = mcp
     app.include_router(openai_webhooks.router)

--- a/app/openai_realtime.py
+++ b/app/openai_realtime.py
@@ -11,6 +11,7 @@ from typing import Any
 import websockets
 from openai import APIStatusError, AsyncOpenAI
 
+from app.logging_safety import provider_error_fields, request_id_from_headers, sanitize_log_text
 from app.models import (
     AcceptPayload,
     ContextPacket,
@@ -277,12 +278,21 @@ class RealtimeBridge:
                     openai_call_id, **payload.model_dump(exclude_none=True)
                 )
         except APIStatusError as exc:
+            error_code, error_type, error_message = provider_error_fields(
+                getattr(exc, "body", None)
+            )
+            request_id = request_id_from_headers(exc.response.headers)
+            if request_id is None:
+                request_id = sanitize_log_text(getattr(exc, "request_id", None), max_length=100)
             logger.error(
-                "OpenAI call accept response call_id=%s status=%s headers=%s body=%r",
+                "OpenAI call accept failed call_id=%s status=%s request_id=%s "
+                "error_code=%s error_type=%s message=%s",
                 call_id,
                 exc.status_code,
-                dict(exc.response.headers),
-                exc.response.text,
+                request_id,
+                error_code,
+                error_type,
+                error_message,
             )
             raise
         except TimeoutError:
@@ -292,13 +302,11 @@ class RealtimeBridge:
                 self.settings.openai_http_timeout_seconds,
             )
             raise
-        # The accept response is bodyless today; log every non-secret response field.
         logger.info(
-            "OpenAI call accept response call_id=%s status=%s headers=%s body=%r",
+            "OpenAI call accept response call_id=%s status=%s request_id=%s",
             call_id,
             raw.status_code,
-            dict(raw.headers),
-            raw.text,
+            request_id_from_headers(raw.headers),
         )
         if raw.status_code < 200 or raw.status_code >= 300:
             raise RuntimeError(f"OpenAI accept failed with HTTP {raw.status_code}")

--- a/app/security.py
+++ b/app/security.py
@@ -1,13 +1,95 @@
 from __future__ import annotations
 
 import secrets
+from collections.abc import Mapping
 
 from fastapi import HTTPException, Request
 from starlette.datastructures import FormData
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from twilio.request_validator import RequestValidator
 
 from app.settings import Settings
+
+OPENAI_WEBHOOK_BODY_MAX_BYTES = 256 * 1024
+TWILIO_WEBHOOK_BODY_MAX_BYTES = 64 * 1024
+
+
+class _RequestBodyTooLarge(Exception):
+    pass
+
+
+class WebhookBodyLimitMiddleware:
+    """Reject oversized provider callbacks before Starlette buffers or parses them."""
+
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    @staticmethod
+    def _limit_for_path(path: str) -> int | None:
+        if path == "/webhooks/openai":
+            return OPENAI_WEBHOOK_BODY_MAX_BYTES
+        if path.startswith("/webhooks/twilio/"):
+            return TWILIO_WEBHOOK_BODY_MAX_BYTES
+        return None
+
+    @staticmethod
+    async def _send_error(send: Send, status: int, detail: str) -> None:
+        body = f'{{"detail":"{detail}"}}'.encode()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode()),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        limit = self._limit_for_path(str(scope.get("path", "")))
+        if limit is None:
+            await self.app(scope, receive, send)
+            return
+
+        headers: Mapping[bytes, bytes] = {
+            key.lower(): value for key, value in scope.get("headers", [])
+        }
+        raw_content_length = headers.get(b"content-length")
+        if raw_content_length is not None:
+            try:
+                content_length = int(raw_content_length)
+            except ValueError:
+                await self._send_error(send, 400, "invalid content-length")
+                return
+            if content_length < 0:
+                await self._send_error(send, 400, "invalid content-length")
+                return
+            if content_length > limit:
+                await self._send_error(send, 413, "request body too large")
+                return
+
+        received = 0
+
+        async def limited_receive() -> Message:
+            nonlocal received
+            message = await receive()
+            if message.get("type") == "http.request":
+                body = message.get("body", b"")
+                if isinstance(body, bytes):
+                    received += len(body)
+                if received > limit:
+                    raise _RequestBodyTooLarge
+            return message
+
+        try:
+            await self.app(scope, limited_receive, send)
+        except _RequestBodyTooLarge:
+            await self._send_error(send, 413, "request body too large")
 
 
 def constant_time_equal(actual: str | None, expected: str) -> bool:

--- a/docs/agent_call_migration.md
+++ b/docs/agent_call_migration.md
@@ -5,30 +5,11 @@
 > follow [self-hosting.md](self-hosting.md). Do not deploy to the maintainer's
 > `agent-call` application.
 
-Run this when there are **no active calls**. Configs in the repo already target
-`agent-call` / `agent-call.fly.dev`.
+The rebrand is already merged, so the **Deploy production** workflow will remain
+red until `agent-call` has been provisioned and first-deployed manually. Keep
+`poke-call` running until the new app is healthy and the cutover smoke passes.
 
-Merging this rebrand before the new Fly app exists will fail the GitHub
-**Deploy production** workflow: it waits on `https://agent-call.fly.dev` for a
-deployment lease, then exits after a few unreachable attempts. That is
-expected. Production stays on `poke-call` until you finish this cutover and
-re-run the workflow (or deploy with `flyctl` as below).
-
-To keep auto-deploy green on the merge commit, complete steps 2–5 first so the
-lease endpoint exists, then merge. Otherwise merge first, ignore that failed
-deploy run, and continue here.
-
-## 1. Lock the old app
-
-```bash
-curl --fail-with-body -sS --request POST \
-  -H "Authorization: Bearer $DEPLOY_GUARD_TOKEN" \
-  https://poke-call.fly.dev/internal/deployment-lock
-```
-
-HTTP 409 means wait for calls to finish.
-
-## 2. Create the new Fly app and volume
+## 1. Create the new Fly app and volume
 
 ```bash
 flyctl apps create agent-call
@@ -36,7 +17,7 @@ flyctl apps create agent-call
 flyctl volumes create agent_call_data --region lax --size 1 -a agent-call
 ```
 
-## 3. Set secrets
+## 2. Set runtime and CI secrets
 
 Copy Twilio / OpenAI / Exa / MCP / debug / deploy-guard values from the old app's vault
 (or local `.env`), then set the renamed agent vars:
@@ -64,25 +45,93 @@ flyctl secrets set -a agent-call \
 
 `flyctl secrets list` shows names only — pull values from your local vault.
 
-## 4. Optional SQLite copy
+The existing GitHub Actions `FLY_API_TOKEN` is scoped to `poke-call`. Create a
+new token scoped to `agent-call` and replace the secret in the `production`
+GitHub environment without printing it:
 
 ```bash
-# From the old machine
-flyctl ssh sftp get /data/poke_call.db ./poke_call.db -a poke-call
-# After first deploy creates /data on agent-call, upload as agent_call.db
-flyctl ssh sftp put ./poke_call.db /data/agent_call.db -a agent-call
+flyctl tokens create deploy -a agent-call -x 8760h \
+  | gh secret set FLY_API_TOKEN --env production
 ```
 
-Or start fresh (call history only).
+## 3. Lock the old app
 
-## 5. Deploy and verify
+Acquire the lease immediately before capturing state. HTTP 409 means wait for
+calls to finish; HTTP 200 blocks new calls for the next 15 minutes.
+
+```bash
+curl --fail-with-body -sS --request POST \
+  -H "Authorization: Bearer $DEPLOY_GUARD_TOKEN" \
+  https://poke-call.fly.dev/internal/deployment-lock
+```
+
+## 4. Optional SQLite copy
+
+The service uses SQLite WAL mode, so do not copy only the live `poke_call.db`
+file and do not overwrite a database opened by a running destination process.
+Create a consistent online backup, seed the unattached new volume through a
+short-lived maintenance Machine, and only then perform the first deploy:
+
+```bash
+migration_dir="$(mktemp -d)"
+
+# The sqlite3 backup API includes committed WAL contents in one consistent file.
+flyctl ssh console -a poke-call -C \
+  'python -c "from pathlib import Path; import sqlite3; snapshot=Path(\"/data/poke_call_snapshot.db\"); snapshot.unlink(missing_ok=True); source=sqlite3.connect(\"file:/data/poke_call.db?mode=ro\", uri=True); target=sqlite3.connect(snapshot); source.backup(target); target.close(); source.close()"'
+flyctl ssh sftp get /data/poke_call_snapshot.db \
+  "$migration_dir/poke_call_snapshot.db" -a poke-call
+
+# Attach the new volume to a temporary maintenance Machine, upload the snapshot,
+# verify it, and give the runtime's fixed non-root UID ownership of the volume.
+flyctl machine run python:3.13-slim sleep infinity \
+  --app agent-call \
+  --region lax \
+  --volume agent_call_data:/data \
+  --restart no \
+  --detach
+flyctl machine list -a agent-call
+flyctl ssh sftp put "$migration_dir/poke_call_snapshot.db" \
+  /data/agent_call.db -a agent-call
+flyctl ssh console -a agent-call -C \
+  'python -c "import sqlite3; connection=sqlite3.connect(\"file:/data/agent_call.db?mode=ro\", uri=True); result=connection.execute(\"PRAGMA integrity_check\").fetchone()[0]; connection.close(); assert result == \"ok\", result"'
+flyctl ssh console -a agent-call -C \
+  'chown -R 10001:10001 /data && chmod 750 /data && chmod 640 /data/agent_call.db'
+flyctl machine destroy <maintenance-machine-id> -a agent-call --force
+
+flyctl ssh console -a poke-call -C \
+  'python -c "from pathlib import Path; Path(\"/data/poke_call_snapshot.db\").unlink(missing_ok=True)"'
+rm -f "$migration_dir/poke_call_snapshot.db"
+rmdir "$migration_dir"
+```
+
+For a fresh database, still use the maintenance Machine to run
+`chown 10001:10001 /data && chmod 750 /data` before the first deploy. The
+container deliberately runs as UID 10001 and must not be granted world-writable
+volume access.
+
+## 5. Perform the first deploy and verify
 
 ```bash
 flyctl deploy -a agent-call --ha=false --remote-only
 curl -fsS https://agent-call.fly.dev/healthz
 ```
 
-## 6. Re-point external webhooks
+This manual first deploy makes the deployment-lease endpoint available so the
+push-to-main workflow can operate normally.
+
+## 6. Freeze the old app and re-point external webhooks
+
+Refresh the old app's 15-minute lease immediately before stopping it. HTTP 409
+means a call became active and the cutover must wait. Once the old Machine is
+stopped, it cannot accept a new call if the lease expires during later steps.
+
+```bash
+curl --fail-with-body -sS --request POST \
+  -H "Authorization: Bearer $DEPLOY_GUARD_TOKEN" \
+  https://poke-call.fly.dev/internal/deployment-lock
+flyctl machine list -a poke-call
+flyctl machine stop <old-poke-call-machine-id> -a poke-call
+```
 
 - OpenAI Platform → Project → Webhooks → `https://agent-call.fly.dev/webhooks/openai` (`realtime.call.incoming`)
 - Any Twilio configs that still reference `poke-call.fly.dev`
@@ -104,14 +153,33 @@ Enable `hooks` in `openclaw.json` if using push; point `AGENT_WEBHOOK_URL` at `<
 
 **Hermes Agent** — add `mcp_servers.agent-call` with `url` + `headers` in `~/.hermes/config.yaml`; leave `AGENT_PUSH_ENABLED=false`.
 
-## 8. Smoke, then decommission
+## 8. Smoke the cutover
 
 ```bash
 # Against the new URL (set PUBLIC_BASE_URL / MCP target accordingly)
 scripts/live_smoke.sh
 # Optional live canary
 uv run python scripts/run_sip_canary.py --mode full
+```
 
+If validation fails, point the client and webhooks back to `poke-call`, then
+restart its stopped Machine. Do not run both apps against the same SQLite
+volume.
+
+## 9. Verify automatic deployment
+
+Re-run the failed **Deploy production** workflow and confirm it acquires the
+live `agent-call` lease, deploys merged `main`, and passes its health check with
+the new app-scoped token.
+
+## 10. Decommission the old app
+
+Verify the old Machine is still stopped immediately before destruction. If it
+was restarted for a rollback, repeat the deployment-lock request from step 6,
+wait for HTTP 200, and stop it again.
+
+```bash
+flyctl machine list -a poke-call
 flyctl apps destroy poke-call
 ```
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -97,6 +97,15 @@ flyctl apps create YOUR_APP_NAME
 # If agent-call is taken — it is, for the maintainer — pick another name.
 # Update fly.toml `app`, `[env].PUBLIC_BASE_URL`, and any CI that references the app.
 flyctl volumes create agent_call_data --region lax --size 1 -a YOUR_APP_NAME
+
+# The image runs as fixed non-root UID 10001. Initialize the empty volume once.
+flyctl machine run python:3.13-slim sleep infinity \
+  --app YOUR_APP_NAME --region lax --volume agent_call_data:/data \
+  --restart no --detach
+flyctl machine list -a YOUR_APP_NAME
+flyctl ssh console -a YOUR_APP_NAME -C \
+  'chown 10001:10001 /data && chmod 750 /data'
+flyctl machine destroy <maintenance-machine-id> -a YOUR_APP_NAME --force
 ```
 
 `fly.toml` as committed defines production at `https://agent-call.fly.dev`: one always-on shared-CPU machine, 512 MB RAM, a 1 GB volume at `/data`, and SQLite at `sqlite:////data/agent_call.db`. Change `app` and `PUBLIC_BASE_URL` before deploying a fork.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -98,7 +98,8 @@ flyctl apps create YOUR_APP_NAME
 # Update fly.toml `app`, `[env].PUBLIC_BASE_URL`, and any CI that references the app.
 flyctl volumes create agent_call_data --region lax --size 1 -a YOUR_APP_NAME
 
-# The image runs as fixed non-root UID 10001. Initialize the empty volume once.
+# The service runs as fixed non-root UID 10001. The entrypoint also repairs
+# legacy root-owned volume contents during upgrades.
 flyctl machine run python:3.13-slim sleep infinity \
   --app YOUR_APP_NAME --region lax --volume agent_call_data:/data \
   --restart no --detach

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# Persistent volumes hide the ownership established in the image. Repair legacy
+# root-owned mounts before dropping privileges so upgrades can still create the
+# SQLite WAL and journal files.
+if [ "$(id -u)" -eq 0 ]; then
+    for data_dir in /data /var/data; do
+        if [ -d "$data_dir" ]; then
+            chown --recursive --no-dereference app:app "$data_dir"
+        fi
+    done
+    exec gosu app "$@"
+fi
+
+exec "$@"

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -75,6 +75,132 @@ async def test_unmapped_incoming_sip_call_is_explicitly_rejected(service):
 
 
 @pytest.mark.asyncio
+async def test_incoming_sip_requires_exact_call_and_plan_headers(service, packet):
+    call_id = await seed_call(service.db, packet, openai_call_id=None)
+    plan_id = f"plan_{call_id}"
+
+    with pytest.raises(LookupError):
+        await service.handle_openai_incoming(
+            "rtc_missing_call_header",
+            [
+                {"name": "X-Plan-Id", "value": plan_id},
+                {"name": "X-Unrelated", "value": f"prefix {call_id} suffix"},
+            ],
+        )
+    with pytest.raises(LookupError):
+        await service.handle_openai_incoming(
+            "rtc_missing_plan_header",
+            [{"name": "X-Bridge-Call-Id", "value": call_id}],
+        )
+    with pytest.raises(LookupError):
+        await service.handle_openai_incoming(
+            "rtc_duplicate_header",
+            [
+                {"name": "X-Plan-Id", "value": plan_id},
+                {"name": "X-Bridge-Call-Id", "value": call_id},
+                {"name": "X-Bridge-Call-Id", "value": "call_other"},
+            ],
+        )
+    with pytest.raises(LookupError):
+        await service.handle_openai_incoming(
+            "rtc_malformed_header",
+            [
+                {"name": "X-Plan-Id", "value": plan_id},
+                {"name": "X-Bridge-Call-Id", "value": f"{call_id} extra"},
+            ],
+        )
+
+    assert service._test_realtime.rejects == [
+        "rtc_missing_call_header",
+        "rtc_missing_plan_header",
+        "rtc_duplicate_header",
+        "rtc_malformed_header",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_incoming_sip_binding_is_atomic(service, packet):
+    call_id = await seed_call(service.db, packet, openai_call_id=None)
+    plan_id = f"plan_{call_id}"
+    headers = [
+        {"name": "X-Plan-Id", "value": plan_id},
+        {"name": "X-Bridge-Call-Id", "value": call_id},
+    ]
+
+    results = await asyncio.gather(
+        service.handle_openai_incoming("rtc_first", headers),
+        service.handle_openai_incoming("rtc_second", headers),
+        return_exceptions=True,
+    )
+
+    assert sum(result == call_id for result in results) == 1
+    assert sum(isinstance(result, RuntimeError) for result in results) == 1
+    call = await service.db.get_call(call_id)
+    assert call["openai_call_id"] in {"rtc_first", "rtc_second"}
+    assert len(service._test_realtime.accepts) == 1
+    assert len(service._test_realtime.rejects) == 1
+
+
+@pytest.mark.asyncio
+async def test_realtime_error_logs_exclude_raw_provider_events(service, packet, caplog):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    provider_secret = "sk-provider-secret-123456789"
+
+    with caplog.at_level("INFO", logger="app.call_state"):
+        await service.handle_realtime_event(
+            call_id,
+            {
+                "type": "error",
+                "event_id": "evt_secret",
+                "error": {
+                    "code": "provider_error",
+                    "type": "invalid_request_error",
+                    "message": f"api_key={provider_secret}\ninvalid request",
+                },
+            },
+        )
+    await wait_background()
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "provider_error" in messages
+    assert "invalid_request_error" in messages
+    assert provider_secret not in messages
+    assert "evt_secret" not in messages
+
+
+@pytest.mark.asyncio
+async def test_failed_response_logs_exclude_raw_status_details(service, packet, caplog):
+    call_id = await seed_call(service.db, packet, state=CallState.ACTIVE)
+    provider_secret = "whsec_provider-secret-123456789"
+
+    with caplog.at_level("ERROR", logger="app.call_state"):
+        await service.handle_realtime_event(
+            call_id,
+            {
+                "type": "response.done",
+                "event_id": "evt_secret",
+                "response": {
+                    "id": "resp_failed",
+                    "status": "failed",
+                    "status_details": {
+                        "error": {
+                            "code": "response_failed",
+                            "type": "server_error",
+                            "message": f"secret={provider_secret}",
+                        }
+                    },
+                },
+            },
+        )
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "response_failed" in messages
+    assert "server_error" in messages
+    assert provider_secret not in messages
+    assert "evt_secret" not in messages
+
+
+@pytest.mark.asyncio
 async def test_initial_session_update_mismatch_terminates_before_dialing(service, packet):
     call_id = await seed_call(service.db, packet)
     await service.db.update_call(

--- a/tests/test_container_security.py
+++ b/tests/test_container_security.py
@@ -6,4 +6,13 @@ from pathlib import Path
 def test_runtime_container_uses_non_root_user():
     dockerfile = (Path(__file__).parents[1] / "Dockerfile").read_text()
 
-    assert "USER app" in dockerfile
+    assert 'ENTRYPOINT ["/usr/local/bin/container-entrypoint"]' in dockerfile
+    assert "--uid 10001" in dockerfile
+    assert "--gid 10001" in dockerfile
+
+
+def test_container_repairs_legacy_volume_ownership_before_dropping_privileges():
+    entrypoint = (Path(__file__).parents[1] / "scripts" / "container-entrypoint.sh").read_text()
+
+    assert "chown --recursive --no-dereference app:app" in entrypoint
+    assert 'exec gosu app "$@"' in entrypoint

--- a/tests/test_container_security.py
+++ b/tests/test_container_security.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_runtime_container_uses_non_root_user():
+    dockerfile = (Path(__file__).parents[1] / "Dockerfile").read_text()
+
+    assert "USER app" in dockerfile

--- a/tests/test_http_clients.py
+++ b/tests/test_http_clients.py
@@ -226,6 +226,52 @@ async def test_realtime_accept_has_a_total_wall_clock_deadline(settings, packet)
 
 
 @pytest.mark.asyncio
+async def test_realtime_accept_logs_only_allowlisted_response_metadata(settings, packet, caplog):
+    provider_secret = "sk-provider-secret-123456789"
+
+    async def accept(*args, **kwargs):
+        return SimpleNamespace(
+            status_code=200,
+            headers={
+                "x-request-id": "req_safe_123",
+                "authorization": f"Bearer {provider_secret}",
+            },
+            text=f"sensitive response {provider_secret}",
+        )
+
+    client = SimpleNamespace(
+        realtime=SimpleNamespace(
+            calls=SimpleNamespace(with_raw_response=SimpleNamespace(accept=accept))
+        )
+    )
+    bridge = RealtimeBridge(
+        settings,
+        client,
+        on_event=lambda *args: None,
+        on_open=lambda *args: None,
+        on_fatal=lambda *args: None,
+    )
+
+    async def no_sideband(_runtime):
+        return None
+
+    bridge._run = no_sideband
+    with caplog.at_level("INFO", logger="app.openai_realtime"):
+        await bridge.accept_and_connect(
+            call_id="call_1",
+            openai_call_id="rtc_1",
+            packet=packet,
+        )
+        await asyncio.sleep(0)
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "status=200" in messages
+    assert "request_id=req_safe_123" in messages
+    assert provider_secret not in messages
+    assert "sensitive response" not in messages
+
+
+@pytest.mark.asyncio
 async def test_call_service_closes_only_internally_created_api_clients(settings, monkeypatch):
     owned = SimpleNamespace(closed=False)
     owned_exa = SimpleNamespace(closed=False)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from twilio.request_validator import RequestValidator
 
 from app.main import create_app
+from app.security import WebhookBodyLimitMiddleware
 from app.settings import Settings
 from tests.conftest import seed_call
 
@@ -206,6 +207,73 @@ def test_unsigned_and_invalid_openai_webhooks_rejected(settings):
         )
     assert unsigned.status_code == 400
     assert invalid.status_code == 400
+
+
+def test_oversized_openai_webhook_is_rejected_before_signature_parsing(settings):
+    app = create_app(settings)
+    body = b"x" * (256 * 1024 + 1)
+    with TestClient(app) as client:
+        response = client.post(
+            "/webhooks/openai",
+            content=body,
+            headers=_openai_headers(settings, body, "wh_oversized"),
+        )
+    assert response.status_code == 413
+
+
+def test_oversized_twilio_webhook_is_rejected_before_form_parsing(settings):
+    app = create_app(settings)
+    with TestClient(app) as client:
+        response = client.post(
+            "/webhooks/twilio/amd?call_id=call_none&plan_id=plan_none",
+            content=b"field=" + b"x" * (64 * 1024),
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+    assert response.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_chunked_webhook_body_cannot_bypass_size_limit():
+    downstream_called = False
+
+    async def downstream(scope, receive, send):
+        nonlocal downstream_called
+        downstream_called = True
+        while True:
+            message = await receive()
+            if not message.get("more_body"):
+                break
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    chunks = iter(
+        [
+            {"type": "http.request", "body": b"x" * (256 * 1024), "more_body": True},
+            {"type": "http.request", "body": b"x", "more_body": False},
+        ]
+    )
+    sent = []
+
+    async def receive():
+        return next(chunks)
+
+    async def send(message):
+        sent.append(message)
+
+    middleware = WebhookBodyLimitMiddleware(downstream)
+    await middleware(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/webhooks/openai",
+            "headers": [],
+        },
+        receive,
+        send,
+    )
+
+    assert downstream_called is True
+    assert sent[0]["status"] == 413
 
 
 def test_openai_webhook_replay_is_rejected(settings):

--- a/uv.lock
+++ b/uv.lock
@@ -753,19 +753,19 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.5"
+version = "3.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/14/c1ffb91b7d1fece86c81e1f9df5474f30fd97e4cdaa398814bbbeee88568/fastmcp-3.4.5.tar.gz", hash = "sha256:a95f2bc876bef42e8b50f7872f24f3f2fe3b1d37408c734e8b9d9e03014b72d3", size = 28800521, upload-time = "2026-07-27T19:20:01.231Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/e2c78e26233cd8a416b21513e1925435d54c008a0ec467dbdaa80369daf7/fastmcp-3.4.6.tar.gz", hash = "sha256:2287938da8364ad7071bec2d2393af6ae10fd4e836f06f506569f1456cc87eb4", size = 28808130, upload-time = "2026-08-05T14:54:42.177Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/4f/73450a436c963c0382d15a882fc5d08f15aadc329194df1b54495a7c8383/fastmcp-3.4.5-py3-none-any.whl", hash = "sha256:5d3d438eb2917e63e6faf53e8cb8fe26d887ec3232f848093a4eecad7fa34861", size = 8017, upload-time = "2026-07-27T19:19:57.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a5/c02275db111892388972edbb05fbcbfdf1e83cbd1fd03356b3a49b93f839/fastmcp-3.4.6-py3-none-any.whl", hash = "sha256:2a29967be9f68cdd1b4cefb413ede74f83adefd923919a37aaac3611eccdd749", size = 8017, upload-time = "2026-08-05T14:54:38.473Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.5"
+version = "3.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -775,9 +775,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/1d/f3e271fbcd01ce01a4cf623b336d8e1305c192aa5d5e8e0223b7167462e9/fastmcp_slim-3.4.5.tar.gz", hash = "sha256:5badc3bceee61f61297eeb9494f499325f3ce1cafabf4611b31f6c3e9d7dff59", size = 591622, upload-time = "2026-07-27T19:15:19.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/b6/b5b9e81e67a3f39534881d2af6aa3fbd2dc367eaa070c3c932770a0c062f/fastmcp_slim-3.4.6.tar.gz", hash = "sha256:6a1e6e42c697ba90abcb1be617a26947d07316f13c6fa138ae7b0de24558e32c", size = 594167, upload-time = "2026-08-05T14:54:15.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/3b/16d8aa8224094519f30b078138e725b8a731bf0a13f1f850e58b5f9b3cc4/fastmcp_slim-3.4.5-py3-none-any.whl", hash = "sha256:bc31217827c4999812543c83ee95ed9a47f3ed1e3fd0bd4f64371e375b748eca", size = 766478, upload-time = "2026-07-27T19:15:18.015Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0b/02c254c46b4323ae5262b76a29af73b50a863efc5739a3454d144d3605ee/fastmcp_slim-3.4.6-py3-none-any.whl", hash = "sha256:3e08e6acb03523a47aa17f4d2ab9943e648a41e20b24084da491a732c46dffdc", size = 769174, upload-time = "2026-08-05T14:54:14.663Z" },
 ]
 
 [package.optional-dependencies]
@@ -1465,7 +1465,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.51.0"
+version = "2.53.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1477,9 +1477,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/d8/06fda9685e47d9a8fc177ef57f8af75207938fad49a45ce23bfa7b6a2a5c/openai-2.51.0.tar.gz", hash = "sha256:4d61287c42eba54086d09346e709cbf7f8cec51822efce9cc399450b9385fba5", size = 1083410, upload-time = "2026-07-30T17:43:26.507Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/cf/36e3e7235fdf6d125c052acc0970924611b17a20a4fe580596faf4566a65/openai-2.53.0.tar.gz", hash = "sha256:baf5802ad08980e1d9d561e1b996e800c8bcd14af5847c6d0e7a5cc59e4d4116", size = 1099435, upload-time = "2026-08-03T21:42:01.664Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/6f/c49e21245ad4865e886f6885e95e998bc024335b392c202bd571639e9d50/openai-2.51.0-py3-none-any.whl", hash = "sha256:91db13ce59a670fddc820a6983989650095e43e3acac09288bceb69356a8904e", size = 1652344, upload-time = "2026-07-30T17:43:24.225Z" },
+    { url = "https://files.pythonhosted.org/packages/78/0f/cc6afea3542a5142c5d8fc8211c5e059a8375105d004a41dfa2c7948dbb0/openai-2.53.0-py3-none-any.whl", hash = "sha256:c694ffc747a3c4d1663ef2b07b811315a476164ee5efa3a993967349ebca7618", size = 1659829, upload-time = "2026-08-03T21:41:59.581Z" },
 ]
 
 [[package]]
@@ -1535,11 +1535,11 @@ wheels = [
 
 [[package]]
 name = "phonenumbers"
-version = "9.0.35"
+version = "9.0.36"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/9c/af506fdd7220cdf6fcea27a3b8d3dc5feb239f5072137c7900155c0c6cf9/phonenumbers-9.0.35.tar.gz", hash = "sha256:b19d97e8c448ccfd8d646888d2a65635372f75b9916006cc0a2f809b531baaea", size = 2306830, upload-time = "2026-07-26T08:28:17.303Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/21/3f1561d3527b27121d6872aeecb6df2a8de8e11af9c36f5a0bd3483d2655/phonenumbers-9.0.36.tar.gz", hash = "sha256:60ca2a6870d2532d6e960105790e85e9d69270ede81746d10cf57f5e437b93ec", size = 2307271, upload-time = "2026-08-01T06:13:44.954Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/35/80f35904033e5584966c255a0140f48934d18c4711c04d4bcbdf5b330bfb/phonenumbers-9.0.35-py2.py3-none-any.whl", hash = "sha256:57ef9787ddf2bc8cc0906d5c876d43fcd65fa25e7330d00b9f2ba8528870b72a", size = 2595440, upload-time = "2026-07-26T08:28:14.033Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5d/74fbcb16b29927bf378f4ec4d47c7b48488b93e1f1af64b26544daf1d55f/phonenumbers-9.0.36-py2.py3-none-any.whl", hash = "sha256:c16a5b95178345ec2df1954578a4ac09e937443b2ee992dd7b15a8e8c81f4acf", size = 2595528, upload-time = "2026-08-01T06:13:41.591Z" },
 ]
 
 [[package]]
@@ -1801,16 +1801,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.2"
+version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
 ]
 
 [[package]]
@@ -2306,15 +2306,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.52.0"
+version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/c8/2d307868453a4bca6e64fa3581d122ae0748a0869c53f159339def179c7c/uvicorn-0.52.0.tar.gz", hash = "sha256:ca8876ad6c1983f394157c168b39d52f6dd56dabf5602fa0982751cffc2293ae", size = 97504, upload-time = "2026-07-29T08:45:34.065Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/18/ccce41535dee1be77735592bd19965f3972c82e07ee703d324709496b716/uvicorn-0.52.1.tar.gz", hash = "sha256:112ec661814189acbccd3f7b86460147cc065fc92c0821afa78918780e4354dd", size = 100571, upload-time = "2026-08-01T18:19:30.732Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/e6/b5c0630ace9757232aec07112be8146b812787db52141ff9d50674aa7634/uvicorn-0.52.0-py3-none-any.whl", hash = "sha256:3d887809810b89ed33501bcf0a9aba469b06ecd608158efce04bd6b48d8c9b08", size = 79058, upload-time = "2026-07-29T08:45:32.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d5/68e6e9bca63c0badf67002890a46d3784c958de45b65e1275ec583ca1f06/uvicorn-0.52.1-py3-none-any.whl", hash = "sha256:e4403f9d93188cf9d1088e9f40e3acd12630e2df8675316704379a7fc20fff6a", size = 79859, upload-time = "2026-08-01T18:19:29.294Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- cap OpenAI and Twilio webhook bodies before buffering or form parsing
- require exact SIP mapping headers and atomically bind one prewarming call
- redact provider error logs and run the production container as non-root
- update the five pending dependency patches and repair the SQLite cutover runbook

## Risk
The SIP mapping path is intentionally stricter and requires both `X-Bridge-Call-Id` and `X-Plan-Id`. The Docker image now runs as UID 10001, so Fly volumes must be initialized with the documented ownership before first deploy.

## Validation
- `uv run ruff format --check app tests scripts`
- `uv run ruff check app tests scripts`
- `uv run mypy app`
- `uv run pytest -q --cov=app` (356 passed, 87.91%)
- `uv run pre-commit run --all-files`
- `scripts/live_smoke.sh 8765`
- `flyctl config validate`
- Docker build, non-root UID check, container startup, and `/healthz`

The billable full SIP canary was not run unattended.