### PR TITLE
Harden hung-cleanup lifespan test against slow runners

### DIFF
--- a/tests/test_lifespan_cleanup.py
+++ b/tests/test_lifespan_cleanup.py
@@ -4,6 +4,7 @@ import asyncio
 
 import pytest
 
+from app.db import Database
 from app.main import create_app
 
 
@@ -58,11 +59,16 @@ async def test_app_lifespan_bounds_a_hung_cleanup_step(settings, monkeypatch):
         async def close(self) -> None:
             attempts.append("openai")
 
+    original_close = Database.close
+    opened: list[Database] = []
+
     async def close_database(self) -> None:
         attempts.append("database")
+        opened.append(self)
 
     # Later cleanup steps inherit the same 50ms bound as the hung stop. Stub them
     # so a slow runner cannot turn that single TimeoutError into an ExceptionGroup.
+    # Call the real close after the assertion so connections are not left to GC.
     monkeypatch.setattr("app.main.create_openai_client", lambda _: ClosingClient())
     monkeypatch.setattr("app.main.Database.close", close_database)
     monkeypatch.setattr("app.main.CallService", HangingStopService)
@@ -76,6 +82,8 @@ async def test_app_lifespan_bounds_a_hung_cleanup_step(settings, monkeypatch):
         await asyncio.wait_for(run_lifespan(), timeout=5)
 
     assert attempts == ["service", "openai", "database"]
+    for database in opened:
+        await original_close(database)
 
 
 @pytest.mark.asyncio

--- a/tests/test_lifespan_cleanup.py
+++ b/tests/test_lifespan_cleanup.py
@@ -54,6 +54,17 @@ async def test_app_lifespan_bounds_a_hung_cleanup_step(settings, monkeypatch):
             attempts.append("service")
             await asyncio.Event().wait()
 
+    class ClosingClient:
+        async def close(self) -> None:
+            attempts.append("openai")
+
+    async def close_database(self) -> None:
+        attempts.append("database")
+
+    # Later cleanup steps inherit the same 50ms bound as the hung stop. Stub them
+    # so a slow runner cannot turn that single TimeoutError into an ExceptionGroup.
+    monkeypatch.setattr("app.main.create_openai_client", lambda _: ClosingClient())
+    monkeypatch.setattr("app.main.Database.close", close_database)
     monkeypatch.setattr("app.main.CallService", HangingStopService)
     application = create_app(settings)
 
@@ -64,7 +75,7 @@ async def test_app_lifespan_bounds_a_hung_cleanup_step(settings, monkeypatch):
     with pytest.raises(TimeoutError):
         await asyncio.wait_for(run_lifespan(), timeout=5)
 
-    assert attempts == ["service"]
+    assert attempts == ["service", "openai", "database"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fly deploy Verify failed on `#71` because `test_app_lifespan_bounds_a_hung_cleanup_step` puts a 50ms timeout on every cleanup step. On the slower deploy runner, `Database.close()` also timed out, so shutdown raised an `ExceptionGroup` that `pytest.raises(TimeoutError)` does not catch. CI passed the same SHA.
- Stub `create_openai_client` and `Database.close` so later cleanup returns immediately. Still asserts a single `TimeoutError` for hung `service.stop`.
- Does not bump the 50ms cap and does not change `fly-deploy.yml`.

## Test plan
- [x] ruff format/check
- [x] mypy app
- [x] `pytest -q tests/test_lifespan_cleanup.py` (4 passed)
- [x] `pytest -q --cov=app` (401 passed, 87.81%)
- [ ] CI Verify + Gitleaks
- [ ] After merge, Fly deploy Verify should get past this test (last good prod is still #67)